### PR TITLE
Note that forks don't count in the repos metric subtitles

### DIFF
--- a/src/components/CommitChart.tsx
+++ b/src/components/CommitChart.tsx
@@ -79,7 +79,9 @@ export function chartCaption(mode: ChartMode): string {
 		case "reviews":
 			return "Cumulative public pull-request reviews";
 		case "repos":
-			return "Cumulative public repositories";
+			// "created" + the forks note: GitHub only counts repositories the user created —
+			// forks are excluded, so this figure is lower than the profile's repository count.
+			return "Cumulative public repositories created (forks don’t count)";
 		default:
 			return "Cumulative public commits";
 	}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -387,7 +387,7 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 		prs: "Public pull requests opened.",
 		issues: "Public issues opened.",
 		reviews: "Public pull-request reviews.",
-		repos: "Public repositories created.",
+		repos: "Public repositories created — forks don’t count.",
 		private: "Private contributions (only users who expose them).",
 		total:
 			"Every contribution type — commits, PRs, issues, reviews, repos, plus private.",


### PR DESCRIPTION
Adds a short forks disclaimer wherever the repos metric is described.

**Why:** the repos figure comes from GitHub's "repositories created" contribution count, which excludes forks — so it reads lower than the repository count on a user's profile page (449 vs 481 for the report that prompted this) and looks like missing data without an explanation.

**How:** appended the note to the leaderboard subtitle and to `chartCaption`, which both the single-user figure caption and the compare caption already share.