### PR TITLE
Lighten the username input placeholder text

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -62,7 +62,7 @@ function Home() {
 						onChange={(e) => setLogin(e.target.value)}
 						placeholder="peetzweg"
 						aria-label="GitHub username"
-						className="min-w-0 flex-1 bg-transparent p-2 pl-1 outline-none"
+						className="min-w-0 flex-1 bg-transparent p-2 pl-1 outline-none placeholder:text-muted-foreground/60"
 					/>
 				</div>
 				<button type="submit" className="btn-primary">


### PR DESCRIPTION
# Description

Lightens the username input's placeholder text (`peetzweg`) on the landing page so it reads more clearly as a hint rather than entered text. Adds `placeholder:text-muted-foreground/60`, tying the placeholder into the existing `muted-foreground` design token at a softer opacity.

## Before

<img width="379" height="293" alt="Screenshot 2026-06-29 at 2 59 44 AM" src="https://github.com/user-attachments/assets/2d8693ec-704b-4e74-bc73-579ba2192796" />


## After
<img width="440" height="364" alt="Screenshot 2026-06-29 at 3 00 20 AM" src="https://github.com/user-attachments/assets/f8aac737-11d9-4c27-bf72-cafd62d48b71" />
