### PR TITLE
Leaderboard Fragment-ref fix + minimal branded 404

### DIFF
--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,0 +1,21 @@
+import { Link } from "@tanstack/react-router";
+
+/**
+ * Router-wide 404, shown for any unmatched route (wired as `defaultNotFoundComponent` in
+ * router.tsx). Deliberately minimal for now — a plain, on-brand fallback to replace TanStack's
+ * generic `<p>Not Found</p>`. Refine into something fun later.
+ */
+export function NotFound() {
+	return (
+		<main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center px-6 py-24 text-center">
+			<p className="text-6xl font-bold tracking-tight">404</p>
+			<h1 className="mt-4 text-xl font-semibold">Page not found</h1>
+			<p className="mt-2 text-sm text-muted-foreground">
+				That page doesn’t exist. Try looking up a GitHub user instead.
+			</p>
+			<Link to="/" className="btn-primary mt-6">
+				Back to commit-history
+			</Link>
+		</main>
+	);
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRouter as createTanStackRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
+import { NotFound } from "#/components/NotFound";
 import { getContext } from "./integrations/tanstack-query/root-provider";
 import { routeTree } from "./routeTree.gen";
 
@@ -10,6 +11,8 @@ export function getRouter() {
 		routeTree,
 		context,
 		scrollRestoration: true,
+		// A plain, on-brand 404 for any unmatched route (replaces TanStack's generic fallback).
+		defaultNotFoundComponent: NotFound,
 		defaultPreload: "intent",
 		// Commit histories change ~monthly, so treat loaded data as fresh for the
 		// whole session: revisiting a user (or a comparison) is instant, no refetch.

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "motion/react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
 	getLeaderboard,
 	getRecentLookups,
@@ -152,9 +152,10 @@ function RecentSection({ recent }: { recent: RecentEntry[] }) {
  * but with no database — the creative is hardcoded for now. Uses the sponsor's own favicon and
  * page title, and links out with rel="sponsored nofollow".
  */
-function SponsorRow() {
+function SponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
 	return (
 		<motion.li
+			ref={ref}
 			layout
 			initial={{ opacity: 0 }}
 			animate={{ opacity: 1 }}
@@ -193,9 +194,10 @@ function SponsorRow() {
  * Pure markup — no database, no ads — pointing at the author's GitHub and Ko-fi.
  * Sprinkled through the leaderboard (after slots 50 and 100, and once at the end).
  */
-function SelfPromoRow() {
+function SelfPromoRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
 	return (
 		<motion.li
+			ref={ref}
 			layout
 			initial={{ opacity: 0 }}
 			animate={{ opacity: 1 }}
@@ -317,9 +319,13 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 			<p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
 			<ol className="mt-4">
 				<AnimatePresence initial={false} mode="popLayout">
-					{rows.map((u, i) => (
-						<Fragment key={u.login}>
+					{/* Flattened into one keyed list rather than Fragment-wrapped pairs: popLayout
+					    attaches a ref to each direct child to measure it, and a Fragment can't hold a
+					    ref (React warns). The interleaved ad/promo rows are keyed motion.li too. */}
+					{rows.flatMap((u, i) => {
+						const items = [
 							<motion.li
+								key={u.login}
 								layout
 								initial={{ opacity: 0 }}
 								animate={{ opacity: 1 }}
@@ -374,15 +380,20 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 										</span>
 									</span>
 								</Link>
-							</motion.li>
-							{/* Sponsor sits in the slot after rank 5 (only once there's more below). */}
-							{i === 4 && rows.length > 5 && <SponsorRow />}
-							{/* Self-promo after slots 10, 50 and 100 (only once there's more below). */}
-							{i === 9 && rows.length > 10 && <SelfPromoRow />}
-							{i === 49 && rows.length > 50 && <SelfPromoRow />}
-							{i === 99 && rows.length > 100 && <SelfPromoRow />}
-						</Fragment>
-					))}
+							</motion.li>,
+						];
+						// Sponsor sits in the slot after rank 5 (only once there's more below).
+						if (i === 4 && rows.length > 5)
+							items.push(<SponsorRow key="sponsor" />);
+						// Self-promo after slots 10, 50 and 100 (only once there's more below).
+						if (i === 9 && rows.length > 10)
+							items.push(<SelfPromoRow key="promo-10" />);
+						if (i === 49 && rows.length > 50)
+							items.push(<SelfPromoRow key="promo-50" />);
+						if (i === 99 && rows.length > 100)
+							items.push(<SelfPromoRow key="promo-100" />);
+						return items;
+					})}
 				</AnimatePresence>
 				{/* Self-promo once the whole leaderboard has finished loading. */}
 				{!hasNextPage && !isFetchingNextPage && rows.length > 0 && (


### PR DESCRIPTION
Two small pre-existing cleanups off main, independent of the contribution-types work in #46.

**1. React.Fragment `ref` warning (leaderboard).** `<AnimatePresence mode="popLayout">` attaches a ref to each direct child to measure it, but the rows were `Fragment`-wrapped (row + occasional interleaved ad/promo), and a Fragment can't hold a ref — React warned and those rows' exit animations couldn't be tracked. Flattened each row + its trailing ad/promo into one keyed list of `motion.li`; `SponsorRow`/`SelfPromoRow` forward a ref to their `motion.li` (React 19 ref-as-prop).

**2. Branded 404.** The router had no `defaultNotFoundComponent`, so unmatched routes fell back to TanStack's generic `<p>Not Found</p>` (and logged a warning). Added a minimal on-brand 404 page (404 + link home) as `defaultNotFoundComponent` — intentionally simple, to make fun later.

Not fixing here: the `data-swiftread-…` hydration mismatch — that's a browser extension mutating the DOM before hydration, not our markup.