### PR TITLE
Show public-commits leaderboard rank on profiles

### DIFF
--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -68,6 +68,9 @@ export interface UserResult {
 	// True when the entity is suspended (under investigation) — the profile is still shown, but
 	// with an under-review notice. The internal reason is never sent to the client.
 	suspended: boolean;
+	// Position on the public-commits leaderboard (1 = most public commits), among active entities.
+	// Null when there's no DB; suppressed in the UI for suspended profiles (hidden from the board).
+	publicRank: number | null;
 }
 
 export interface LeaderEntry {
@@ -200,6 +203,26 @@ async function suspendedSet(logins: string[]): Promise<Set<string>> {
 }
 
 /**
+ * Public-leaderboard position for a user with `publicCommits` public commits: how many active
+ * entities sit ahead of them, plus one. Same ordering as the "public" leaderboard (`total_commits`
+ * DESC), so the number matches where you'd land on the start page. Ties share a rank — two users
+ * with equal commits both count the same crowd ahead. Null without a DB.
+ */
+async function publicRankFor(publicCommits: number): Promise<number | null> {
+	if (!db) return null;
+	const [row] = await db
+		.select({ ahead: sql<number>`count(*)` })
+		.from(entities)
+		.where(
+			and(
+				isNull(entities.suspendedAt),
+				gt(entities.totalCommits, publicCommits),
+			),
+		);
+	return Number(row?.ahead ?? 0) + 1;
+}
+
+/**
  * Resolve several users' histories in one round-trip, tolerating partial failure so one bad
  * username doesn't sink the whole comparison.
  */
@@ -207,24 +230,39 @@ export const getCommitHistories = createServerFn({ method: "GET" })
 	.validator((logins: string[]) => logins)
 	.handler(async ({ data: logins }): Promise<UserResult[]> => {
 		const token = serverToken();
-		const [results, suspended] = await Promise.all([
-			Promise.all(
-				logins.map(async (login): Promise<UserResult> => {
-					try {
-						const history = await getCachedCommitHistory(login, token);
-						return { login, history, error: null, suspended: false };
-					} catch (e) {
-						return {
-							login,
-							history: null,
-							error: e instanceof Error ? e.message : "Failed to load",
-							suspended: false,
-						};
-					}
-				}),
+		// allSettled (not all): one user's failed GitHub fetch must not reject the whole batch and
+		// blank out the others. suspendedSet is fetched alongside and is best-effort — a DB hiccup
+		// there shouldn't drop already-loaded profiles, so it falls back to "none suspended".
+		const [settled, suspended] = await Promise.all([
+			Promise.allSettled(
+				logins.map((login) => getCachedCommitHistory(login, token)),
 			),
-			suspendedSet(logins),
+			suspendedSet(logins).catch(() => new Set<string>()),
 		]);
-		for (const r of results) r.suspended = suspended.has(r.login.toLowerCase());
-		return results;
+		return Promise.all(
+			settled.map(async (outcome, i): Promise<UserResult> => {
+				const login = logins[i];
+				const isSuspended = suspended.has(login.toLowerCase());
+				if (outcome.status === "rejected") {
+					const e = outcome.reason;
+					return {
+						login,
+						history: null,
+						error: e instanceof Error ? e.message : "Failed to load",
+						suspended: isSuspended,
+						publicRank: null,
+					};
+				}
+				const history = outcome.value;
+				// Rank is supplementary — never let a ranking-query failure drop a loaded profile.
+				const publicRank = await publicRankFor(history.total).catch(() => null);
+				return {
+					login,
+					history,
+					error: null,
+					suspended: isSuspended,
+					publicRank,
+				};
+			}),
+		);
 	});

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -78,7 +78,12 @@ const GENERIC_POINTS: CommitPoint[] = (() => {
 function PendingUser() {
 	const { user } = Route.useParams();
 	const login = user.split(",")[0];
-	const labels = ["Public commits", "Followers", "Busiest month"];
+	const labels = [
+		"Public rank",
+		"Public commits",
+		"Followers",
+		"Busiest month",
+	];
 	return (
 		<main className="mx-auto max-w-4xl px-6 py-12">
 			<Link
@@ -272,6 +277,8 @@ function ProfilePanel({
 	const { user, points, total, totalRestricted } = result.history!;
 	const hasPrivate = totalRestricted > 0;
 	const since = monthYear(user.createdAt);
+	// Public-leaderboard rank — hidden for suspended profiles, which are off the board entirely.
+	const rank = result.suspended ? null : result.publicRank;
 	// Busiest month by total activity (public + private), so it's meaningful for private-heavy users.
 	const busiest = points.reduce(
 		(best, p) =>
@@ -313,6 +320,9 @@ function ProfilePanel({
 			</header>
 
 			<div className="mx-auto mt-6 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
+				{rank !== null && (
+					<Stat label="Public rank" value={`#${rank.toLocaleString()}`} />
+				)}
 				<Stat label="Public commits" value={total.toLocaleString()} />
 				{hasPrivate && (
 					<Stat


### PR DESCRIPTION
Adds a **Public rank** stat as the first data field on a profile, alongside the existing Public commits / Followers / Busiest month.

**Why:** people want to know where they stand on the leaderboard without scrolling for themselves — and a user can rank well past the 250-row display cap, so the client can't derive it from the leaderboard slice it holds.

**How:** ranked purely on public commits (`count(*)` of active entities with more `total_commits` — the same column the public leaderboard sorts by) so the gameable private numbers can't move it. Computed server-side and piggybacked on the existing `getCommitHistories` round-trip (no extra request), suppressed for suspended profiles. While in there, switched the batch fetch to `Promise.allSettled` so one failed GitHub request no longer blanks the whole comparison.

Index follow-up for scale tracked in #27. No schema change — `publicRank` is a computed response field.