### PR TITLE
Stop stripping referrer on outbound links

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,7 @@ export function Header() {
 				<a
 					href="https://www.star-history.com/"
 					target="_blank"
-					rel="noreferrer"
+					rel="noopener"
 					className="header-link hidden text-sm sm:flex"
 					title="Inspired by star-history.com"
 				>
@@ -23,7 +23,7 @@ export function Header() {
 				<a
 					href="https://github.com/peetzweg/commit-history"
 					target="_blank"
-					rel="noreferrer"
+					rel="noopener"
 					className="header-link"
 					title="View source on GitHub"
 					aria-label="View source on GitHub"

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -222,7 +222,7 @@ function SuspendedNotice() {
 				<a
 					href="https://github.com/peetzweg/commit-history/issues"
 					target="_blank"
-					rel="noreferrer"
+					rel="noopener"
 					className="underline hover:text-foreground"
 				>
 					open an issue
@@ -308,7 +308,7 @@ function ProfilePanel({
 					<a
 						href={`https://github.com/${user.login}`}
 						target="_blank"
-						rel="noreferrer"
+						rel="noopener"
 						className="text-sm text-muted-foreground hover:underline"
 					>
 						@{user.login}
@@ -445,7 +445,7 @@ function EmbedSnippet({ login }: { login: string }) {
 				<a
 					href="https://github.com/peetzweg"
 					target="_blank"
-					rel="noreferrer"
+					rel="noopener"
 					className="block overflow-hidden rounded-xl border border-border"
 				>
 					<img
@@ -563,7 +563,7 @@ function ComparisonView({
 						<a
 							href={`https://github.com/${r.login}`}
 							target="_blank"
-							rel="noreferrer"
+							rel="noopener"
 							className="hover:underline"
 						>
 							{r.login}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -197,7 +197,7 @@ function SelfPromoRow() {
 					<a
 						href="https://github.com/peetzweg"
 						target="_blank"
-						rel="noreferrer"
+						rel="noopener"
 						className="font-medium text-foreground hover:underline"
 					>
 						peetzweg
@@ -207,7 +207,7 @@ function SelfPromoRow() {
 				<a
 					href="https://ko-fi.com/peetzweg"
 					target="_blank"
-					rel="noreferrer"
+					rel="noopener"
 					className="btn-secondary shrink-0 text-xs"
 				>
 					Buy me a coffee →


### PR DESCRIPTION
Switch outbound links from `rel="noreferrer"` to `rel="noopener"`.

**Why:** I want the sites I link out to (star-history, Ko-fi, my own repo) to see in their analytics that the traffic came from commit-history.com. `noreferrer` was stripping the `Referer` header — the exact signal those analytics use — so we were hiding ourselves.

**How:** `noopener` keeps the security protection (the new tab can't hijack our page) but lets the browser send the referrer, so the destination sees `commit-history.com` as the source. No tracking params added — the header does the job. The rebates sponsor ad is unchanged (it already used `noopener`).

Note: GitHub *profile* links still won't surface this anywhere (profiles have no traffic panel); the repo link will show up under the repo's Insights → Traffic → Referring sites.