### PR TITLE
Exclude the in-progress month from commit history

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -90,7 +90,12 @@ export interface MonthWindow {
 	label: string;
 }
 
-/** Generate monthly windows from `start` up to and including the month containing `now`. */
+/**
+ * Generate monthly windows from `start` up to and including the last *completed* month before
+ * `now`. The current, in-progress month is deliberately excluded: it holds only a few days of
+ * data, so plotting it flattens every curve at the end and skews totals/leaderboard. It rolls
+ * back in automatically once the month completes.
+ */
 export function monthlyWindows(start: Date, now: Date): MonthWindow[] {
 	const windows: MonthWindow[] = [];
 	let year = start.getUTCFullYear();
@@ -98,7 +103,8 @@ export function monthlyWindows(start: Date, now: Date): MonthWindow[] {
 	const endYear = now.getUTCFullYear();
 	const endMonth = now.getUTCMonth();
 
-	while (year < endYear || (year === endYear && month <= endMonth)) {
+	// Strict `<` on the current month → stop before it (only completed months are included).
+	while (year < endYear || (year === endYear && month < endMonth)) {
 		const from = new Date(Date.UTC(year, month, 1, 0, 0, 0));
 		// Last instant of this month = day 0 of next month.
 		const to = new Date(Date.UTC(year, month + 1, 0, 23, 59, 59));


### PR DESCRIPTION
Follow-up: #35

Stop plotting the current, in-progress calendar month. It holds only a few days of commits, so it flattened every chart at the end and skewed the lifetime total + leaderboard — most visible right after a month rollover (just happened for July).

**Why:** partial-month data makes each graph look broken.

**How:** `monthlyWindows()` now stops at the last *completed* month (`month < endMonth`). Every consumer (web chart, embed SVG, totals, leaderboard) is built from that same list, so it's a single-seam fix. The cache's trailing refresh reuses the same function, so once a month completes it rolls back in automatically — no manual step.

Deliberately hides the current month for now; #35 tracks the nicer version (show it as a dashed "in progress" trend segment, Plausible-style).
