### PR TITLE
Make chart labels responsive (bigger on mobile, slightly bigger on desktop)

### DIFF
--- a/src/components/ChartLegend.tsx
+++ b/src/components/ChartLegend.tsx
@@ -8,29 +8,39 @@ export interface LegendEntry {
 	color: string;
 }
 
-const FONT = 15;
-const ROW_H = 25;
-const PAD_X = 13;
-const PAD_Y = 11;
-const SWATCH = 13;
-const GAP = 10;
+// Geometry is expressed relative to the font size (the defaults below are tuned for a 15px
+// label) so the whole box scales when the chart grows its labels on mobile.
+const BASE_FONT = 15;
+const ROW_H = 25 / BASE_FONT;
+const PAD_X = 13 / BASE_FONT;
+const PAD_Y = 11 / BASE_FONT;
+const SWATCH = 13 / BASE_FONT;
+const GAP = 10 / BASE_FONT;
 // The xkcd font's metrics aren't available at render time (SSR, fixed viewBox, no DOM measure),
 // so the box width is approximated from each label's character count.
-const CHAR_W = 8.4;
+const CHAR_W = 8.4 / BASE_FONT;
 
 export function ChartLegend({
 	entries,
 	x,
 	y,
+	font = BASE_FONT,
 }: {
 	entries: LegendEntry[];
 	x: number;
 	y: number;
+	/** Label font size in viewBox units; the box scales with it. */
+	font?: number;
 }) {
 	if (entries.length === 0) return null;
+	const rowH = ROW_H * font;
+	const padX = PAD_X * font;
+	const padY = PAD_Y * font;
+	const swatch = SWATCH * font;
+	const gap = GAP * font;
 	const longest = Math.max(...entries.map((e) => e.label.length));
-	const boxW = PAD_X * 2 + SWATCH + GAP + longest * CHAR_W;
-	const boxH = PAD_Y * 2 + entries.length * ROW_H - (ROW_H - FONT);
+	const boxW = padX * 2 + swatch + gap + longest * CHAR_W * font;
+	const boxH = padY * 2 + entries.length * rowH - (rowH - font);
 
 	return (
 		<g>
@@ -46,22 +56,22 @@ export function ChartLegend({
 				filter="url(#xkcdify)"
 			/>
 			{entries.map((e, i) => {
-				const rowTop = y + PAD_Y + i * ROW_H;
+				const rowTop = y + padY + i * rowH;
 				return (
 					<g key={e.label}>
 						<rect
-							x={x + PAD_X}
+							x={x + padX}
 							y={rowTop}
-							width={SWATCH}
-							height={SWATCH}
+							width={swatch}
+							height={swatch}
 							rx={3}
 							fill={e.color}
 							filter="url(#xkcdify)"
 						/>
 						<text
-							x={x + PAD_X + SWATCH + GAP}
-							y={rowTop + SWATCH - 1}
-							fontSize={FONT}
+							x={x + padX + swatch + gap}
+							y={rowTop + swatch - 1}
+							fontSize={font}
 							fill="currentColor"
 						>
 							{e.label}

--- a/src/components/CommitChart.tsx
+++ b/src/components/CommitChart.tsx
@@ -1,14 +1,23 @@
 import { useState } from "react";
 import { ChartLegend } from "#/components/ChartLegend";
 import type { CommitPoint } from "#/lib/github";
+import { useIsMobile } from "#/lib/useIsMobile";
 
-// Fixed viewBox; the <svg> scales to its container via width:100%. No DOM measurement, so this
-// renders identically on the server (and can be reused verbatim for the /$user.svg embed).
+// Fixed viewBox; the <svg> scales to its container via width:100%. Because labels are sized in
+// viewBox units, they shrink with the container — so on a phone we swap to a layout with larger
+// fonts and roomier padding (the desktop fonts are also nudged up a touch, since folks screenshot
+// these to share). The /$user.svg embed renders its own SVG (lib/chart-svg.ts) and is unaffected.
 const W = 880;
 const H = 420;
-const PAD = { top: 48, right: 24, bottom: 36, left: 60 };
-const innerW = W - PAD.left - PAD.right;
-const innerH = H - PAD.top - PAD.bottom;
+
+const DESKTOP = {
+	pad: { top: 48, right: 24, bottom: 36, left: 60 },
+	font: { title: 24, axis: 16, readout: 16, legend: 16 },
+};
+const MOBILE = {
+	pad: { top: 56, right: 16, bottom: 50, left: 88 },
+	font: { title: 32, axis: 26, readout: 24, legend: 24 },
+};
 
 // star-history's brand green.
 const ACCENT = "#16a34a";
@@ -37,6 +46,10 @@ export function CommitChart({
 	label?: string;
 }) {
 	const [hover, setHover] = useState<number | null>(null);
+	const isMobile = useIsMobile();
+	const { pad: PAD, font: FONT } = isMobile ? MOBILE : DESKTOP;
+	const innerW = W - PAD.left - PAD.right;
+	const innerH = H - PAD.top - PAD.bottom;
 	if (points.length === 0) return null;
 
 	// Cumulative value to plot, and the month's delta — per the selected mode.
@@ -130,7 +143,7 @@ export function CommitChart({
 			<text
 				x={PAD.left}
 				y={28}
-				fontSize={22}
+				fontSize={FONT.title}
 				fontWeight={400}
 				fill="currentColor"
 			>
@@ -154,7 +167,7 @@ export function CommitChart({
 						textAnchor="end"
 						dominantBaseline="middle"
 						fill="#6b7280"
-						fontSize={14}
+						fontSize={FONT.axis}
 					>
 						{compact(v)}
 					</text>
@@ -169,7 +182,7 @@ export function CommitChart({
 					y={H - 10}
 					textAnchor="middle"
 					fill="#6b7280"
-					fontSize={14}
+					fontSize={FONT.axis}
 				>
 					{t.year}
 				</text>
@@ -203,6 +216,7 @@ export function CommitChart({
 					entries={[{ label, color: ACCENT }]}
 					x={PAD.left + 14}
 					y={PAD.top + 6}
+					font={FONT.legend}
 				/>
 			)}
 
@@ -230,7 +244,7 @@ export function CommitChart({
 						y={PAD.top - 8}
 						textAnchor="middle"
 						fill="currentColor"
-						fontSize={15}
+						fontSize={FONT.readout}
 					>
 						{monthLabel(hp.date)}: {cval(hp).toLocaleString()} total
 						{dval(hp) ? ` (+${dval(hp)})` : ""}

--- a/src/components/MultiCommitChart.tsx
+++ b/src/components/MultiCommitChart.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ChartLegend } from "#/components/ChartLegend";
 import type { ChartMode } from "#/components/CommitChart";
 import type { CommitPoint } from "#/lib/github";
+import { useIsMobile } from "#/lib/useIsMobile";
 
 /** Cumulative value to plot for a point, per the public/private/both selection.
  *  "both" sums public commits and private contributions. */
@@ -33,11 +34,18 @@ export interface ChartSeries {
 	points: CommitPoint[];
 }
 
+// Fixed viewBox scaled to container width — see CommitChart for why the layout is responsive.
 const W = 880;
 const H = 420;
-const PAD = { top: 40, right: 24, bottom: 30, left: 60 };
-const innerW = W - PAD.left - PAD.right;
-const innerH = H - PAD.top - PAD.bottom;
+
+const DESKTOP = {
+	pad: { top: 40, right: 24, bottom: 30, left: 60 },
+	font: { axis: 16, readout: 15, legend: 16 },
+};
+const MOBILE = {
+	pad: { top: 46, right: 16, bottom: 44, left: 88 },
+	font: { axis: 26, readout: 22, legend: 24 },
+};
 
 function compact(n: number) {
 	return new Intl.NumberFormat("en-US", { notation: "compact" }).format(n);
@@ -65,6 +73,10 @@ export function MultiCommitChart({
 	chartMode?: ChartMode;
 }) {
 	const [hoverFrac, setHoverFrac] = useState<number | null>(null);
+	const isMobile = useIsMobile();
+	const { pad: PAD, font: FONT } = isMobile ? MOBILE : DESKTOP;
+	const innerW = W - PAD.left - PAD.right;
+	const innerH = H - PAD.top - PAD.bottom;
 	if (series.length === 0 || series.every((s) => s.points.length === 0)) {
 		return null;
 	}
@@ -211,7 +223,7 @@ export function MultiCommitChart({
 						textAnchor="end"
 						dominantBaseline="middle"
 						fill="#6b7280"
-						fontSize={14}
+						fontSize={FONT.axis}
 					>
 						{compact(v)}
 					</text>
@@ -225,7 +237,7 @@ export function MultiCommitChart({
 					y={H - 10}
 					textAnchor="middle"
 					fill="#6b7280"
-					fontSize={14}
+					fontSize={FONT.axis}
 				>
 					{t.label}
 				</text>
@@ -255,6 +267,7 @@ export function MultiCommitChart({
 				entries={series.map((s) => ({ label: s.login, color: s.color }))}
 				x={PAD.left + 14}
 				y={PAD.top + 6}
+				font={FONT.legend}
 			/>
 
 			{/* Hover: vertical guide + a dot and value per series */}
@@ -287,7 +300,7 @@ export function MultiCommitChart({
 								<text
 									x={px + 8}
 									y={py - 6}
-									fontSize={13}
+									fontSize={FONT.readout}
 									fill={s.color}
 									fontWeight={600}
 								>
@@ -302,7 +315,7 @@ export function MultiCommitChart({
 							x={Math.min(Math.max(hoverX, PAD.left + 40), W - PAD.right - 40)}
 							y={PAD.top - 6}
 							textAnchor="middle"
-							fontSize={13}
+							fontSize={FONT.readout}
 							fill="currentColor"
 						>
 							{(() => {

--- a/src/lib/useIsMobile.ts
+++ b/src/lib/useIsMobile.ts
@@ -1,0 +1,22 @@
+import { useSyncExternalStore } from "react";
+
+// Tailwind's `sm` breakpoint. Below this we treat the viewport as a phone and grow the
+// chart's labels + padding so they stay legible once the fixed-viewBox SVG is squeezed
+// into a narrow container.
+const MOBILE_QUERY = "(max-width: 639px)";
+
+function subscribe(onChange: () => void) {
+	const mql = window.matchMedia(MOBILE_QUERY);
+	mql.addEventListener("change", onChange);
+	return () => mql.removeEventListener("change", onChange);
+}
+
+/** True when the viewport is phone-width. SSR renders the desktop layout (getServerSnapshot
+ *  returns false); the client corrects on hydration. */
+export function useIsMobile() {
+	return useSyncExternalStore(
+		subscribe,
+		() => window.matchMedia(MOBILE_QUERY).matches,
+		() => false,
+	);
+}

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -373,12 +373,14 @@ function SingleView({
 				/>
 			</motion.div>
 
-			<div className="mt-2 flex flex-wrap items-center justify-between gap-3 sm:mt-4">
-				<p className="text-xs text-muted-foreground">
+			<div className="mt-2 flex flex-wrap items-center gap-3 sm:mt-4 sm:justify-between">
+				<p className="w-full text-xs text-muted-foreground sm:w-auto">
 					Cumulative commits attributed by GitHub since {since} — the same
 					dataset as the contribution graph.
 				</p>
-				<AddUser currentLogins={otherLogins} label="Compare with…" />
+				<div className="ml-auto sm:ml-0">
+					<AddUser currentLogins={otherLogins} label="Compare with…" />
+				</div>
 			</div>
 		</>
 	);

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -78,7 +78,7 @@ const GENERIC_POINTS: CommitPoint[] = (() => {
 function PendingUser() {
 	const { user } = Route.useParams();
 	const login = user.split(",")[0];
-	const labels = ["Public commits", "Busiest month", "Since"];
+	const labels = ["Public commits", "Followers", "Busiest month"];
 	return (
 		<main className="mx-auto max-w-4xl px-6 py-12">
 			<Link
@@ -98,11 +98,11 @@ function PendingUser() {
 				</div>
 			</header>
 
-			<div className="mt-8 flex flex-wrap gap-10">
+			<div className="mx-auto mt-8 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
 				{labels.map((label) => (
 					<div key={label}>
 						{/* reserve value + hint heights; they animate in once data arrives */}
-						<div className="h-8" />
+						<div className="h-7" />
 						<div className="text-xs uppercase tracking-wide text-muted-foreground">
 							{label}
 						</div>

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -111,7 +111,7 @@ function PendingUser() {
 				))}
 			</div>
 
-			<div className="-mx-3 mt-3 py-3 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
+			<div className="-mx-6 mt-3 pt-[18px] pb-[6px] sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
 				<div className="pointer-events-none opacity-40 blur-[6px]">
 					<CommitChart points={GENERIC_POINTS} mode="public" />
 				</div>
@@ -245,7 +245,7 @@ function Stat({
 				initial={{ opacity: 0, y: -4 }}
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.35 }}
-				className="text-2xl font-semibold tabular-nums"
+				className="text-xl font-semibold tabular-nums"
 			>
 				{value}
 			</motion.div>
@@ -312,7 +312,7 @@ function ProfilePanel({
 				</div>
 			</header>
 
-			<div className="mt-6 flex flex-wrap gap-10">
+			<div className="mx-auto mt-6 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center">
 				<Stat label="Public commits" value={total.toLocaleString()} />
 				{hasPrivate && (
 					<Stat
@@ -364,7 +364,7 @@ function SingleView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-3 mt-3 py-3 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-6 mt-3 pt-[18px] pb-[6px] sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<CommitChart
 					points={points}
@@ -373,7 +373,7 @@ function SingleView({
 				/>
 			</motion.div>
 
-			<div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+			<div className="mt-2 flex flex-wrap items-center justify-between gap-3 sm:mt-4">
 				<p className="text-xs text-muted-foreground">
 					Cumulative commits attributed by GitHub since {since} — the same
 					dataset as the contribution graph.
@@ -448,7 +448,7 @@ function ComparisonView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-3 mt-6 py-3 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-6 mt-6 pt-[18px] pb-[6px] sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<MultiCommitChart
 					series={series}

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -111,7 +111,7 @@ function PendingUser() {
 				))}
 			</div>
 
-			<div className="-mx-6 mt-3 pt-[18px] pb-[6px] sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
+			<div className="-mx-4 mt-3 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
 				<div className="pointer-events-none opacity-40 blur-[6px]">
 					<CommitChart points={GENERIC_POINTS} mode="public" />
 				</div>
@@ -312,7 +312,7 @@ function ProfilePanel({
 				</div>
 			</header>
 
-			<div className="mx-auto mt-6 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center">
+			<div className="mx-auto mt-6 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
 				<Stat label="Public commits" value={total.toLocaleString()} />
 				{hasPrivate && (
 					<Stat
@@ -320,6 +320,7 @@ function ProfilePanel({
 						value={totalRestricted.toLocaleString()}
 					/>
 				)}
+				<Stat label="Followers" value={user.followers.toLocaleString()} />
 				<Stat
 					label="Busiest month"
 					value={busiest ? monthYear(busiest.date) : "—"}
@@ -329,7 +330,6 @@ function ProfilePanel({
 							: undefined
 					}
 				/>
-				<Stat label="Followers" value={user.followers.toLocaleString()} />
 			</div>
 		</div>
 	);
@@ -364,7 +364,7 @@ function SingleView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-6 mt-3 pt-[18px] pb-[6px] sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-4 mt-3 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<CommitChart
 					points={points}
@@ -448,7 +448,7 @@ function ComparisonView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-6 mt-6 pt-[18px] pb-[6px] sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<MultiCommitChart
 					series={series}

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -111,7 +111,7 @@ function PendingUser() {
 				))}
 			</div>
 
-			<div className="mt-3 rounded-xl border border-border p-4">
+			<div className="mt-3 sm:rounded-xl sm:border sm:border-border sm:p-4">
 				<div className="pointer-events-none opacity-40 blur-[6px]">
 					<CommitChart points={GENERIC_POINTS} mode="public" />
 				</div>
@@ -364,7 +364,7 @@ function SingleView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="mt-3 rounded-xl border border-border p-4"
+				className="mt-3 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<CommitChart
 					points={points}
@@ -448,7 +448,7 @@ function ComparisonView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="mt-6 rounded-xl border border-border p-4"
+				className="mt-6 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<MultiCommitChart
 					series={series}

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -111,7 +111,7 @@ function PendingUser() {
 				))}
 			</div>
 
-			<div className="mt-3 sm:rounded-xl sm:border sm:border-border sm:p-4">
+			<div className="-mx-3 mt-3 py-3 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
 				<div className="pointer-events-none opacity-40 blur-[6px]">
 					<CommitChart points={GENERIC_POINTS} mode="public" />
 				</div>
@@ -364,7 +364,7 @@ function SingleView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="mt-3 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-3 mt-3 py-3 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<CommitChart
 					points={points}
@@ -448,7 +448,7 @@ function ComparisonView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="mt-6 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-3 mt-6 py-3 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
 			>
 				<MultiCommitChart
 					series={series}


### PR DESCRIPTION
Makes the commit-history chart's labels responsive: noticeably larger on mobile, slightly larger on desktop.

**Why:** A lot of our traffic is on mobile and the chart is hard to read there. The SVG uses a fixed `viewBox` scaled to container width, so labels (sized in viewBox units) shrink with the container — on a phone the axis labels rendered at ~6px. The small desktop bump also helps the screenshots people share on X/LinkedIn.

**How:** Each chart now selects a `DESKTOP`/`MOBILE` layout preset (fonts **and** padding) via a small `useIsMobile` hook (`useSyncExternalStore` + `matchMedia`, SSR renders desktop and corrects on hydration). Padding is part of the preset, not just font size — the one judgment call — because the y-axis labels anchor against a fixed left pad, so larger fonts alone would clip off the left edge; mobile widens it to compensate. `ChartLegend` takes a `font` prop and scales its box proportionally.

The `/$user.svg` embed (`lib/chart-svg.ts`) is a separate renderer and is intentionally untouched.
