### PR TITLE
Show private/public/both contributions in comparison view

### DIFF
--- a/src/components/MultiCommitChart.tsx
+++ b/src/components/MultiCommitChart.tsx
@@ -1,5 +1,16 @@
 import { useState } from "react";
+import type { ChartMode } from "#/components/CommitChart";
 import type { CommitPoint } from "#/lib/github";
+
+/** Cumulative value to plot for a point, per the public/private/both selection.
+ *  "both" sums public commits and private contributions. */
+export function chartValue(p: CommitPoint, mode: ChartMode) {
+	return mode === "public"
+		? p.cumulative
+		: mode === "private"
+			? p.restrictedCumulative
+			: p.cumulative + p.restrictedCumulative;
+}
 
 // First color is star-history's brand green; the rest are a distinguishable palette.
 export const SERIES_COLORS = [
@@ -46,19 +57,20 @@ function monthLabel(date: string) {
 export function MultiCommitChart({
 	series,
 	mode,
+	chartMode = "public",
 }: {
 	series: ChartSeries[];
 	mode: TimelineMode;
+	chartMode?: ChartMode;
 }) {
 	const [hoverFrac, setHoverFrac] = useState<number | null>(null);
 	if (series.length === 0 || series.every((s) => s.points.length === 0)) {
 		return null;
 	}
 
-	const yMax = Math.max(
-		1,
-		...series.flatMap((s) => s.points.map((p) => p.cumulative)),
-	);
+	const cval = (p: CommitPoint) => chartValue(p, chartMode);
+
+	const yMax = Math.max(1, ...series.flatMap((s) => s.points.map(cval)));
 	const y = (v: number) => PAD.top + innerH - (v / yMax) * innerH;
 	const baseline = PAD.top + innerH;
 
@@ -84,7 +96,7 @@ export function MultiCommitChart({
 		return s.points
 			.map(
 				(p, i) =>
-					`${i === 0 ? "M" : "L"}${xOf(s, i).toFixed(1)},${y(p.cumulative).toFixed(1)}`,
+					`${i === 0 ? "M" : "L"}${xOf(s, i).toFixed(1)},${y(cval(p)).toFixed(1)}`,
 			)
 			.join(" ");
 	}
@@ -254,7 +266,7 @@ export function MultiCommitChart({
 						if (!hp) return null;
 						const p = s.points[hp.i];
 						const px = xOf(s, hp.i);
-						const py = y(p.cumulative);
+						const py = y(cval(p));
 						return (
 							<g key={s.login}>
 								<circle
@@ -272,7 +284,7 @@ export function MultiCommitChart({
 									fill={s.color}
 									fontWeight={600}
 								>
-									{p.cumulative.toLocaleString()}
+									{cval(p).toLocaleString()}
 								</text>
 							</g>
 						);

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -364,7 +364,16 @@ function ComparisonView({
 	allLogins: string[];
 }) {
 	const [mode, setMode] = useState<TimelineMode>("date");
+	const [chartMode, setChartMode] = useState<ChartMode>("both");
 	const go = useGoToLogins();
+
+	// Show the public/private/both toggle only when at least one developer exposes
+	// private contributions — otherwise "private"/"both" would be identical to "public".
+	const anyPrivate = results.some(
+		// biome-ignore lint/style/noNonNullAssertion: ok results always have history
+		(r) => r.history!.totalRestricted > 0,
+	);
+	const effectiveChartMode = anyPrivate ? chartMode : "public";
 
 	const series: ChartSeries[] = results.map((r, i) => ({
 		login: r.login,
@@ -372,6 +381,17 @@ function ComparisonView({
 		// biome-ignore lint/style/noNonNullAssertion: ok results always have history
 		points: r.history!.points,
 	}));
+
+	// Legend total reflects the selected mode so the numbers match the lines.
+	const legendTotal = (r: UserResult) =>
+		effectiveChartMode === "public"
+			? // biome-ignore lint/style/noNonNullAssertion: ok results always have history
+				r.history!.total
+			: effectiveChartMode === "private"
+				? // biome-ignore lint/style/noNonNullAssertion: ok results always have history
+					r.history!.totalRestricted
+				: // biome-ignore lint/style/noNonNullAssertion: ok results always have history
+					r.history!.total + r.history!.totalRestricted;
 
 	function removeLogin(login: string) {
 		go(allLogins.filter((l) => l !== login));
@@ -386,7 +406,12 @@ function ComparisonView({
 						Comparing {series.length} developers
 					</p>
 				</div>
-				<TimelineToggle mode={mode} onChange={setMode} />
+				<div className="flex flex-wrap items-center gap-2">
+					{anyPrivate && (
+						<ChartModeToggle mode={chartMode} onChange={setChartMode} />
+					)}
+					<TimelineToggle mode={mode} onChange={setMode} />
+				</div>
 			</header>
 
 			<motion.div
@@ -395,7 +420,11 @@ function ComparisonView({
 				transition={{ duration: 0.5 }}
 				className="mt-6 rounded-xl border border-border p-4"
 			>
-				<MultiCommitChart series={series} mode={mode} />
+				<MultiCommitChart
+					series={series}
+					mode={mode}
+					chartMode={effectiveChartMode}
+				/>
 			</motion.div>
 
 			{mode === "aligned" && (
@@ -426,8 +455,7 @@ function ComparisonView({
 							{r.login}
 						</a>
 						<span className="tabular-nums text-muted-foreground">
-							{/* biome-ignore lint/style/noNonNullAssertion: ok results have history */}
-							{r.history!.total.toLocaleString()}
+							{legendTotal(r).toLocaleString()}
 						</span>
 						<button
 							type="button"


### PR DESCRIPTION
Closes #9 — the compare page now has the same public/private/both toggle the single-user view already has.

**Why:** The comparison view always plotted public commits only, but most devs do a lot of private work, so comparisons were missing the more interesting half.

**How:** `MultiCommitChart` takes a `chartMode` prop and picks `cumulative` / `restrictedCumulative` / their sum per point (shared `chartValue` helper). The toggle only appears when at least one developer exposes private contributions, and the legend totals follow the selected mode so the numbers match the lines.