### PR TITLE
Cap leaderboard pagination at 250 entries

### DIFF
--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -90,7 +90,15 @@ export interface StartPageData {
 
 export type LeaderMode = "public" | "private" | "both" | "followers";
 
-export const LEADERBOARD_PAGE_SIZE = 20;
+/**
+ * Cumulative row counts revealed at each scroll step. The list is capped at the final value
+ * (250) so scrolling can never dump the whole table; bigger chunks further down mean fewer
+ * requests as you go (25 → +25 → +50 → +100 → +50).
+ */
+export const LEADERBOARD_PAGE_STOPS = [25, 50, 100, 200, 250] as const;
+/** Hard ceiling on how many rows any single mode's leaderboard will serve. */
+export const LEADERBOARD_MAX =
+	LEADERBOARD_PAGE_STOPS[LEADERBOARD_PAGE_STOPS.length - 1];
 const RECENT_LIMIT = 16;
 
 // Ranking is done in SQL per mode so pagination stays consistent as you scroll.
@@ -158,7 +166,7 @@ export const getStartPageData = createServerFn({ method: "GET" }).handler(
 	async (): Promise<StartPageData> => {
 		const [recent, leaderboard] = await Promise.all([
 			queryRecent(RECENT_LIMIT),
-			queryLeaderboard("public", 0, LEADERBOARD_PAGE_SIZE),
+			queryLeaderboard("public", 0, LEADERBOARD_PAGE_STOPS[0]),
 		]);
 		return { recent, leaderboard };
 	},
@@ -167,10 +175,13 @@ export const getStartPageData = createServerFn({ method: "GET" }).handler(
 /** One page of the leaderboard for a given mode — drives infinite scroll. */
 export const getLeaderboard = createServerFn({ method: "GET" })
 	.validator((p: { mode: LeaderMode; offset: number; limit: number }) => p)
-	.handler(
-		({ data }): Promise<LeaderEntry[]> =>
-			queryLeaderboard(data.mode, data.offset, data.limit),
-	);
+	.handler(({ data }): Promise<LeaderEntry[]> => {
+		// Hard cap regardless of client-supplied params: nobody dumps the whole table by
+		// hand-crafting an offset/limit. Clamp so we never read past LEADERBOARD_MAX.
+		const offset = Math.min(Math.max(0, data.offset), LEADERBOARD_MAX);
+		const limit = Math.min(Math.max(0, data.limit), LEADERBOARD_MAX - offset);
+		return queryLeaderboard(data.mode, offset, limit);
+	});
 
 /** Recent lookups — polled for the live "Recently looked up" strip. */
 export const getRecentLookups = createServerFn({ method: "GET" }).handler(

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,7 +6,7 @@ import {
 	getLeaderboard,
 	getRecentLookups,
 	getStartPageData,
-	LEADERBOARD_PAGE_SIZE,
+	LEADERBOARD_PAGE_STOPS,
 	type LeaderEntry,
 	type LeaderMode,
 	type RecentEntry,
@@ -188,17 +188,29 @@ function Leaderboard({
 		queryKey: ["leaderboard", mode],
 		queryFn: ({ pageParam }) =>
 			getLeaderboard({
-				data: { mode, offset: pageParam, limit: LEADERBOARD_PAGE_SIZE },
+				data: { mode, offset: pageParam.offset, limit: pageParam.limit },
 			}),
-		initialPageParam: 0,
-		getNextPageParam: (lastPage, allPages) =>
-			lastPage.length < LEADERBOARD_PAGE_SIZE
-				? undefined
-				: allPages.reduce((n, p) => n + p.length, 0),
+		initialPageParam: { offset: 0, limit: LEADERBOARD_PAGE_STOPS[0] as number },
+		// Reveal rows in widening chunks up to the final stop (the 250 cap). Stop early if the
+		// DB returns a short page (table exhausted) or we've reached the last stop.
+		getNextPageParam: (_lastPage, allPages) => {
+			const loaded = allPages.reduce((n, p) => n + p.length, 0);
+			const expected = LEADERBOARD_PAGE_STOPS[allPages.length - 1];
+			if (expected !== undefined && loaded < expected) return undefined;
+			const nextStop = LEADERBOARD_PAGE_STOPS[allPages.length];
+			if (nextStop === undefined) return undefined;
+			return { offset: loaded, limit: nextStop - loaded };
+		},
 		// Seed page 1 of the default (Public) mode from the SSR loader — no flash.
 		initialData:
-			mode === "public" ? { pages: [initialPage], pageParams: [0] } : undefined,
-		refetchInterval: 10_000,
+			mode === "public"
+				? {
+						pages: [initialPage],
+						pageParams: [{ offset: 0, limit: LEADERBOARD_PAGE_STOPS[0] }],
+					}
+				: undefined,
+		// No background polling: the board changes slowly. It refetches on mount (navigating
+		// back shows new entries immediately) and on window focus, but never while idle.
 	});
 
 	const rows = query.data?.pages.flat() ?? [];


### PR DESCRIPTION
Caps each leaderboard mode at 250 rows and loads them in widening chunks instead of an unbounded 20-at-a-time infinite scroll.

**Why:** Scrolling the leaderboard previously paginated through the *entire* `entities` table 20 rows at a time, and a 10s poll refetched every loaded page — so an idle tab scrolled deep was a steady compute drain and effectively dumped the DB to anyone.

**How:** A `LEADERBOARD_PAGE_STOPS = [25, 50, 100, 200, 250]` schedule drives `useInfiniteQuery` in widening steps and stops at the final stop (≤5 requests to the cap). The real guard is server-side: `getLeaderboard` clamps `offset`/`limit` so `offset + limit` can never exceed 250 regardless of what a client sends — the stop schedule is just UX. Background polling is dropped; the board refetches on mount/focus but never while idle.