### PR TITLE
Throttle 'Recently looked up' polling to 16s

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,12 +23,13 @@ export const Route = createFileRoute("/")({
 function Home() {
 	const navigate = useNavigate();
 	const initial = Route.useLoaderData();
-	// Live "Recently looked up": poll every 4s, seeded by the SSR loader.
+	// Live "Recently looked up": poll every 16s, seeded by the SSR loader. Kept deliberately
+	// gentle to stay easy on the server-function call budget.
 	const { data: recent } = useQuery({
 		queryKey: ["recent"],
 		queryFn: () => getRecentLookups(),
 		initialData: initial.recent,
-		refetchInterval: 4_000,
+		refetchInterval: 16_000,
 	});
 	const [login, setLogin] = useState("");
 


### PR DESCRIPTION
Slows the homepage's "Recently looked up" auto-refetch from every 4s to every 16s.

**Why:** be more cautious with the server-function call budget — that strip doesn't need second-by-second freshness.

**How:** one-line change to the `refetchInterval` on the `recent` query in `src/routes/index.tsx` (the leaderboard's 10s poll is left as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)