### PR TITLE
Collect all public contribution types monthly (#39)

### DIFF
--- a/drizzle/0004_neat_nocturne.sql
+++ b/drizzle/0004_neat_nocturne.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "entities" ADD COLUMN "total_issues" integer;--> statement-breakpoint
+ALTER TABLE "entities" ADD COLUMN "total_pull_requests" integer;--> statement-breakpoint
+ALTER TABLE "entities" ADD COLUMN "total_reviews" integer;--> statement-breakpoint
+ALTER TABLE "entities" ADD COLUMN "total_repos" integer;--> statement-breakpoint
+ALTER TABLE "monthly_commits" ADD COLUMN "issues" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "monthly_commits" ADD COLUMN "pull_requests" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "monthly_commits" ADD COLUMN "reviews" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "monthly_commits" ADD COLUMN "repos" integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,318 @@
+{
+  "id": "77583d84-f774-46eb-ab57-38afa4a742e6",
+  "prevId": "6fdc5d97-9e8c-43c2-8222-ea913ba28e51",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_commits": {
+          "name": "total_commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_restricted": {
+          "name": "total_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_issues": {
+          "name": "total_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pull_requests": {
+          "name": "total_pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_reviews": {
+          "name": "total_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_repos": {
+          "name": "total_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers": {
+          "name": "followers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following": {
+          "name": "following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_username": {
+          "name": "twitter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_at": {
+          "name": "built_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lookups": {
+      "name": "lookups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searched_at": {
+          "name": "searched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lookups_entity_id_entities_id_fk": {
+          "name": "lookups_entity_id_entities_id_fk",
+          "tableFrom": "lookups",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monthly_commits": {
+      "name": "monthly_commits",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted": {
+          "name": "restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issues": {
+          "name": "issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_requests": {
+          "name": "pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repos": {
+          "name": "repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monthly_commits_entity_id_entities_id_fk": {
+          "name": "monthly_commits_entity_id_entities_id_fk",
+          "tableFrom": "monthly_commits",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monthly_commits_entity_id_month_pk": {
+          "name": "monthly_commits_entity_id_month_pk",
+          "columns": [
+            "entity_id",
+            "month"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1782664311926,
       "tag": "0003_flimsy_cloak",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782922145086,
+      "tag": "0004_neat_nocturne",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check": "biome check",
     "suspend": "bun scripts/suspend.ts",
     "refresh": "bun scripts/refresh.ts",
+    "backfill": "bun scripts/backfill-contributions.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"

--- a/scripts/backfill-contributions.ts
+++ b/scripts/backfill-contributions.ts
@@ -1,0 +1,172 @@
+/**
+ * Backfill the additional public contribution types — issues opened, PRs opened, PR reviews, and
+ * repositories created — onto every entity's monthly history and lifetime totals.
+ *
+ * These columns didn't exist when older rows were cached, so their per-month values sit at 0 and
+ * the entity-level totals (total_issues, …) are NULL until filled. This script does a full rebuild
+ * per user via the SAME code path the app uses (fetchCommitHistory), then upserts the result —
+ * so it also refreshes commits/private/profile as a side effect. Mirrors scripts/refresh.ts.
+ *
+ * Run with bun, which auto-loads the local (un-committed) `.env`, so no `--env-file` flag:
+ *
+ *   bun run backfill <login>   # one account
+ *   bun run backfill           # only un-backfilled rows (total_issues IS NULL), top contributors first
+ *   bun run backfill --all     # every user, top contributors first
+ *
+ * Safe to re-run. Processes highest-commit accounts first so the most relevant profiles are done
+ * early if the run is interrupted. Gentle pacing keeps us well under GitHub's GraphQL rate limit.
+ */
+import { desc, eq, isNull, sql } from "drizzle-orm";
+import { db } from "#/lib/db";
+import { entities, monthlyCommits } from "#/lib/db/schema";
+import { fetchCommitHistory } from "#/lib/github";
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+if (!process.env.DATABASE_URL)
+	throw new Error("DATABASE_URL is required (add it to .env)");
+if (!GITHUB_TOKEN) throw new Error("GITHUB_TOKEN is required (add it to .env)");
+if (!db) throw new Error("Database client failed to initialise.");
+const token = GITHUB_TOKEN;
+const database = db;
+
+const entityId = (login: string) => `user:${login.trim().toLowerCase()}`;
+
+// Delay between users. Each user costs ~1 + ceil(months/12) GraphQL requests (≈1 point each);
+// this pacing keeps a long run comfortably under the 5,000 points/hour primary limit and avoids
+// tripping secondary (burst) limits.
+const DELAY_MS = 300;
+
+async function backfill(id: string, login: string): Promise<string> {
+	const history = await fetchCommitHistory(login, token);
+	const {
+		user,
+		points,
+		total,
+		totalRestricted,
+		totalIssues,
+		totalPullRequests,
+		totalReviews,
+		totalRepos,
+	} = history;
+	const now = new Date();
+
+	// Full-rebuild semantics: stamp builtAt + all lifetime totals (incl. the new types).
+	await database
+		.update(entities)
+		.set({
+			name: user.name,
+			avatarUrl: user.avatarUrl,
+			createdAt: new Date(user.createdAt),
+			totalCommits: total,
+			totalRestricted,
+			totalIssues,
+			totalPullRequests,
+			totalReviews,
+			totalRepos,
+			followers: user.followers,
+			following: user.following,
+			publicRepos: user.publicRepos,
+			bio: user.bio,
+			company: user.company,
+			location: user.location,
+			websiteUrl: user.websiteUrl,
+			twitterUsername: user.twitterUsername,
+			lastFetched: now,
+			builtAt: now,
+		})
+		.where(eq(entities.id, id));
+
+	if (points.length > 0) {
+		await database
+			.insert(monthlyCommits)
+			.values(
+				points.map((p) => ({
+					entityId: id,
+					month: p.date,
+					commits: p.commits,
+					restricted: p.restricted,
+					issues: p.issues,
+					pullRequests: p.pullRequests,
+					reviews: p.reviews,
+					repos: p.repos,
+				})),
+			)
+			.onConflictDoUpdate({
+				target: [monthlyCommits.entityId, monthlyCommits.month],
+				set: {
+					commits: sql`excluded.commits`,
+					restricted: sql`excluded.restricted`,
+					issues: sql`excluded.issues`,
+					pullRequests: sql`excluded.pull_requests`,
+					reviews: sql`excluded.reviews`,
+					repos: sql`excluded.repos`,
+				},
+			});
+	}
+
+	return `${total.toLocaleString()} commits · ${totalIssues.toLocaleString()} issues · ${totalPullRequests.toLocaleString()} PRs · ${totalReviews.toLocaleString()} reviews`;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const [arg1] = process.argv.slice(2);
+
+if (arg1 && !arg1.startsWith("--")) {
+	// One particular user.
+	const id = entityId(arg1);
+	const [row] = await database
+		.select({ id: entities.id, login: entities.login })
+		.from(entities)
+		.where(eq(entities.id, id))
+		.limit(1);
+	if (!row) {
+		console.error(
+			`✗ "${arg1}" is not in the database yet — nobody has looked them up. Check the spelling.`,
+		);
+		process.exit(1);
+	}
+	console.log(`${row.login} → ${await backfill(row.id, row.login)}`);
+} else if (!arg1 || arg1 === "--all") {
+	// Highest-commit accounts first, so the most relevant profiles land early.
+	const base = database
+		.select({ id: entities.id, login: entities.login })
+		.from(entities);
+	const rows =
+		arg1 === "--all"
+			? await base.orderBy(desc(entities.totalCommits))
+			: await base
+					.where(isNull(entities.totalIssues))
+					.orderBy(desc(entities.totalCommits));
+
+	console.log(
+		`${rows.length} entit${rows.length === 1 ? "y" : "ies"} to backfill` +
+			(arg1 === "--all" ? " (all)" : " (un-backfilled only)") +
+			`, top contributors first\n`,
+	);
+
+	let ok = 0;
+	let failed = 0;
+	for (const { id, login } of rows) {
+		try {
+			const summary = await backfill(id, login);
+			ok++;
+			console.log(`✓ ${login.padEnd(24)} ${summary}`);
+		} catch (e) {
+			failed++;
+			console.log(`✗ ${login.padEnd(24)} ${(e as Error).message}`);
+		}
+		await sleep(DELAY_MS);
+	}
+
+	console.log(`\nDone. ${ok} backfilled, ${failed} failed.`);
+} else {
+	console.log(
+		[
+			"Usage:",
+			"  bun run backfill <login>   backfill one account",
+			"  bun run backfill           backfill only un-backfilled rows (total_issues IS NULL)",
+			"  bun run backfill --all     backfill every user",
+		].join("\n"),
+	);
+	process.exit(1);
+}

--- a/scripts/backfill-contributions.ts
+++ b/scripts/backfill-contributions.ts
@@ -5,7 +5,7 @@
  * These columns didn't exist when older rows were cached, so their per-month values sit at 0 and
  * the entity-level totals (total_issues, …) are NULL until filled. This script does a full rebuild
  * per user via the SAME code path the app uses (fetchCommitHistory), then upserts the result —
- * so it also refreshes commits/private/profile as a side effect. Mirrors scripts/refresh.ts.
+ * so it also refreshes commits/private/profile as a side effect.
  *
  * Run with bun, which auto-loads the local (un-committed) `.env`, so no `--env-file` flag:
  *
@@ -13,8 +13,13 @@
  *   bun run backfill           # only un-backfilled rows (total_issues IS NULL), top contributors first
  *   bun run backfill --all     # every user, top contributors first
  *
- * Safe to re-run. Processes highest-commit accounts first so the most relevant profiles are done
- * early if the run is interrupted. Gentle pacing keeps us well under GitHub's GraphQL rate limit.
+ * Politeness: the GitHub token is SHARED with the live site, so this paces itself well under
+ * GitHub's 5,000 points/hour limit and never spends below a reserved floor (leaving headroom for
+ * real traffic). Tune the target spend with BACKFILL_RATE (requests/hour, default 2500).
+ *
+ * Safe to re-run and interrupt: each finished user gets total_issues set, so the default mode
+ * resumes on whatever is left. Highest-commit accounts are processed first, so the leaderboard and
+ * most-viewed profiles are correct within the first stretch of a long run.
  */
 import { desc, eq, isNull, sql } from "drizzle-orm";
 import { db } from "#/lib/db";
@@ -31,12 +36,54 @@ const database = db;
 
 const entityId = (login: string) => `user:${login.trim().toLowerCase()}`;
 
-// Delay between users. Each user costs ~1 + ceil(months/12) GraphQL requests (≈1 point each);
-// this pacing keeps a long run comfortably under the 5,000 points/hour primary limit and avoids
-// tripping secondary (burst) limits.
-const DELAY_MS = 300;
+// Requests/hour we aim to spend (≈ GraphQL points). Well under the 5,000/hr limit so the live
+// site keeps working. Override with BACKFILL_RATE=<n>.
+const TARGET_RATE = Number(process.env.BACKFILL_RATE ?? 2500);
+// Never let the remaining budget drop below this — pure headroom for live traffic. If we ever get
+// this low, we wait for GitHub's window to reset before continuing.
+const REMAINING_FLOOR = 500;
+// How often (in users) to poll the live rate-limit budget. The poll itself costs 0 points.
+const POLL_EVERY = 25;
 
-async function backfill(id: string, login: string): Promise<string> {
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface RateLimit {
+	remaining: number;
+	resetAt: string;
+}
+
+/** Query GitHub's current rate-limit budget. `rateLimit` queries themselves cost 0 points. */
+async function rateLimit(): Promise<RateLimit | null> {
+	try {
+		const res = await fetch("https://api.github.com/graphql", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				"User-Agent": "commit-history-backfill",
+			},
+			body: JSON.stringify({ query: "query { rateLimit { remaining resetAt } }" }),
+		});
+		const json = (await res.json()) as { data?: { rateLimit: RateLimit } };
+		return json.data?.rateLimit ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** If we're near the reserved floor, sleep until GitHub's window resets (plus a small buffer). */
+async function respectFloor(): Promise<void> {
+	const rl = await rateLimit();
+	if (!rl) return;
+	if (rl.remaining > REMAINING_FLOOR) return;
+	const waitMs = Math.max(0, new Date(rl.resetAt).getTime() - Date.now()) + 2000;
+	console.log(
+		`… budget low (${rl.remaining} left) — pausing ${Math.ceil(waitMs / 1000)}s until reset`,
+	);
+	await sleep(waitMs);
+}
+
+async function backfill(id: string, login: string): Promise<{ log: string; requests: number }> {
 	const history = await fetchCommitHistory(login, token);
 	const {
 		user,
@@ -104,10 +151,34 @@ async function backfill(id: string, login: string): Promise<string> {
 			});
 	}
 
-	return `${total.toLocaleString()} commits · ${totalIssues.toLocaleString()} issues · ${totalPullRequests.toLocaleString()} PRs · ${totalReviews.toLocaleString()} reviews`;
+	// 1 profile request + one batched request per 12 months.
+	const requests = 1 + Math.ceil(points.length / 12);
+	const log = `${total.toLocaleString()} commits · ${totalIssues.toLocaleString()} issues · ${totalPullRequests.toLocaleString()} PRs · ${totalReviews.toLocaleString()} reviews`;
+	return { log, requests };
 }
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/** Process one user with a single rate-limit-aware retry, then pace to the target spend. */
+async function processUser(id: string, login: string): Promise<boolean> {
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			const { log, requests } = await backfill(id, login);
+			console.log(`✓ ${login.padEnd(24)} ${log}`);
+			// Politeness pacing: spread this user's request cost across the target hourly rate.
+			await sleep((requests / TARGET_RATE) * 3_600_000);
+			return true;
+		} catch (e) {
+			const msg = (e as Error).message;
+			const rateLimited = /rate limit|secondary|403|429/i.test(msg);
+			if (rateLimited && attempt === 0) {
+				await respectFloor();
+				continue; // retry the same user once after the window resets
+			}
+			console.log(`✗ ${login.padEnd(24)} ${msg}`);
+			return false;
+		}
+	}
+	return false;
+}
 
 const [arg1] = process.argv.slice(2);
 
@@ -125,7 +196,7 @@ if (arg1 && !arg1.startsWith("--")) {
 		);
 		process.exit(1);
 	}
-	console.log(`${row.login} → ${await backfill(row.id, row.login)}`);
+	await processUser(row.id, row.login);
 } else if (!arg1 || arg1 === "--all") {
 	// Highest-commit accounts first, so the most relevant profiles land early.
 	const base = database
@@ -141,21 +212,16 @@ if (arg1 && !arg1.startsWith("--")) {
 	console.log(
 		`${rows.length} entit${rows.length === 1 ? "y" : "ies"} to backfill` +
 			(arg1 === "--all" ? " (all)" : " (un-backfilled only)") +
-			`, top contributors first\n`,
+			`, top contributors first, ~${TARGET_RATE} req/hr\n`,
 	);
 
 	let ok = 0;
 	let failed = 0;
-	for (const { id, login } of rows) {
-		try {
-			const summary = await backfill(id, login);
-			ok++;
-			console.log(`✓ ${login.padEnd(24)} ${summary}`);
-		} catch (e) {
-			failed++;
-			console.log(`✗ ${login.padEnd(24)} ${(e as Error).message}`);
-		}
-		await sleep(DELAY_MS);
+	for (let i = 0; i < rows.length; i++) {
+		if (i > 0 && i % POLL_EVERY === 0) await respectFloor();
+		const { id, login } = rows[i];
+		if (await processUser(id, login)) ok++;
+		else failed++;
 	}
 
 	console.log(`\nDone. ${ok} backfilled, ${failed} failed.`);
@@ -166,6 +232,8 @@ if (arg1 && !arg1.startsWith("--")) {
 			"  bun run backfill <login>   backfill one account",
 			"  bun run backfill           backfill only un-backfilled rows (total_issues IS NULL)",
 			"  bun run backfill --all     backfill every user",
+			"",
+			"  BACKFILL_RATE=<n>          target requests/hour (default 2500, ceiling 5000)",
 		].join("\n"),
 	);
 	process.exit(1);

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -11,6 +11,7 @@ import {
 	type MonthlyCount,
 	monthlyWindows,
 	type Profile,
+	sumContributionTypes,
 } from "#/lib/github";
 
 /**
@@ -56,8 +57,9 @@ function applyTail(
 	let cumulative = head.at(-1)?.cumulative ?? 0;
 	let restrictedCumulative = head.at(-1)?.restrictedCumulative ?? 0;
 	const tailPoints: CommitPoint[] = tailWindows.map((w, i) => {
-		const commits = tail[i]?.commits ?? 0;
-		const restricted = tail[i]?.restricted ?? 0;
+		const m = tail[i];
+		const commits = m?.commits ?? 0;
+		const restricted = m?.restricted ?? 0;
 		cumulative += commits;
 		restrictedCumulative += restricted;
 		return {
@@ -66,6 +68,10 @@ function applyTail(
 			cumulative,
 			restricted,
 			restrictedCumulative,
+			issues: m?.issues ?? 0,
+			pullRequests: m?.pullRequests ?? 0,
+			reviews: m?.reviews ?? 0,
+			repos: m?.repos ?? 0,
 		};
 	});
 	const points = [...head, ...tailPoints];
@@ -75,6 +81,7 @@ function applyTail(
 		points,
 		total: last?.cumulative ?? 0,
 		totalRestricted: last?.restrictedCumulative ?? 0,
+		...sumContributionTypes(points),
 	};
 }
 
@@ -118,10 +125,17 @@ async function getFromDb(
 		.select()
 		.from(monthlyCommits)
 		.where(eq(monthlyCommits.entityId, id));
-	const byMonth = new Map(
+	const byMonth = new Map<string, MonthlyCount>(
 		rows.map((r) => [
 			r.month,
-			{ commits: r.commits, restricted: r.restricted },
+			{
+				commits: r.commits,
+				restricted: r.restricted,
+				issues: r.issues,
+				pullRequests: r.pullRequests,
+				reviews: r.reviews,
+				repos: r.repos,
+			},
 		]),
 	);
 	const profile: Profile = {
@@ -139,9 +153,17 @@ async function getFromDb(
 		publicRepos: row.publicRepos ?? 0,
 	};
 	const windows = monthlyWindows(row.createdAt ?? now, now);
+	const emptyMonth: MonthlyCount = {
+		commits: 0,
+		restricted: 0,
+		issues: 0,
+		pullRequests: 0,
+		reviews: 0,
+		repos: 0,
+	};
 	const points = buildPoints(
 		windows,
-		windows.map((w) => byMonth.get(w.label) ?? { commits: 0, restricted: 0 }),
+		windows.map((w) => byMonth.get(w.label) ?? emptyMonth),
 	);
 	const last = points.at(-1);
 	const cached: CommitHistory = {
@@ -149,6 +171,7 @@ async function getFromDb(
 		points,
 		total: last?.cumulative ?? 0,
 		totalRestricted: last?.restrictedCumulative ?? 0,
+		...sumContributionTypes(points),
 	};
 
 	// Fresh enough → serve untouched.
@@ -191,7 +214,16 @@ async function persist(
 	now: Date,
 	fullRebuild: boolean,
 ) {
-	const { user, points, total, totalRestricted } = history;
+	const {
+		user,
+		points,
+		total,
+		totalRestricted,
+		totalIssues,
+		totalPullRequests,
+		totalReviews,
+		totalRepos,
+	} = history;
 	try {
 		await database
 			.insert(entities)
@@ -205,6 +237,10 @@ async function persist(
 				createdAt: new Date(user.createdAt),
 				totalCommits: total,
 				totalRestricted,
+				totalIssues,
+				totalPullRequests,
+				totalReviews,
+				totalRepos,
 				followers: user.followers,
 				following: user.following,
 				publicRepos: user.publicRepos,
@@ -232,7 +268,18 @@ async function persist(
 					websiteUrl: user.websiteUrl,
 					twitterUsername: user.twitterUsername,
 					lastFetched: now,
-					...(fullRebuild ? { builtAt: now } : {}),
+					// Only stamp builtAt + the per-type lifetime totals on a full rebuild. A trailing
+					// refresh only re-fetches the tail, so its totals would undercount the (possibly
+					// not-yet-backfilled) history — leaving them untouched keeps null = "not backfilled".
+					...(fullRebuild
+						? {
+								builtAt: now,
+								totalIssues,
+								totalPullRequests,
+								totalReviews,
+								totalRepos,
+							}
+						: {}),
 				},
 			});
 
@@ -245,6 +292,10 @@ async function persist(
 						month: p.date,
 						commits: p.commits,
 						restricted: p.restricted,
+						issues: p.issues,
+						pullRequests: p.pullRequests,
+						reviews: p.reviews,
+						repos: p.repos,
 					})),
 				)
 				.onConflictDoUpdate({
@@ -252,6 +303,10 @@ async function persist(
 					set: {
 						commits: sql`excluded.commits`,
 						restricted: sql`excluded.restricted`,
+						issues: sql`excluded.issues`,
+						pullRequests: sql`excluded.pull_requests`,
+						reviews: sql`excluded.reviews`,
+						repos: sql`excluded.repos`,
 					},
 				});
 		}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -22,6 +22,13 @@ export const entities = pgTable("entities", {
 	createdAt: timestamp("created_at", { withTimezone: true }), // defines the window start
 	totalCommits: integer("total_commits").notNull().default(0), // public commits
 	totalRestricted: integer("total_restricted").notNull().default(0), // private contributions
+	// Additional public contribution-type lifetime totals. Nullable so null = "not yet backfilled
+	// with the new types" (drives the backfill script's default mode), distinct from a real 0 —
+	// same rationale as the profile-metadata columns below.
+	totalIssues: integer("total_issues"), // public issues opened
+	totalPullRequests: integer("total_pull_requests"), // public PRs opened
+	totalReviews: integer("total_reviews"), // public PR reviews
+	totalRepos: integer("total_repos"), // public repositories created
 	// Profile metadata — mutable, refreshed on the trailing-refresh path (see cache.ts). All
 	// nullable so an unknown value (older row, fetch failure) stays distinguishable from a real 0.
 	followers: integer("followers"),
@@ -50,6 +57,12 @@ export const monthlyCommits = pgTable(
 		month: date("month").notNull(), // YYYY-MM-01
 		commits: integer("commits").notNull(), // public commits
 		restricted: integer("restricted").notNull().default(0), // private contributions
+		// Additional public contribution types for the month. Default 0 (a fresh migration leaves
+		// historical rows at 0 until the backfill script or a full rebuild fills real values).
+		issues: integer("issues").notNull().default(0), // public issues opened
+		pullRequests: integer("pull_requests").notNull().default(0), // public PRs opened
+		reviews: integer("reviews").notNull().default(0), // public PR reviews
+		repos: integer("repos").notNull().default(0), // public repositories created
 	},
 	(t) => [primaryKey({ columns: [t.entityId, t.month] })],
 );

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -9,6 +9,12 @@
  *
  * We deliberately use `totalCommitContributions` (commits-only, same definition as the green
  * contribution graph) rather than the contribution calendar, which mixes in issues/PRs/reviews.
+ *
+ * Alongside commits we also collect the other **public** contribution-type scalars the same
+ * collection exposes — issues opened, PRs opened, PR reviews, repositories created — at the same
+ * monthly resolution. These are stored but NOT plotted on the commit graph; they power per-type
+ * breakdowns and change indicators (follow-up issues). `restrictedContributionsCount` remains a
+ * separate, opaque all-types count that GitHub does not break down by type.
  */
 
 const GITHUB_GRAPHQL = "https://api.github.com/graphql";
@@ -54,12 +60,24 @@ export interface CommitPoint {
 	restricted: number;
 	/** Running total of private contributions. */
 	restrictedCumulative: number;
+	/** Public issues opened in that month. */
+	issues: number;
+	/** Public pull requests opened in that month. */
+	pullRequests: number;
+	/** Public pull-request reviews in that month. */
+	reviews: number;
+	/** Public repositories created in that month. */
+	repos: number;
 }
 
 /** Per-month counts as fetched from GitHub, before accumulation. */
 export interface MonthlyCount {
 	commits: number;
 	restricted: number;
+	issues: number;
+	pullRequests: number;
+	reviews: number;
+	repos: number;
 }
 
 export interface CommitHistory {
@@ -69,6 +87,32 @@ export interface CommitHistory {
 	total: number;
 	/** Lifetime private contributions (0 unless the user exposes them). */
 	totalRestricted: number;
+	/** Lifetime public issues opened. */
+	totalIssues: number;
+	/** Lifetime public pull requests opened. */
+	totalPullRequests: number;
+	/** Lifetime public pull-request reviews. */
+	totalReviews: number;
+	/** Lifetime public repositories created. */
+	totalRepos: number;
+}
+
+/** Sum the additional public contribution-type counts across a series of points. */
+export function sumContributionTypes(points: CommitPoint[]): {
+	totalIssues: number;
+	totalPullRequests: number;
+	totalReviews: number;
+	totalRepos: number;
+} {
+	return points.reduce(
+		(acc, p) => ({
+			totalIssues: acc.totalIssues + p.issues,
+			totalPullRequests: acc.totalPullRequests + p.pullRequests,
+			totalReviews: acc.totalReviews + p.reviews,
+			totalRepos: acc.totalRepos + p.repos,
+		}),
+		{ totalIssues: 0, totalPullRequests: 0, totalReviews: 0, totalRepos: 0 },
+	);
 }
 
 export class GitHubError extends Error {
@@ -238,7 +282,7 @@ export async function fetchMonthlyCommits(
 			const aliases = batch
 				.map(
 					(w, i) =>
-						`w${i}: contributionsCollection(from: "${w.from}", to: "${w.to}") { totalCommitContributions restrictedContributionsCount }`,
+						`w${i}: contributionsCollection(from: "${w.from}", to: "${w.to}") { totalCommitContributions restrictedContributionsCount totalIssueContributions totalPullRequestContributions totalPullRequestReviewContributions totalRepositoryContributions }`,
 				)
 				.join("\n");
 			return graphql<{
@@ -247,6 +291,10 @@ export async function fetchMonthlyCommits(
 					{
 						totalCommitContributions: number;
 						restrictedContributionsCount: number;
+						totalIssueContributions: number;
+						totalPullRequestContributions: number;
+						totalPullRequestReviewContributions: number;
+						totalRepositoryContributions: number;
 					}
 				>;
 			}>(token, `query { user(login: "${login}") { ${aliases} } }`);
@@ -254,10 +302,17 @@ export async function fetchMonthlyCommits(
 	);
 
 	return results.flatMap((res, b) =>
-		batches[b].map((_, i) => ({
-			commits: res.user[`w${i}`]?.totalCommitContributions ?? 0,
-			restricted: res.user[`w${i}`]?.restrictedContributionsCount ?? 0,
-		})),
+		batches[b].map((_, i) => {
+			const w = res.user[`w${i}`];
+			return {
+				commits: w?.totalCommitContributions ?? 0,
+				restricted: w?.restrictedContributionsCount ?? 0,
+				issues: w?.totalIssueContributions ?? 0,
+				pullRequests: w?.totalPullRequestContributions ?? 0,
+				reviews: w?.totalPullRequestReviewContributions ?? 0,
+				repos: w?.totalRepositoryContributions ?? 0,
+			};
+		}),
 	);
 }
 
@@ -269,8 +324,9 @@ export function buildPoints(
 	let cumulative = 0;
 	let restrictedCumulative = 0;
 	return windows.map((w, i) => {
-		const commits = monthly[i]?.commits ?? 0;
-		const restricted = monthly[i]?.restricted ?? 0;
+		const m = monthly[i];
+		const commits = m?.commits ?? 0;
+		const restricted = m?.restricted ?? 0;
 		cumulative += commits;
 		restrictedCumulative += restricted;
 		return {
@@ -279,6 +335,10 @@ export function buildPoints(
 			cumulative,
 			restricted,
 			restrictedCumulative,
+			issues: m?.issues ?? 0,
+			pullRequests: m?.pullRequests ?? 0,
+			reviews: m?.reviews ?? 0,
+			repos: m?.repos ?? 0,
 		};
 	});
 }
@@ -300,5 +360,6 @@ export async function fetchCommitHistory(
 		points,
 		total: last?.cumulative ?? 0,
 		totalRestricted: last?.restrictedCumulative ?? 0,
+		...sumContributionTypes(points),
 	};
 }

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -70,6 +70,10 @@ const GENERIC_POINTS: CommitPoint[] = (() => {
 			cumulative,
 			restricted: 0,
 			restrictedCumulative: 0,
+			issues: 0,
+			pullRequests: 0,
+			reviews: 0,
+			repos: 0,
 		});
 	}
 	return pts;


### PR DESCRIPTION
Closes #39.

Extends our monthly `contributionsCollection` fetch to also collect the other **public** contribution types — issues opened, PRs opened, PR reviews, and repositories created — alongside the commits we already track, at the same monthly resolution.

**Why:** today we only store commits (+ the opaque private count). Capturing the full public breakdown per month is the foundation for per-type views and CoinGecko-style change indicators (#40–#43), without changing what the graph shows.

**How:** per-month counts land on `monthly_commits`; per-type lifetime totals on `entities`. The entity totals are **nullable** so `null` means "not yet backfilled" (same pattern as `followers`) — that drives the backfill script's default mode. On the trailing-refresh path those totals are deliberately left untouched (only stamped on a full rebuild) so a partial refresh can't overwrite the null flag with an undercount. The commit graph and SVG are untouched — this is data collection only.

New/refreshed lookups populate the types automatically. A one-off `bun run backfill` fills existing rows, ordered by commit count so the most relevant profiles finish first. Migration `0004` adds the columns.
