### PR TITLE
Fix graph hover readout

### DIFF
--- a/src/components/ChartTooltip.tsx
+++ b/src/components/ChartTooltip.tsx
@@ -1,0 +1,130 @@
+// Floating hover readout, à la the in-chart legend: a wobbly rounded box (run through the
+// chart's #xkcdify filter) with a date header and one row per series — color swatch + label +
+// value. It self-places next to the cursor and clamps inside the plot bounds so it never spills
+// past the chart edge. Only the border and swatches get the hand-drawn wobble; text stays crisp.
+
+export interface TooltipRow {
+	label: string;
+	value: string;
+	color: string;
+}
+
+// Geometry is expressed relative to the font size (tuned for 15px) so the box scales with the
+// chart's larger mobile labels, mirroring ChartLegend.
+const BASE_FONT = 15;
+const ROW_H = 24 / BASE_FONT;
+const PAD_X = 13 / BASE_FONT;
+const PAD_Y = 8 / BASE_FONT;
+const SWATCH = 12 / BASE_FONT;
+const GAP = 9 / BASE_FONT;
+// Space between a row's label and its right-aligned value.
+const COL_GAP = 18 / BASE_FONT;
+// The xkcd font's metrics aren't measurable at render time, so widths are approximated from
+// character counts.
+const CHAR_W = 8.4 / BASE_FONT;
+// How far to sit from the cursor before clamping.
+const OFFSET = 16 / BASE_FONT;
+
+export function ChartTooltip({
+	title,
+	rows,
+	anchorX,
+	anchorY,
+	bounds,
+	font = BASE_FONT,
+}: {
+	title: string;
+	rows: TooltipRow[];
+	/** Cursor position (viewBox units) the box floats beside. */
+	anchorX: number;
+	anchorY: number;
+	/** Plot area the box must stay within (viewBox units). */
+	bounds: { left: number; right: number; top: number; bottom: number };
+	font?: number;
+}) {
+	if (rows.length === 0) return null;
+	const rowH = ROW_H * font;
+	const padX = PAD_X * font;
+	const padY = PAD_Y * font;
+	const swatch = SWATCH * font;
+	const gap = GAP * font;
+	const colGap = COL_GAP * font;
+	const charW = CHAR_W * font;
+	const offset = OFFSET * font;
+
+	const rowW = (r: TooltipRow) =>
+		swatch + gap + (r.label.length + r.value.length) * charW + colGap;
+	const contentW = Math.max(title.length * charW, ...rows.map(rowW));
+	const boxW = padX * 2 + contentW;
+	const lines = rows.length + 1; // header + one per series
+	const boxH = padY * 2 + lines * rowH;
+
+	// Prefer the right of the cursor; flip left if it would overflow, then clamp both axes.
+	let bx = anchorX + offset;
+	if (bx + boxW > bounds.right) bx = anchorX - offset - boxW;
+	bx = Math.max(bounds.left, Math.min(bx, bounds.right - boxW));
+	let by = anchorY - boxH / 2;
+	by = Math.max(bounds.top, Math.min(by, bounds.bottom - boxH));
+
+	const lineY = (i: number) => by + padY + i * rowH + rowH / 2;
+	const valueRight = bx + padX + contentW;
+
+	return (
+		<g>
+			<rect
+				x={bx}
+				y={by}
+				width={boxW}
+				height={boxH}
+				rx={10}
+				fill="var(--background, #fff)"
+				stroke="currentColor"
+				strokeWidth={2}
+				filter="url(#xkcdify)"
+			/>
+			<text
+				x={bx + padX}
+				y={lineY(0)}
+				fontSize={font}
+				fontWeight={600}
+				dominantBaseline="central"
+				fill="currentColor"
+			>
+				{title}
+			</text>
+			{rows.map((r, i) => (
+				<g key={r.label}>
+					<rect
+						x={bx + padX}
+						y={lineY(i + 1) - swatch / 2}
+						width={swatch}
+						height={swatch}
+						rx={3}
+						fill={r.color}
+						filter="url(#xkcdify)"
+					/>
+					<text
+						x={bx + padX + swatch + gap}
+						y={lineY(i + 1)}
+						fontSize={font}
+						dominantBaseline="central"
+						fill="currentColor"
+					>
+						{r.label}
+					</text>
+					<text
+						x={valueRight}
+						y={lineY(i + 1)}
+						fontSize={font}
+						textAnchor="end"
+						fontWeight={600}
+						dominantBaseline="central"
+						fill={r.color}
+					>
+						{r.value}
+					</text>
+				</g>
+			))}
+		</g>
+	);
+}

--- a/src/components/MultiCommitChart.tsx
+++ b/src/components/MultiCommitChart.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChartLegend } from "#/components/ChartLegend";
+import { ChartTooltip } from "#/components/ChartTooltip";
 import type { ChartMode } from "#/components/CommitChart";
 import type { CommitPoint } from "#/lib/github";
 import { useIsMobile } from "#/lib/useIsMobile";
@@ -63,6 +64,23 @@ function monthLabel(date: string) {
 	});
 }
 
+// Inverse of monthIndex: build a first-of-month date string for a month index.
+function monthLabelFromIndex(mi: number) {
+	const year = Math.floor(mi / 12);
+	const month = (mi % 12) + 1;
+	return monthLabel(`${year}-${String(month).padStart(2, "0")}-01`);
+}
+
+// Human label for an aligned-timeline step (months since each series' own start).
+function alignedStepLabel(i: number) {
+	if (i <= 0) return "Start";
+	const years = Math.floor(i / 12);
+	const months = i % 12;
+	if (years === 0) return `${months} mo`;
+	if (months === 0) return `${years}y`;
+	return `${years}y ${months}mo`;
+}
+
 export function MultiCommitChart({
 	series,
 	mode,
@@ -72,7 +90,8 @@ export function MultiCommitChart({
 	mode: TimelineMode;
 	chartMode?: ChartMode;
 }) {
-	const [hoverFrac, setHoverFrac] = useState<number | null>(null);
+	const [hover, setHover] = useState<{ frac: number; y: number } | null>(null);
+	const hoverFrac = hover?.frac ?? null;
 	const isMobile = useIsMobile();
 	const { pad: PAD, font: FONT } = isMobile ? MOBILE : DESKTOP;
 	const innerW = W - PAD.left - PAD.right;
@@ -142,20 +161,38 @@ export function MultiCommitChart({
 
 	function onMove(e: React.MouseEvent<SVGSVGElement>) {
 		const rect = e.currentTarget.getBoundingClientRect();
-		setHoverFrac(
-			Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)),
-		);
+		// Convert the pointer to viewBox units, then to a fraction of the *plot*
+		// area (not the full width) — otherwise the guide line drifts left of the
+		// cursor by the left padding.
+		const svgX = ((e.clientX - rect.left) / rect.width) * W;
+		const svgY = ((e.clientY - rect.top) / rect.height) * H;
+		setHover({
+			frac: Math.max(0, Math.min(1, (svgX - PAD.left) / innerW)),
+			y: svgY,
+		});
 	}
 
 	// Resolve hover to a point per series.
 	const hoverX = hoverFrac == null ? null : PAD.left + hoverFrac * innerW;
+	// The month (date mode) / step index (aligned mode) under the cursor, independent
+	// of any single series — so the readout's header reflects where the mouse is, not
+	// whichever series happens to be closest.
+	const hoverMonth =
+		hoverFrac == null ? null : Math.round(t0 + hoverFrac * (t1 - t0));
+	const hoverStep =
+		hoverFrac == null ? null : Math.round(hoverFrac * (maxLen - 1));
 	function hoverPoint(s: ChartSeries): { i: number } | null {
 		if (hoverFrac == null) return null;
 		if (mode === "aligned") {
-			const i = Math.round(hoverFrac * (maxLen - 1));
+			const i = hoverStep as number;
 			return i < s.points.length ? { i } : null;
 		}
-		const mi = t0 + hoverFrac * (t1 - t0);
+		// Only report this series where its line actually exists: skip months before
+		// it started or after it ended. Within range, snap to the nearest point.
+		const mi = hoverMonth as number;
+		const start = monthIndex(s.points[0].date);
+		const end = monthIndex(s.points[s.points.length - 1].date);
+		if (mi < start || mi > end) return null;
 		let best = 0;
 		let bestD = Infinity;
 		s.points.forEach((p, i) => {
@@ -175,7 +212,7 @@ export function MultiCommitChart({
 			aria-label="Cumulative commits over time"
 			className="chart-sketch block h-auto w-full text-foreground"
 			onMouseMove={onMove}
-			onMouseLeave={() => setHoverFrac(null)}
+			onMouseLeave={() => setHover(null)}
 		>
 			<defs>
 				{single && (
@@ -270,8 +307,8 @@ export function MultiCommitChart({
 				font={FONT.legend}
 			/>
 
-			{/* Hover: vertical guide + a dot and value per series */}
-			{hoverX != null && (
+			{/* Hover: vertical guide + a dot per series + one floating readout box */}
+			{hoverX != null && hover != null && (
 				<g>
 					<line
 						x1={hoverX}
@@ -285,45 +322,54 @@ export function MultiCommitChart({
 						const hp = hoverPoint(s);
 						if (!hp) return null;
 						const p = s.points[hp.i];
-						const px = xOf(s, hp.i);
-						const py = y(cval(p));
 						return (
-							<g key={s.login}>
-								<circle
-									cx={px}
-									cy={py}
-									r={4}
-									fill={s.color}
-									stroke="#fff"
-									strokeWidth={1.5}
-								/>
-								<text
-									x={px + 8}
-									y={py - 6}
-									fontSize={FONT.readout}
-									fill={s.color}
-									fontWeight={600}
-								>
-									{cval(p).toLocaleString()}
-								</text>
-							</g>
+							<circle
+								key={s.login}
+								cx={xOf(s, hp.i)}
+								cy={y(cval(p))}
+								r={4}
+								fill={s.color}
+								stroke="#fff"
+								strokeWidth={1.5}
+							/>
 						);
 					})}
-					{/* x label for the hovered position (date mode shows the month) */}
-					{mode === "date" && series[0] && (
-						<text
-							x={Math.min(Math.max(hoverX, PAD.left + 40), W - PAD.right - 40)}
-							y={PAD.top - 6}
-							textAnchor="middle"
-							fontSize={FONT.readout}
-							fill="currentColor"
-						>
-							{(() => {
-								const hp = hoverPoint(series[0]);
-								return hp ? monthLabel(series[0].points[hp.i].date) : "";
-							})()}
-						</text>
-					)}
+					{(() => {
+						const rows = series
+							.map((s) => {
+								const hp = hoverPoint(s);
+								if (!hp) return null;
+								return {
+									label: s.login,
+									value: cval(s.points[hp.i]).toLocaleString(),
+									color: s.color,
+								};
+							})
+							.filter((r): r is NonNullable<typeof r> => r != null);
+						const title =
+							mode === "date"
+								? hoverMonth != null
+									? monthLabelFromIndex(hoverMonth)
+									: ""
+								: hoverStep != null
+									? alignedStepLabel(hoverStep)
+									: "";
+						return (
+							<ChartTooltip
+								title={title}
+								rows={rows}
+								anchorX={hoverX}
+								anchorY={hover.y}
+								bounds={{
+									left: PAD.left,
+									right: W - PAD.right,
+									top: PAD.top,
+									bottom: baseline,
+								}}
+								font={FONT.readout}
+							/>
+						);
+					})()}
 				</g>
 			)}
 		</svg>

--- a/src/components/MultiCommitChart.tsx
+++ b/src/components/MultiCommitChart.tsx
@@ -15,6 +15,15 @@ export function chartValue(p: CommitPoint, mode: ChartMode) {
 			: p.cumulative + p.restrictedCumulative;
 }
 
+/** Commits added in this point's own month (the non-cumulative delta), per selection. */
+export function chartDelta(p: CommitPoint, mode: ChartMode) {
+	return mode === "public"
+		? p.commits
+		: mode === "private"
+			? p.restricted
+			: p.commits + p.restricted;
+}
+
 // First color is star-history's brand green; the rest are a distinguishable palette.
 export const SERIES_COLORS = [
 	"#16a34a",
@@ -101,6 +110,7 @@ export function MultiCommitChart({
 	}
 
 	const cval = (p: CommitPoint) => chartValue(p, chartMode);
+	const dcval = (p: CommitPoint) => chartDelta(p, chartMode);
 
 	const yMax = Math.max(1, ...series.flatMap((s) => s.points.map(cval)));
 	const y = (v: number) => PAD.top + innerH - (v / yMax) * innerH;
@@ -339,11 +349,14 @@ export function MultiCommitChart({
 							.map((s) => {
 								const hp = hoverPoint(s);
 								if (!hp) return null;
-								return {
-									label: s.login,
-									value: cval(s.points[hp.i]).toLocaleString(),
-									color: s.color,
-								};
+								const p = s.points[hp.i];
+								const delta = dcval(p);
+								// Total, with the month's own additions in brackets behind it.
+								const value =
+									delta > 0
+										? `${cval(p).toLocaleString()} (+${delta.toLocaleString()})`
+										: cval(p).toLocaleString();
+								return { label: s.login, value, color: s.color };
 							})
 							.filter((r): r is NonNullable<typeof r> => r != null);
 						const title =


### PR DESCRIPTION
Fixes the hover interaction on the multi-developer comparison chart, which was clipping labels, misplacing the guide line, and reporting bogus values.

**Why:** Hovering the chart showed value labels clipped off the right edge and overlapping the date label, the vertical guide line sat noticeably left of the actual cursor, and a series was reported (with a value) even at months where its line doesn't exist yet — e.g. hovering 2012 claimed "Jan 2018 = 158" for a contributor who only started in 2018.

**How:** The pointer is now converted to viewBox units against the plot area so the guide tracks the cursor exactly. The scattered per-point labels and separate date label are replaced by a single floating readout box (`ChartTooltip`, styled like the legend) that shows the hovered month and one row per contributor. A series only contributes a row and dot where its line actually exists, and the header reflects the hovered month rather than whichever series is nearest. Works for any number of contributors.