### PR TITLE
Add Plausible analytics

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -62,6 +62,12 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 			},
 		],
 		scripts: [
+			// Plausible (privacy-friendly analytics) — self-hosted, with outbound-link tracking.
+			{
+				defer: true,
+				"data-domain": "commit-history.com",
+				src: "https://analytics.drdrip.xyz/js/script.outbound-links.js",
+			},
 			{
 				type: "application/ld+json",
 				children: JSON.stringify({


### PR DESCRIPTION
Adds privacy-friendly, self-hosted Plausible analytics to the site.

**Why:** We want basic traffic/usage insight without a heavyweight, privacy-invasive tracker.

**How:** Inject the Plausible snippet (the `script.outbound-links.js` variant, so external link clicks are tracked too) via the root route's `head.scripts` array in `src/routes/__root.tsx`, rather than hand-editing the HTML shell — TanStack Start renders it into the `<head>` SSR-side, so it loads on every route.

Verified the `<script defer data-domain="commit-history.com" src="…/script.outbound-links.js">` tag renders in the served SSR HTML, and `pnpm build` passes.