### PR TITLE
Add hand-drawn in-chart legend to both graphs

### DIFF
--- a/src/components/ChartLegend.tsx
+++ b/src/components/ChartLegend.tsx
@@ -1,0 +1,74 @@
+// In-chart hand-drawn legend box, à la star-history.com: a wobbly rounded border (run through
+// the chart's #xkcdify filter) with a color swatch + label per series, sitting in the chart's
+// empty top-left corner. Only the border and swatches get the hand-drawn wobble — the text is
+// left crisp so it stays readable.
+
+export interface LegendEntry {
+	label: string;
+	color: string;
+}
+
+const FONT = 15;
+const ROW_H = 25;
+const PAD_X = 13;
+const PAD_Y = 11;
+const SWATCH = 13;
+const GAP = 10;
+// The xkcd font's metrics aren't available at render time (SSR, fixed viewBox, no DOM measure),
+// so the box width is approximated from each label's character count.
+const CHAR_W = 8.4;
+
+export function ChartLegend({
+	entries,
+	x,
+	y,
+}: {
+	entries: LegendEntry[];
+	x: number;
+	y: number;
+}) {
+	if (entries.length === 0) return null;
+	const longest = Math.max(...entries.map((e) => e.label.length));
+	const boxW = PAD_X * 2 + SWATCH + GAP + longest * CHAR_W;
+	const boxH = PAD_Y * 2 + entries.length * ROW_H - (ROW_H - FONT);
+
+	return (
+		<g>
+			<rect
+				x={x}
+				y={y}
+				width={boxW}
+				height={boxH}
+				rx={10}
+				fill="var(--background, #fff)"
+				stroke="currentColor"
+				strokeWidth={2}
+				filter="url(#xkcdify)"
+			/>
+			{entries.map((e, i) => {
+				const rowTop = y + PAD_Y + i * ROW_H;
+				return (
+					<g key={e.label}>
+						<rect
+							x={x + PAD_X}
+							y={rowTop}
+							width={SWATCH}
+							height={SWATCH}
+							rx={3}
+							fill={e.color}
+							filter="url(#xkcdify)"
+						/>
+						<text
+							x={x + PAD_X + SWATCH + GAP}
+							y={rowTop + SWATCH - 1}
+							fontSize={FONT}
+							fill="currentColor"
+						>
+							{e.label}
+						</text>
+					</g>
+				);
+			})}
+		</g>
+	);
+}

--- a/src/components/CommitChart.tsx
+++ b/src/components/CommitChart.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ChartLegend } from "#/components/ChartLegend";
 import type { CommitPoint } from "#/lib/github";
 
 // Fixed viewBox; the <svg> scales to its container via width:100%. No DOM measurement, so this
@@ -28,9 +29,12 @@ export type ChartMode = "public" | "private" | "both";
 export function CommitChart({
 	points,
 	mode = "both",
+	label,
 }: {
 	points: CommitPoint[];
 	mode?: ChartMode;
+	/** Username shown in the in-chart legend (omit to hide the legend). */
+	label?: string;
 }) {
 	const [hover, setHover] = useState<number | null>(null);
 	if (points.length === 0) return null;
@@ -193,6 +197,14 @@ export function CommitChart({
 					) : null,
 				)}
 			</g>
+
+			{label && (
+				<ChartLegend
+					entries={[{ label, color: ACCENT }]}
+					x={PAD.left + 14}
+					y={PAD.top + 6}
+				/>
+			)}
 
 			{/* Hover marker (kept crisp for precision) */}
 			{hp && (

--- a/src/components/MultiCommitChart.tsx
+++ b/src/components/MultiCommitChart.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ChartLegend } from "#/components/ChartLegend";
 import type { ChartMode } from "#/components/CommitChart";
 import type { CommitPoint } from "#/lib/github";
 
@@ -249,6 +250,12 @@ export function MultiCommitChart({
 					/>
 				))}
 			</g>
+
+			<ChartLegend
+				entries={series.map((s) => ({ label: s.login, color: s.color }))}
+				x={PAD.left + 14}
+				y={PAD.top + 6}
+			/>
 
 			{/* Hover: vertical guide + a dot and value per series */}
 			{hoverX != null && (

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -340,7 +340,11 @@ function SingleView({
 				transition={{ duration: 0.5 }}
 				className="mt-3 rounded-xl border border-border p-4"
 			>
-				<CommitChart points={points} mode={hasPrivate ? mode : "public"} />
+				<CommitChart
+					points={points}
+					mode={hasPrivate ? mode : "public"}
+					label={user.login}
+				/>
 			</motion.div>
 
 			<div className="mt-4 flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
Adds a star-history-style legend box *inside* the chart SVG, for both the single and comparison graphs.

**Why:** The graphs had no in-chart key — the single view had none at all, and the comparison view only had plain HTML pills below the chart. star-history.com shows a little hand-drawn legend box right on the canvas, which reads much nicer and makes the chart self-contained (and screenshot-friendly).

**How:** A shared `ChartLegend` SVG component renders a wobbly rounded border (reusing the existing `#xkcdify` filter) with a color swatch + name per series, tucked into the chart's empty top-left corner. Only the border and swatches get the hand-drawn wobble — the text stays crisp so it's readable. `CommitChart` passes the username; `MultiCommitChart` renders one row per developer. The comparison view keeps its existing pills as the add/remove controls.

Box width is approximated from label length since there's no DOM to measure the xkcd font at SSR time.