### PR TITLE
Suspend gamed accounts from the leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ A classic Personal Access Token with `read:user` is enough for the **public** co
 - The chart is **hand-rolled inline SVG** (`src/components/CommitChart.tsx`) — no chart library — which is what makes the xkcd filter and the standalone embed (`src/lib/chart-svg.ts`) possible.
 - **Caching** (`src/lib/cache.ts`) is incremental: past months are immutable, so a returning user only re-fetches the trailing month. With `DATABASE_URL` set it persists to **Neon Postgres** (via Drizzle) and powers the leaderboard + recent lookups; without it, it falls back to an in-memory cache so the app still runs.
 
+## 🛡️ Moderation
+
+Some accounts game the board (botted commits, bought followers). To hide one until you've
+investigated, suspend it — a soft, reversible flag (`entities.suspended_at`). Suspended
+accounts drop off the leaderboard and "recently looked up" but stay directly viewable with an
+under-review notice. Run with [bun](https://bun.sh) (it auto-loads your local `.env`):
+
+```bash
+bun run suspend <login> "botted commits"   # suspend (asks to confirm)
+bun run suspend --remove <login>           # reactivate
+bun run suspend --list                     # list suspended accounts
+```
+
 ## ☁️ Deploy (Netlify)
 
 The app is wired for Netlify via [`@netlify/vite-plugin-tanstack-start`](https://www.npmjs.com/package/@netlify/vite-plugin-tanstack-start) (already in `vite.config.ts`). Settings (also in `netlify.toml`):

--- a/drizzle/0003_flimsy_cloak.sql
+++ b/drizzle/0003_flimsy_cloak.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "entities" ADD COLUMN "suspended_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "entities" ADD COLUMN "suspended_reason" text;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,266 @@
+{
+  "id": "6fdc5d97-9e8c-43c2-8222-ea913ba28e51",
+  "prevId": "0c3b7008-15b7-4701-9baf-b83cff2c6468",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_commits": {
+          "name": "total_commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_restricted": {
+          "name": "total_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "followers": {
+          "name": "followers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following": {
+          "name": "following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_username": {
+          "name": "twitter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_at": {
+          "name": "built_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lookups": {
+      "name": "lookups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searched_at": {
+          "name": "searched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lookups_entity_id_entities_id_fk": {
+          "name": "lookups_entity_id_entities_id_fk",
+          "tableFrom": "lookups",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monthly_commits": {
+      "name": "monthly_commits",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted": {
+          "name": "restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monthly_commits_entity_id_entities_id_fk": {
+          "name": "monthly_commits_entity_id_entities_id_fk",
+          "tableFrom": "monthly_commits",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monthly_commits_entity_id_month_pk": {
+          "name": "monthly_commits_entity_id_month_pk",
+          "columns": [
+            "entity_id",
+            "month"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1782501939952,
       "tag": "0002_fat_sir_ram",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1782664311926,
+      "tag": "0003_flimsy_cloak",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "biome format",
     "lint": "biome lint",
     "check": "biome check",
+    "suspend": "bun scripts/suspend.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"

--- a/scripts/suspend.ts
+++ b/scripts/suspend.ts
@@ -1,0 +1,103 @@
+/**
+ * Moderation CLI: hide a gamed/suspicious account from the leaderboard until it's investigated.
+ *
+ * Run with bun, which auto-loads the local (un-committed) `.env`, so no `--env-file` flag:
+ *
+ *   bun run suspend <login> ["reason"]   # suspend (asks to confirm)
+ *   bun run suspend --remove <login>     # reactivate
+ *   bun run suspend --list               # list suspended accounts
+ *
+ * Suspension is a soft, reversible flag (entities.suspended_at) — no data is deleted. A suspended
+ * account drops off the leaderboard and "recently looked up" but is still directly viewable, with
+ * an under-review notice. Mirrors scripts/backfill-profiles.mjs: plain neon() SQL, no build step.
+ */
+import { neon } from "@neondatabase/serverless";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) throw new Error("DATABASE_URL is required (add it to .env)");
+
+const sql = neon(DATABASE_URL);
+
+const entityId = (login: string) => `user:${login.trim().toLowerCase()}`;
+const profileUrl = (login: string) => `https://commit-history.com/${login}`;
+
+/** Ask for an explicit yes; anything else aborts. */
+function confirm(question: string): boolean {
+	const answer = (prompt(`${question} [y/N]`) ?? "").trim().toLowerCase();
+	return answer === "y" || answer === "yes";
+}
+
+async function list() {
+	const rows = await sql`
+		select login, suspended_at, suspended_reason from entities
+		where suspended_at is not null order by suspended_at desc`;
+	if (rows.length === 0) {
+		console.log("No suspended accounts.");
+		return;
+	}
+	console.log(`${rows.length} suspended:\n`);
+	for (const r of rows) {
+		const when = new Date(r.suspended_at).toISOString().slice(0, 10);
+		console.log(
+			`  ${r.login.padEnd(24)} ${when}  ${r.suspended_reason ?? ""}`.trimEnd(),
+		);
+	}
+}
+
+async function remove(login: string) {
+	const id = entityId(login);
+	const [row] = await sql`select login from entities where id = ${id}`;
+	if (!row) {
+		console.error(`✗ "${login}" is not in the database — check the spelling.`);
+		process.exit(1);
+	}
+	if (!confirm(`Reactivate ${row.login}?`)) {
+		console.log("Aborted.");
+		return;
+	}
+	await sql`update entities set suspended_at = null, suspended_reason = null where id = ${id}`;
+	console.log(`✓ Reactivated. ${profileUrl(row.login)}`);
+}
+
+async function suspend(login: string, reason: string | null) {
+	const id = entityId(login);
+	const [row] = await sql`select login, suspended_at from entities where id = ${id}`;
+	if (!row) {
+		console.error(
+			`✗ "${login}" is not in the database yet — nobody has looked them up. Check the spelling.`,
+		);
+		process.exit(1);
+	}
+	if (row.suspended_at) {
+		console.log(`${row.login} is already suspended. ${profileUrl(row.login)}`);
+		return;
+	}
+	if (!confirm(`Suspend ${row.login} from the leaderboard?`)) {
+		console.log("Aborted.");
+		return;
+	}
+	await sql`update entities set suspended_at = now(), suspended_reason = ${reason} where id = ${id}`;
+	console.log(`✓ Suspended. ${profileUrl(row.login)}`);
+}
+
+const [arg1, arg2, ...rest] = process.argv.slice(2);
+
+if (arg1 === "--list") {
+	await list();
+} else if (arg1 === "--remove") {
+	if (!arg2) throw new Error("usage: bun run suspend --remove <login>");
+	await remove(arg2);
+} else if (arg1 && !arg1.startsWith("--")) {
+	const reason = [arg2, ...rest].filter(Boolean).join(" ") || null;
+	await suspend(arg1, reason);
+} else {
+	console.log(
+		[
+			"Usage:",
+			'  bun run suspend <login> ["reason"]   suspend an account',
+			"  bun run suspend --remove <login>     reactivate an account",
+			"  bun run suspend --list               list suspended accounts",
+		].join("\n"),
+	);
+	process.exit(arg1 ? 1 : 0);
+}

--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -1,5 +1,14 @@
 import { createServerFn } from "@tanstack/react-start";
-import { desc, eq, gt, sql } from "drizzle-orm";
+import {
+	and,
+	desc,
+	eq,
+	gt,
+	inArray,
+	isNotNull,
+	isNull,
+	sql,
+} from "drizzle-orm";
 import { getCommitHistory as getCachedCommitHistory } from "#/lib/cache";
 import { db } from "#/lib/db";
 import { entities, lookups } from "#/lib/db/schema";
@@ -56,6 +65,9 @@ export interface UserResult {
 	login: string;
 	history: CommitHistory | null;
 	error: string | null;
+	// True when the entity is suspended (under investigation) — the profile is still shown, but
+	// with an under-review notice. The internal reason is never sent to the client.
+	suspended: boolean;
 }
 
 export interface LeaderEntry {
@@ -106,14 +118,16 @@ async function queryLeaderboard(
 		followers: entities.followers,
 	};
 	const base = db.select(cols).from(entities);
+	// Suspended entities (gamed/under-investigation) are hidden from every mode.
+	const active = isNull(entities.suspendedAt);
 	// Private mode only lists users who expose private contributions; followers mode only those
 	// with a known follower count.
 	const scoped =
 		mode === "private"
-			? base.where(gt(entities.totalRestricted, 0))
+			? base.where(and(active, gt(entities.totalRestricted, 0)))
 			: mode === "followers"
-				? base.where(gt(entities.followers, 0))
-				: base;
+				? base.where(and(active, gt(entities.followers, 0)))
+				: base.where(active);
 	return scoped.orderBy(order).limit(limit).offset(offset);
 }
 
@@ -128,6 +142,7 @@ async function queryRecent(limit: number): Promise<RecentEntry[]> {
 		})
 		.from(lookups)
 		.innerJoin(entities, eq(entities.id, lookups.entityId))
+		.where(isNull(entities.suspendedAt))
 		.groupBy(entities.id)
 		.orderBy(desc(sql`max(${lookups.searchedAt})`))
 		.limit(limit);
@@ -162,6 +177,17 @@ export const getRecentLookups = createServerFn({ method: "GET" }).handler(
 	(): Promise<RecentEntry[]> => queryRecent(RECENT_LIMIT),
 );
 
+/** Which of these logins are currently suspended (lower-cased). Empty without a DB. */
+async function suspendedSet(logins: string[]): Promise<Set<string>> {
+	if (!db || logins.length === 0) return new Set();
+	const ids = logins.map((l) => `user:${l.trim().toLowerCase()}`);
+	const rows = await db
+		.select({ login: entities.login })
+		.from(entities)
+		.where(and(inArray(entities.id, ids), isNotNull(entities.suspendedAt)));
+	return new Set(rows.map((r) => r.login.toLowerCase()));
+}
+
 /**
  * Resolve several users' histories in one round-trip, tolerating partial failure so one bad
  * username doesn't sink the whole comparison.
@@ -170,18 +196,24 @@ export const getCommitHistories = createServerFn({ method: "GET" })
 	.validator((logins: string[]) => logins)
 	.handler(async ({ data: logins }): Promise<UserResult[]> => {
 		const token = serverToken();
-		return Promise.all(
-			logins.map(async (login): Promise<UserResult> => {
-				try {
-					const history = await getCachedCommitHistory(login, token);
-					return { login, history, error: null };
-				} catch (e) {
-					return {
-						login,
-						history: null,
-						error: e instanceof Error ? e.message : "Failed to load",
-					};
-				}
-			}),
-		);
+		const [results, suspended] = await Promise.all([
+			Promise.all(
+				logins.map(async (login): Promise<UserResult> => {
+					try {
+						const history = await getCachedCommitHistory(login, token);
+						return { login, history, error: null, suspended: false };
+					} catch (e) {
+						return {
+							login,
+							history: null,
+							error: e instanceof Error ? e.message : "Failed to load",
+							suspended: false,
+						};
+					}
+				}),
+			),
+			suspendedSet(logins),
+		]);
+		for (const r of results) r.suspended = suspended.has(r.login.toLowerCase());
+		return results;
 	});

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -34,6 +34,10 @@ export const entities = pgTable("entities", {
 	twitterUsername: text("twitter_username"),
 	lastFetched: timestamp("last_fetched", { withTimezone: true }), // staleness / trailing refresh; also "profile last updated"
 	builtAt: timestamp("built_at", { withTimezone: true }), // last full rebuild (catches backfills)
+	// Moderation: null = active. When set, the entity is hidden from the leaderboard and
+	// "recently looked up" (still directly viewable, with an under-review notice) until cleared.
+	suspendedAt: timestamp("suspended_at", { withTimezone: true }),
+	suspendedReason: text("suspended_reason"), // internal note — never shown publicly
 });
 
 /** Per-month commit counts. Past months are immutable; only the current month changes. */

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -203,6 +203,31 @@ function View() {
 	);
 }
 
+/** Shown on a suspended profile — public-facing, never reveals the internal reason. */
+function SuspendedNotice() {
+	return (
+		<div className="mt-6 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm">
+			<p className="font-medium text-amber-700 dark:text-amber-400">
+				⚠️ This profile is under review.
+			</p>
+			<p className="mt-1 text-muted-foreground">
+				Its commit history looks suspicious, so it's hidden from the leaderboard
+				while we investigate. If this is your account and you think it's a
+				mistake, please{" "}
+				<a
+					href="https://github.com/peetzweg/commit-history/issues"
+					target="_blank"
+					rel="noreferrer"
+					className="underline hover:text-foreground"
+				>
+					open an issue
+				</a>
+				.
+			</p>
+		</div>
+	);
+}
+
 // ── Single user: the detailed view ──────────────────────────────────────────
 
 function Stat({
@@ -325,6 +350,7 @@ function SingleView({
 
 	return (
 		<>
+			{result.suspended && <SuspendedNotice />}
 			<div className="mt-6">
 				<ProfilePanel result={result} />
 			</div>
@@ -481,6 +507,7 @@ function ComparisonView({
 								result={r}
 								color={SERIES_COLORS[i % SERIES_COLORS.length]}
 							/>
+							{r.suspended && <SuspendedNotice />}
 						</div>
 					))}
 				</div>


### PR DESCRIPTION
Adds a quick way to pull suspicious/gamed accounts off the public leaderboard until we've investigated them.

**Why:** people are gaming the board (botted commits, bought followers) and there was no moderation at all — anyone in the DB gets ranked.

**How:** a reversible \`entities.suspended_at\` flag (no data deleted). It's filtered out of both ranking queries (\`queryLeaderboard\` across all modes + \`queryRecent\`), so suspended accounts vanish from the leaderboard and "recently looked up". They stay directly viewable at \`/<login>\` with a friendly under-review notice linking to issues — the internal reason is never sent to the client. Managed via a bun CLI (\`bun run suspend <login> "reason"\` / \`--remove\` / \`--list\`) that confirms before writing and prints the public link.

Migration \`0003\` adds two nullable columns and has been applied. An auth-gated admin web page is deliberately left for later — it'll drive this same flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)