### PR TITLE
Remove gap between github.com/ prefix and username input

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -62,7 +62,7 @@ function Home() {
 						onChange={(e) => setLogin(e.target.value)}
 						placeholder="peetzweg"
 						aria-label="GitHub username"
-						className="min-w-0 flex-1 bg-transparent p-2 pl-1 outline-none"
+						className="min-w-0 flex-1 bg-transparent p-2 pl-0 outline-none"
 					/>
 				</div>
 				<button type="submit" className="btn-primary">


### PR DESCRIPTION
# Description

Removes the gap between the `github.com/` prefix and the username input on the landing page. The input carried `pl-1` (4px) of left padding on top of the prefix span's spacing, which pushed the typed username away from the `/`. Switched to `pl-0` so the username sits flush against the slash and reads like a real URL.

## Before

<img width="315" height="303" alt="Screenshot 2026-06-29 at 2 58 34 AM" src="https://github.com/user-attachments/assets/d6ea1a7a-bfa0-4543-9cb8-3d10ccf6c3b3" />



Visible gap between the `/` and the typed username.

## After

<img width="229" height="115" alt="Screenshot 2026-06-29 at 2 55 06 AM" src="https://github.com/user-attachments/assets/72ce22c3-e049-4950-b6f5-15dfed4a5314" />


The username sits flush against the slash, reading as one continuous URL.
