### PR TITLE
Cache user/comparison data in-session, speed up recent poll

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -11,7 +11,16 @@ export function getRouter() {
 		context,
 		scrollRestoration: true,
 		defaultPreload: "intent",
-		defaultPreloadStaleTime: 0,
+		// Commit histories change ~monthly, so treat loaded data as fresh for the
+		// whole session: revisiting a user (or a comparison) is instant, no refetch.
+		// A real "revisit" is a fresh page load, which starts a new in-memory cache.
+		defaultStaleTime: Infinity,
+		// Preloaded-on-intent data is fresh too, so the hover-preload is actually
+		// reused on click instead of being re-fetched.
+		defaultPreloadStaleTime: Infinity,
+		// Keep cached loader data around long enough that browsing away and back
+		// stays instant (default gcTime is 30 min).
+		defaultGcTime: 1000 * 60 * 60,
 	});
 
 	setupRouterSsrQueryIntegration({ router, queryClient: context.queryClient });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,12 +23,12 @@ export const Route = createFileRoute("/")({
 function Home() {
 	const navigate = useNavigate();
 	const initial = Route.useLoaderData();
-	// Live "Recently looked up": poll every 10s, seeded by the SSR loader.
+	// Live "Recently looked up": poll every 4s, seeded by the SSR loader.
 	const { data: recent } = useQuery({
 		queryKey: ["recent"],
 		queryFn: () => getRecentLookups(),
 		initialData: initial.recent,
-		refetchInterval: 10_000,
+		refetchInterval: 4_000,
 	});
 	const [login, setLogin] = useState("");
 


### PR DESCRIPTION
Caches per-user and comparison views in the browser for the session, and tightens the "recently looked up" poll.

**Why:** Revisiting a user (or a comparison) re-ran the router loader every time — needless requests for data that only changes ~monthly. We also wanted the recent list to feel snappier.

**How:** The `/$user` data is loaded via a TanStack Router loader, not React Query, so the cache knobs live in `router.tsx`. Set `defaultStaleTime`/`defaultPreloadStaleTime` to `Infinity` (and `gcTime` to 1h) — same in-memory, session-lived behavior React Query gives by default. Repeat lookups are now instant with zero requests; a fresh page load still revalidates (and the server already caches GitHub at 1min/7d). Separately, recent-lookups poll drops 10s → 4s.