### PR TITLE
Stabilize leaderboard pagination (tiebreaker + page dedupe)

### DIFF
--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import {
 	and,
+	asc,
 	desc,
 	eq,
 	gt,
@@ -158,6 +159,11 @@ async function queryLeaderboard(
 					sql`${entities.totalCommits} + coalesce(${entities.totalIssues}, 0) + coalesce(${entities.totalPullRequests}, 0) + coalesce(${entities.totalReviews}, 0) + coalesce(${entities.totalRepos}, 0) + ${entities.totalRestricted}`,
 				)
 			: sql`${rankCol} desc nulls last`;
+	// Deterministic tiebreaker. Without it, Postgres returns tied rows in arbitrary,
+	// query-to-query-different order — and since each scroll stop is a separate OFFSET query,
+	// a tie group straddling a page boundary gets shuffled between fetches: some users appear
+	// twice in the stitched list and others silently vanish from the board entirely.
+	const tiebreak = asc(entities.id);
 	const cols = {
 		login: entities.login,
 		name: entities.name,
@@ -187,7 +193,7 @@ async function queryLeaderboard(
 	const scoped = positive
 		? base.where(and(active, gt(positive, 0)))
 		: base.where(active);
-	return scoped.orderBy(order).limit(limit).offset(offset);
+	return scoped.orderBy(order, tiebreak).limit(limit).offset(offset);
 }
 
 async function queryRecent(limit: number): Promise<RecentEntry[]> {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -362,7 +362,15 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 		// back shows new entries immediately) and on window focus, but never while idle.
 	});
 
-	const rows = query.data?.pages.flat() ?? [];
+	// Pages are separate OFFSET queries against a live table: if ranks shift between fetches
+	// (a freshly built user slots in mid-scroll), a login can land in two pages. Keep the first
+	// occurrence — duplicates would collide as React keys and hide a neighbouring row.
+	const seenLogins = new Set<string>();
+	const rows = (query.data?.pages.flat() ?? []).filter((r) => {
+		if (seenLogins.has(r.login)) return false;
+		seenLogins.add(r.login);
+		return true;
+	});
 
 	// Infinite scroll: load the next page when the sentinel nears the viewport.
 	const sentinel = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
Fixes users randomly missing from (or duplicated on) the leaderboards.

**Why:** the board query ordered only by the ranked metric, and Postgres returns tied rows in arbitrary order that differs per query. Since each infinite-scroll stop is a separate OFFSET query, a tie group straddling a page boundary gets shuffled between fetches — some users show up twice in the stitched list and others silently vanish. Measured live on the repos board: 250 stitched rows contained only 248 unique users.

**How:** add `entities.id` as a deterministic tiebreaker to the leaderboard ordering, and dedupe rows by login when flattening pages on the client (ranks can still legitimately shift between fetches when a freshly built user slots in mid-scroll; duplicates also collided as React keys). Verified against production data: three consecutive stitched runs now return 250/250 unique rows in identical order.