### PR TITLE
Make history builds incremental and resumable; drop full rebuilds

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -8,7 +8,9 @@ import {
 	fetchCommitHistory,
 	fetchMonthlyCommits,
 	fetchProfile,
+	GitHubError,
 	type MonthlyCount,
+	type MonthWindow,
 	monthlyWindows,
 	type Profile,
 	sumContributionTypes,
@@ -17,19 +19,33 @@ import {
 /**
  * Incremental commit-history cache.
  *
- * Completed past months never change, so a returning user only needs the trailing month(s)
- * re-fetched — turning a ~`months/12`-request lifetime fetch into a single small request.
+ * Completed past months are treated as immutable: once a month is stored it is never
+ * re-fetched (except the frontier month, see below). There are no periodic full rebuilds —
+ * a profile is built exactly once, month by month, and afterwards only extended forward.
  *
- * Storage is Neon Postgres when DATABASE_URL is set (durable + shared across instances), else a
- * per-process in-memory Map (so local dev / the app still work with no database).
+ * Builds are **resumable**: months are fetched in chunks and each chunk is persisted the
+ * moment it lands, so a serverless timeout mid-build loses at most one chunk. The next
+ * request picks up from the last stored month instead of starting over — large accounts
+ * converge across a few requests instead of never finishing (and burning GitHub quota on
+ * every doomed attempt).
  *
- * Two TTLs:
- *  - TAIL_TTL: how long a cached result is served untouched (no GitHub call at all).
- *  - FULL_TTL: after this, rebuild from scratch — catches *backfilled* history (rebases,
- *    repos made public, identity changes) that can alter long-past months.
+ * `entities.builtAt` marks a *completed* initial build (null = still building). Entity
+ * totals are stamped only once every month row is stored, so a half-written build can never
+ * masquerade as a finished one (zeroed charts / corrupted leaderboard totals).
+ *
+ * Storage is Neon Postgres when DATABASE_URL is set (durable + shared across instances),
+ * else a per-process in-memory Map (so local dev / the app still work with no database).
  */
-const TAIL_TTL = 60_000; // 1 min
-const FULL_TTL = 7 * 24 * 60 * 60_000; // 7 days
+const TAIL_TTL = 60_000; // serve cached untouched for 1 min — no GitHub call at all
+
+// Months fetched + persisted per resumable step: 3 batches × 6 months (see BATCH/CONCURRENCY
+// in github.ts) = one full concurrency wave, ~5s of wall clock.
+const CHUNK_MONTHS = 18;
+
+// Wall-clock budget for starting new chunks within one request. Netlify sync functions are
+// killed at ~10s; a chunk takes ~5s, so past this point we stop starting chunks and let the
+// next request resume from the persisted frontier rather than get killed mid-flight.
+const BUILD_BUDGET_MS = 6_000;
 
 export async function getCommitHistory(
 	login: string,
@@ -45,19 +61,33 @@ export async function getCommitHistory(
 		: getFromMemory(login, token, now);
 }
 
-/** Recompute a series' tail from `tail`, splicing it onto the months before it. */
-function applyTail(
-	prevPoints: CommitPoint[],
-	profile: Profile,
-	tailWindows: { label: string }[],
-	tail: MonthlyCount[],
-): CommitHistory {
-	const tailKeys = new Set(tailWindows.map((w) => w.label));
-	const head = prevPoints.filter((p) => !tailKeys.has(p.date));
+/** Assemble a CommitHistory from a profile + cumulative points. */
+function toHistory(user: Profile, points: CommitPoint[]): CommitHistory {
+	const last = points.at(-1);
+	return {
+		user,
+		points,
+		total: last?.cumulative ?? 0,
+		totalRestricted: last?.restrictedCumulative ?? 0,
+		...sumContributionTypes(points),
+	};
+}
+
+/**
+ * Splice freshly fetched months onto a series, replacing any overlap (the frontier month is
+ * deliberately re-fetched on resume/refresh) and continuing the cumulative sums.
+ */
+function appendTail(
+	prev: CommitPoint[],
+	windows: { label: string }[],
+	counts: MonthlyCount[],
+): CommitPoint[] {
+	const keys = new Set(windows.map((w) => w.label));
+	const head = prev.filter((p) => !keys.has(p.date));
 	let cumulative = head.at(-1)?.cumulative ?? 0;
 	let restrictedCumulative = head.at(-1)?.restrictedCumulative ?? 0;
-	const tailPoints: CommitPoint[] = tailWindows.map((w, i) => {
-		const m = tail[i];
+	const tail: CommitPoint[] = windows.map((w, i) => {
+		const m = counts[i];
 		const commits = m?.commits ?? 0;
 		const restricted = m?.restricted ?? 0;
 		cumulative += commits;
@@ -74,15 +104,7 @@ function applyTail(
 			repos: m?.repos ?? 0,
 		};
 	});
-	const points = [...head, ...tailPoints];
-	const last = points.at(-1);
-	return {
-		user: profile,
-		points,
-		total: last?.cumulative ?? 0,
-		totalRestricted: last?.restrictedCumulative ?? 0,
-		...sumContributionTypes(points),
-	};
+	return [...head, ...tail];
 }
 
 // ── Neon-backed store ────────────────────────────────────────────────────────
@@ -91,54 +113,19 @@ function entityId(login: string) {
 	return `user:${login.trim().toLowerCase()}`;
 }
 
-async function getFromDb(
-	database: DB,
-	login: string,
-	token: string,
-	now: Date,
-): Promise<CommitHistory> {
-	const id = entityId(login);
-	const nowMs = now.getTime();
+type EntityRow = typeof entities.$inferSelect;
 
-	let row: typeof entities.$inferSelect | undefined;
-	try {
-		[row] = await database
-			.select()
-			.from(entities)
-			.where(eq(entities.id, id))
-			.limit(1);
-	} catch {
-		// DB read failed — degrade to a direct fetch so the page still renders.
-		return fetchCommitHistory(login, token);
-	}
+const EMPTY_MONTH: MonthlyCount = {
+	commits: 0,
+	restricted: 0,
+	issues: 0,
+	pullRequests: 0,
+	reviews: 0,
+	repos: 0,
+};
 
-	// Cold or stale → full rebuild.
-	if (!row || !row.builtAt || nowMs - row.builtAt.getTime() > FULL_TTL) {
-		const history = await fetchCommitHistory(login, token);
-		await persist(database, id, history, now, true);
-		await recordLookup(database, id, now);
-		return history;
-	}
-
-	// Reconstruct the cached series from stored months.
-	const rows = await database
-		.select()
-		.from(monthlyCommits)
-		.where(eq(monthlyCommits.entityId, id));
-	const byMonth = new Map<string, MonthlyCount>(
-		rows.map((r) => [
-			r.month,
-			{
-				commits: r.commits,
-				restricted: r.restricted,
-				issues: r.issues,
-				pullRequests: r.pullRequests,
-				reviews: r.reviews,
-				repos: r.repos,
-			},
-		]),
-	);
-	const profile: Profile = {
+function profileFromRow(row: EntityRow, now: Date): Profile {
+	return {
 		login: row.login,
 		name: row.name,
 		avatarUrl: row.avatarUrl ?? "",
@@ -152,71 +139,232 @@ async function getFromDb(
 		following: row.following ?? 0,
 		publicRepos: row.publicRepos ?? 0,
 	};
-	const windows = monthlyWindows(row.createdAt ?? now, now);
-	const emptyMonth: MonthlyCount = {
-		commits: 0,
-		restricted: 0,
-		issues: 0,
-		pullRequests: 0,
-		reviews: 0,
-		repos: 0,
-	};
-	const points = buildPoints(
-		windows,
-		windows.map((w) => byMonth.get(w.label) ?? emptyMonth),
-	);
-	const last = points.at(-1);
-	const cached: CommitHistory = {
-		user: profile,
-		points,
-		total: last?.cumulative ?? 0,
-		totalRestricted: last?.restrictedCumulative ?? 0,
-		...sumContributionTypes(points),
-	};
+}
 
-	// Fresh enough → serve untouched.
-	if (row.lastFetched && nowMs - row.lastFetched.getTime() < TAIL_TTL) {
-		await recordLookup(database, id, now);
-		return cached;
+async function getFromDb(
+	database: DB,
+	login: string,
+	token: string,
+	now: Date,
+): Promise<CommitHistory> {
+	const id = entityId(login);
+	const nowMs = now.getTime();
+
+	let row: EntityRow | undefined;
+	try {
+		[row] = await database
+			.select()
+			.from(entities)
+			.where(eq(entities.id, id))
+			.limit(1);
+	} catch {
+		// DB read failed — degrade to a direct fetch so the page still renders.
+		return fetchCommitHistory(login, token);
 	}
 
-	// Trailing refresh: re-fetch only the last cached month → now.
-	const lastLabel = cached.points.at(-1)?.date;
-	const tailStart = lastLabel
-		? new Date(`${lastLabel}T00:00:00Z`)
-		: (row.createdAt ?? now);
-	const tailWindows = monthlyWindows(tailStart, now);
-
-	let history: CommitHistory;
-	try {
-		const tailCommits = await fetchMonthlyCommits(login, token, tailWindows);
-		let profileNext = profile;
+	let profile: Profile;
+	if (row) {
+		profile = profileFromRow(row, now);
+	} else {
+		// First sighting: the profile fetch validates the login and yields createdAt, which
+		// defines the window range. Insert the row up front — it's the FK target for the month
+		// rows and the resume anchor if this build doesn't finish within the request.
+		profile = await fetchProfile(login, token);
 		try {
-			profileNext = await fetchProfile(login, token);
+			await upsertProfile(database, id, profile);
 		} catch {
-			/* keep cached profile */
+			// Can't store anything without the entity row (FK) — degrade to a direct fetch.
+			return fetchCommitHistory(login, token);
 		}
-		history = applyTail(cached.points, profileNext, tailWindows, tailCommits);
-		await persist(database, id, history, now, false);
-	} catch {
-		// Network hiccup on refresh: serve what we have.
-		history = cached;
+	}
+
+	// Stored months = the immutable head of the series.
+	let monthRows: { month: string; counts: MonthlyCount }[] = [];
+	if (row) {
+		const rows = await database
+			.select()
+			.from(monthlyCommits)
+			.where(eq(monthlyCommits.entityId, id));
+		monthRows = rows.map((r) => ({
+			month: r.month,
+			counts: {
+				commits: r.commits,
+				restricted: r.restricted,
+				issues: r.issues,
+				pullRequests: r.pullRequests,
+				reviews: r.reviews,
+				repos: r.repos,
+			},
+		}));
+	}
+	const byMonth = new Map(monthRows.map((r) => [r.month, r.counts]));
+	// Labels are YYYY-MM-DD, so string order = time order.
+	const lastStored = monthRows.reduce<string | null>(
+		(max, r) => (max === null || r.month > max ? r.month : max),
+		null,
+	);
+
+	const createdAt = row?.createdAt ?? new Date(profile.createdAt);
+	const windows = monthlyWindows(createdAt, now);
+	const headWindows = lastStored
+		? windows.filter((w) => w.label <= lastStored)
+		: [];
+	// Everything from the last stored month (inclusive) forward. Re-fetching the frontier
+	// month costs nothing extra and self-heals a legacy partial value in it.
+	const todo = lastStored
+		? windows.filter((w) => w.label >= lastStored)
+		: windows;
+	const head = buildPoints(
+		headWindows,
+		headWindows.map((w) => byMonth.get(w.label) ?? EMPTY_MONTH),
+	);
+
+	// A row only carries builtAt once its initial build completed; until then every request
+	// resumes the build regardless of TTLs.
+	const complete = row?.builtAt != null;
+
+	// Fully built + fresh → serve straight from the DB, no GitHub calls at all.
+	if (
+		complete &&
+		row?.lastFetched &&
+		nowMs - row.lastFetched.getTime() < TAIL_TTL
+	) {
+		await recordLookup(database, id, now);
+		return toHistory(profile, head);
+	}
+
+	// Refresh the mutable profile metadata (followers, bio, …) — one cheap request. Skipped
+	// on first sighting, where the profile was fetched moments ago.
+	if (row) {
+		try {
+			profile = await fetchProfile(login, token);
+		} catch {
+			/* keep the stored profile */
+		}
+	}
+
+	// Fetch the outstanding months in resumable chunks, persisting each as soon as it lands.
+	let points = head;
+	let frontierDone = true;
+	const startedAt = Date.now();
+	try {
+		for (let i = 0; i < todo.length; i += CHUNK_MONTHS) {
+			if (i > 0 && Date.now() - startedAt > BUILD_BUDGET_MS) {
+				frontierDone = false;
+				break;
+			}
+			const chunk = todo.slice(i, i + CHUNK_MONTHS);
+			const counts = await fetchMonthlyCommits(login, token, chunk);
+			await persistMonths(database, id, chunk, counts);
+			points = appendTail(points, chunk, counts);
+		}
+	} catch (err) {
+		// Mid-build failure on an unfinished profile: everything fetched so far is persisted,
+		// so surface the error and let the retry resume from the frontier.
+		if (!complete) throw err;
+		// Tail-refresh hiccup on an already-built profile: serve what we have.
+		await recordLookup(database, id, now);
+		return toHistory(profile, head);
+	}
+
+	const history = toHistory(profile, points);
+	if (frontierDone) {
+		// Every month is stored — only now stamp entity totals (+ builtAt on first completion).
+		await persistEntity(database, id, history, now, !complete);
+	} else if (!complete) {
+		// Ran out of request budget mid-build. Progress is persisted; the next request resumes.
+		// An honest retry beats silently serving a truncated chart with wrong totals.
+		throw new GitHubError(
+			`Still building ${profile.login}'s history (large account) — try again in a few seconds to continue.`,
+			503,
+		);
 	}
 	await recordLookup(database, id, now);
 	return history;
 }
 
-/** Upsert the entity + its months. `fullRebuild` also stamps builtAt (else it's left intact). */
-async function persist(
+/** Insert/refresh the profile columns only — never touches totals or builtAt. */
+async function upsertProfile(database: DB, id: string, user: Profile) {
+	const profileCols = {
+		name: user.name,
+		avatarUrl: user.avatarUrl,
+		followers: user.followers,
+		following: user.following,
+		publicRepos: user.publicRepos,
+		bio: user.bio,
+		company: user.company,
+		location: user.location,
+		websiteUrl: user.websiteUrl,
+		twitterUsername: user.twitterUsername,
+	};
+	await database
+		.insert(entities)
+		.values({
+			id,
+			kind: "user",
+			login: user.login,
+			htmlUrl: `https://github.com/${user.login}`,
+			createdAt: new Date(user.createdAt),
+			...profileCols,
+		})
+		.onConflictDoUpdate({ target: entities.id, set: profileCols });
+}
+
+/**
+ * Upsert one chunk of month rows. Throws on failure — the caller must not treat the chunk
+ * as stored (the resume frontier is derived from these rows).
+ */
+async function persistMonths(
+	database: DB,
+	id: string,
+	windows: MonthWindow[],
+	counts: MonthlyCount[],
+) {
+	if (windows.length === 0) return;
+	await database
+		.insert(monthlyCommits)
+		.values(
+			windows.map((w, i) => ({
+				entityId: id,
+				month: w.label,
+				commits: counts[i]?.commits ?? 0,
+				restricted: counts[i]?.restricted ?? 0,
+				issues: counts[i]?.issues ?? 0,
+				pullRequests: counts[i]?.pullRequests ?? 0,
+				reviews: counts[i]?.reviews ?? 0,
+				repos: counts[i]?.repos ?? 0,
+			})),
+		)
+		.onConflictDoUpdate({
+			target: [monthlyCommits.entityId, monthlyCommits.month],
+			set: {
+				commits: sql`excluded.commits`,
+				restricted: sql`excluded.restricted`,
+				issues: sql`excluded.issues`,
+				pullRequests: sql`excluded.pull_requests`,
+				reviews: sql`excluded.reviews`,
+				repos: sql`excluded.repos`,
+			},
+		});
+}
+
+/**
+ * Stamp the entity with the series' totals. Runs only after every month row is stored.
+ * `firstCompletion` additionally stamps builtAt + the per-type lifetime totals: on a fresh
+ * build every month was just fetched, so the sums are real. On a routine tail refresh the
+ * type totals are left untouched — legacy rows may predate the per-type backfill (their
+ * stored months default to 0), and summing those would undercount; null must keep meaning
+ * "not backfilled".
+ */
+async function persistEntity(
 	database: DB,
 	id: string,
 	history: CommitHistory,
 	now: Date,
-	fullRebuild: boolean,
+	firstCompletion: boolean,
 ) {
 	const {
 		user,
-		points,
 		total,
 		totalRestricted,
 		totalIssues,
@@ -268,10 +416,7 @@ async function persist(
 					websiteUrl: user.websiteUrl,
 					twitterUsername: user.twitterUsername,
 					lastFetched: now,
-					// Only stamp builtAt + the per-type lifetime totals on a full rebuild. A trailing
-					// refresh only re-fetches the tail, so its totals would undercount the (possibly
-					// not-yet-backfilled) history — leaving them untouched keeps null = "not backfilled".
-					...(fullRebuild
+					...(firstCompletion
 						? {
 								builtAt: now,
 								totalIssues,
@@ -282,36 +427,9 @@ async function persist(
 						: {}),
 				},
 			});
-
-		if (points.length > 0) {
-			await database
-				.insert(monthlyCommits)
-				.values(
-					points.map((p) => ({
-						entityId: id,
-						month: p.date,
-						commits: p.commits,
-						restricted: p.restricted,
-						issues: p.issues,
-						pullRequests: p.pullRequests,
-						reviews: p.reviews,
-						repos: p.repos,
-					})),
-				)
-				.onConflictDoUpdate({
-					target: [monthlyCommits.entityId, monthlyCommits.month],
-					set: {
-						commits: sql`excluded.commits`,
-						restricted: sql`excluded.restricted`,
-						issues: sql`excluded.issues`,
-						pullRequests: sql`excluded.pull_requests`,
-						reviews: sql`excluded.reviews`,
-						repos: sql`excluded.repos`,
-					},
-				});
-		}
 	} catch {
-		// Persisting is best-effort: a write failure shouldn't break the response.
+		// Best-effort: the month rows are already stored, and without builtAt/lastFetched the
+		// next request simply re-runs this (idempotent) stamp.
 	}
 }
 
@@ -328,7 +446,6 @@ async function recordLookup(database: DB, id: string, now: Date) {
 interface MemEntry {
 	history: CommitHistory;
 	fetchedAt: number;
-	builtAt: number;
 }
 const mem = new Map<string, MemEntry>();
 
@@ -341,9 +458,11 @@ async function getFromMemory(
 	const cached = mem.get(key);
 	const nowMs = now.getTime();
 
-	if (!cached || nowMs - cached.builtAt > FULL_TTL) {
+	// Built once, then only ever extended forward — same policy as the DB store. Local dev has
+	// no serverless timeout, so the initial build runs in one go.
+	if (!cached) {
 		const history = await fetchCommitHistory(login, token);
-		mem.set(key, { history, fetchedAt: nowMs, builtAt: nowMs });
+		mem.set(key, { history, fetchedAt: nowMs });
 		return history;
 	}
 	if (nowMs - cached.fetchedAt < TAIL_TTL) return cached.history;
@@ -355,20 +474,18 @@ async function getFromMemory(
 	const tailWindows = monthlyWindows(tailStart, now);
 
 	try {
-		const tailCommits = await fetchMonthlyCommits(login, token, tailWindows);
+		const tailCounts = await fetchMonthlyCommits(login, token, tailWindows);
 		let profile = cached.history.user;
 		try {
 			profile = await fetchProfile(login, token);
 		} catch {
 			/* keep */
 		}
-		const history = applyTail(
-			cached.history.points,
+		const history = toHistory(
 			profile,
-			tailWindows,
-			tailCommits,
+			appendTail(cached.history.points, tailWindows, tailCounts),
 		);
-		mem.set(key, { history, fetchedAt: nowMs, builtAt: cached.builtAt });
+		mem.set(key, { history, fetchedAt: nowMs });
 		return history;
 	} catch {
 		return cached.history;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -40,7 +40,7 @@ export const entities = pgTable("entities", {
 	websiteUrl: text("website_url"),
 	twitterUsername: text("twitter_username"),
 	lastFetched: timestamp("last_fetched", { withTimezone: true }), // staleness / trailing refresh; also "profile last updated"
-	builtAt: timestamp("built_at", { withTimezone: true }), // last full rebuild (catches backfills)
+	builtAt: timestamp("built_at", { withTimezone: true }), // initial build completed; null = months still being fetched incrementally
 	// Moderation: null = active. When set, the entity is hidden from the leaderboard and
 	// "recently looked up" (still directly viewable, with an under-review notice) until cleared.
 	suspendedAt: timestamp("suspended_at", { withTimezone: true }),


### PR DESCRIPTION
Rewrites the cache layer so a profile's history is built exactly once, month by month, and afterwards only extended forward — the periodic 7-day full rebuild is gone.

**Why:** past completed months don't change for our purposes, so re-fetching a whole lifetime every week wasted quota; worse, a large uncached account couldn't finish its initial build inside a serverless request at all — nothing was persisted, so every retry restarted from zero.

**How:** months are fetched in ~18-month chunks and each chunk is persisted the moment it lands; past a per-request time budget the build stops and the next request resumes from the last stored month. `builtAt` now means "initial build completed" (null = still building), and entity totals are stamped only after every month row is stored, so a half-written build can't overwrite leaderboard totals. Deliberate call: while a build is incomplete the request fails with a clear "still building, retry" message instead of serving a truncated chart with wrong totals.

Verified against the dev server end-to-end: a large 2007 account built across three requests (chunked persist → retry message → resume → complete) and then served instantly from cache; an existing already-built profile refreshed in <1s via the tail path.