### PR TITLE
Auto-continue in-progress history builds with a live progress card

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -273,10 +273,12 @@ async function getFromDb(
 		await persistEntity(database, id, history, now, !complete);
 	} else if (!complete) {
 		// Ran out of request budget mid-build. Progress is persisted; the next request resumes.
-		// An honest retry beats silently serving a truncated chart with wrong totals.
+		// An honest retry beats silently serving a truncated chart with wrong totals. The progress
+		// payload lets the client show a live "X of Y months" bar while it polls to continue.
 		throw new GitHubError(
 			`Still building ${profile.login}'s history (large account) — try again in a few seconds to continue.`,
 			503,
+			{ monthsFetched: points.length, monthsTotal: windows.length },
 		);
 	}
 	await recordLookup(database, id, now);

--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -13,7 +13,11 @@ import {
 import { getCommitHistory as getCachedCommitHistory } from "#/lib/cache";
 import { db } from "#/lib/db";
 import { entities, lookups } from "#/lib/db/schema";
-import { type CommitHistory, GitHubError } from "#/lib/github";
+import {
+	type BuildProgress,
+	type CommitHistory,
+	GitHubError,
+} from "#/lib/github";
 
 /**
  * Server function: resolves a username's lifetime commit history.
@@ -85,6 +89,9 @@ export interface UserResult {
 	// Position on the public-commits leaderboard (1 = most public commits), among active entities.
 	// Null when there's no DB; suppressed in the UI for suspended profiles (hidden from the board).
 	publicRank: number | null;
+	// Non-null while the initial server-side build is still in progress — each poll of the loader
+	// advances it. Mutually exclusive with `error`: a building result is progress, not a failure.
+	building: BuildProgress | null;
 }
 
 export interface LeaderEntry {
@@ -336,12 +343,24 @@ export const getCommitHistories = createServerFn({ method: "GET" })
 				const isSuspended = suspended.has(login.toLowerCase());
 				if (outcome.status === "rejected") {
 					const e = outcome.reason;
+					// The 503 "still building" rejection carries progress — surface it as `building`
+					// (with error null) so the client polls to continue instead of showing a failure
+					// card. This mapping runs server-side, in-process, so instanceof sees the raw reason.
+					const building =
+						e instanceof GitHubError && e.status === 503 && e.progress
+							? e.progress
+							: null;
 					return {
 						login,
 						history: null,
-						error: e instanceof Error ? e.message : "Failed to load",
+						error: building
+							? null
+							: e instanceof Error
+								? e.message
+								: "Failed to load",
 						suspended: isSuspended,
 						publicRank: null,
+						building,
 					};
 				}
 				const history = outcome.value;
@@ -353,6 +372,7 @@ export const getCommitHistories = createServerFn({ method: "GET" })
 					error: null,
 					suspended: isSuspended,
 					publicRank,
+					building: null,
 				};
 			}),
 		);

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -160,10 +160,20 @@ export function sumContributionTypes(points: CommitPoint[]): {
 	);
 }
 
+/** How far along an incremental history build is (see cache.ts). */
+export interface BuildProgress {
+	/** Months already fetched & persisted (including the stored head). */
+	monthsFetched: number;
+	/** Total months in the account's lifetime window. */
+	monthsTotal: number;
+}
+
 export class GitHubError extends Error {
 	constructor(
 		message: string,
 		readonly status: number,
+		/** Set only on the 503 "still building" error, so callers can report progress. */
+		readonly progress?: BuildProgress,
 	) {
 		super(message);
 		this.name = "GitHubError";

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -5,7 +5,7 @@ import {
 	useRouter,
 } from "@tanstack/react-router";
 import { motion } from "motion/react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
 	type ChartMode,
 	CommitChart,
@@ -23,7 +23,7 @@ import {
 	parseLogins,
 	type UserResult,
 } from "#/lib/commit-history";
-import type { CommitPoint } from "#/lib/github";
+import type { BuildProgress, CommitPoint } from "#/lib/github";
 import { availableMetrics, METRIC_TOTAL } from "#/lib/metrics";
 
 // ── Chart metrics ─────────────────────────────────────────────────────────────
@@ -218,11 +218,193 @@ function useGoToLogins() {
 	};
 }
 
+// ── Build polling: keep an in-progress server-side build moving ───────────────
+
+const BUILD_POLL_MS = 3_000;
+const BUILD_POLL_TIMEOUT_MS = 5 * 60_000;
+// Consecutive polls with no monthsFetched growth before giving up. Each healthy poll fetches
+// a chunk or more, so this many stalls means something is genuinely stuck (quota, DB writes).
+const BUILD_MAX_STALLED_POLLS = 5;
+
+/**
+ * While any result is `building`, re-run this route's loader every few seconds — each run
+ * advances the build server-side (there are no background workers; requests ARE the worker).
+ * Polls chain off loaderData identity, so they never overlap: period ≈ loader time + delay.
+ * `router.invalidate` keeps the current view rendered (no pending flash) and keeps loaderData
+ * the single source of truth, which MetricBar reads directly.
+ */
+function useBuildPolling(results: UserResult[]) {
+	const router = useRouter();
+	const { user } = Route.useParams();
+	const [gaveUp, setGaveUp] = useState(false);
+	const startedAt = useRef<number | null>(null);
+	const lastFetched = useRef(-1);
+	const stalls = useRef(0);
+
+	const anyBuilding = results.some((r) => r.building);
+
+	// A different login set is a fresh polling session.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset exactly when the route param changes
+	useEffect(() => {
+		startedAt.current = null;
+		lastFetched.current = -1;
+		stalls.current = 0;
+		setGaveUp(false);
+	}, [user]);
+
+	useEffect(() => {
+		if (!anyBuilding || gaveUp) return;
+		startedAt.current ??= Date.now();
+		const fetched = results.reduce(
+			(sum, r) => sum + (r.building?.monthsFetched ?? 0),
+			0,
+		);
+		stalls.current = fetched > lastFetched.current ? 0 : stalls.current + 1;
+		lastFetched.current = fetched;
+		if (
+			Date.now() - startedAt.current > BUILD_POLL_TIMEOUT_MS ||
+			stalls.current >= BUILD_MAX_STALLED_POLLS
+		) {
+			setGaveUp(true);
+			return;
+		}
+		const t = setTimeout(() => {
+			router.invalidate({ filter: (m) => m.routeId === "/$user" });
+		}, BUILD_POLL_MS);
+		return () => clearTimeout(t);
+	}, [results, anyBuilding, gaveUp, router]);
+
+	const retry = () => {
+		startedAt.current = null;
+		lastFetched.current = -1;
+		stalls.current = 0;
+		setGaveUp(false);
+		router.invalidate({ filter: (m) => m.routeId === "/$user" });
+	};
+
+	return { gaveUp, retry };
+}
+
+function BuildProgressCard({
+	login,
+	progress,
+}: {
+	login: string;
+	progress: BuildProgress;
+}) {
+	const pct =
+		progress.monthsTotal > 0
+			? Math.min(
+					100,
+					Math.round((progress.monthsFetched / progress.monthsTotal) * 100),
+				)
+			: 0;
+	return (
+		<div className="rounded-xl border border-border p-4 text-left">
+			<p className="text-sm font-medium">Building {login}’s history…</p>
+			<div
+				className="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted"
+				role="progressbar"
+				aria-valuenow={pct}
+				aria-valuemin={0}
+				aria-valuemax={100}
+				aria-label={`Fetching ${login}'s history`}
+			>
+				<div
+					className="h-full rounded-full bg-primary transition-[width] duration-700 ease-out"
+					style={{ width: `${pct}%` }}
+				/>
+			</div>
+			<p
+				className="mt-2 text-xs text-muted-foreground tabular-nums"
+				aria-live="polite"
+			>
+				{progress.monthsFetched.toLocaleString()} of{" "}
+				{progress.monthsTotal.toLocaleString()} months fetched
+			</p>
+			<p className="mt-1 text-xs text-muted-foreground">
+				Large accounts take a moment on first lookup — hang tight.
+			</p>
+		</div>
+	);
+}
+
+/** Full-page building state — mirrors PendingUser's shell so nothing jumps when data lands. */
+function BuildingView({
+	building,
+	failed,
+}: {
+	building: UserResult[];
+	failed: UserResult[];
+}) {
+	const primary = building[0];
+	return (
+		<main className="mx-auto max-w-4xl px-6 py-12">
+			<Link
+				to="/"
+				className="text-sm text-muted-foreground hover:text-foreground"
+			>
+				← commit-history
+			</Link>
+			<header className="mt-6 flex items-center gap-4">
+				<div className="h-14 w-14 rounded-full border border-border bg-muted" />
+				<div>
+					<h1 className="text-2xl font-bold">&nbsp;</h1>
+					<span className="text-sm text-muted-foreground">
+						@{primary.login}
+					</span>
+				</div>
+			</header>
+			<div className="mt-8 grid gap-3 sm:max-w-md">
+				{building.map(
+					(r) =>
+						r.building && (
+							<BuildProgressCard
+								key={r.login}
+								login={r.login}
+								progress={r.building}
+							/>
+						),
+				)}
+			</div>
+			<div className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
+				<div className="pointer-events-none opacity-40 blur-[6px]">
+					<CommitChart points={GENERIC_POINTS} mode="public" />
+				</div>
+			</div>
+			{failed.length > 0 && (
+				<p className="mt-4 text-xs text-destructive">
+					Couldn’t load:{" "}
+					{failed.map((r) => `${r.login} (${r.error})`).join(", ")}
+				</p>
+			)}
+		</main>
+	);
+}
+
 function View() {
 	const results = Route.useLoaderData();
+	const { gaveUp, retry } = useBuildPolling(results);
 	const ok = results.filter((r) => r.history);
-	const failed = results.filter((r) => r.error);
+	const building = gaveUp ? [] : results.filter((r) => r.building);
+	// Once polling gives up, building entries degrade to failures with a retryable message.
+	const failed = results
+		.filter((r) => r.error || (gaveUp && r.building))
+		.map((r) =>
+			r.error
+				? r
+				: {
+						...r,
+						error:
+							"This build is taking longer than expected — hit Retry to continue it.",
+					},
+		);
 	const logins = results.map((r) => r.login);
+
+	// Nothing loaded yet but at least one build in flight → full-page building state.
+	if (ok.length === 0 && building.length > 0) {
+		return <BuildingView building={building} failed={failed} />;
+	}
 
 	if (ok.length === 0) {
 		return (
@@ -233,6 +415,11 @@ function View() {
 						<span className="font-medium">{r.login}</span>: {r.error}
 					</p>
 				))}
+				{gaveUp && (
+					<button type="button" onClick={retry} className="btn-primary mt-6">
+						Retry
+					</button>
+				)}
 				<div className="mt-6">
 					<Link
 						to="/"
@@ -258,10 +445,34 @@ function View() {
 			) : (
 				<ComparisonView results={ok} allLogins={logins} />
 			)}
+			{/* Compare view with someone still building → inline progress card(s). */}
+			{building.length > 0 && (
+				<div className="mt-6 grid gap-3 sm:max-w-md">
+					{building.map(
+						(r) =>
+							r.building && (
+								<BuildProgressCard
+									key={r.login}
+									login={r.login}
+									progress={r.building}
+								/>
+							),
+					)}
+				</div>
+			)}
 			{failed.length > 0 && (
 				<p className="mt-4 text-xs text-destructive">
 					Couldn’t load:{" "}
 					{failed.map((r) => `${r.login} (${r.error})`).join(", ")}
+					{gaveUp && (
+						<button
+							type="button"
+							onClick={retry}
+							className="ml-2 underline hover:text-foreground"
+						>
+							Retry
+						</button>
+					)}
 				</p>
 			)}
 		</main>

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -355,7 +355,7 @@ function BuildingView({
 					</span>
 				</div>
 			</header>
-			<div className="mt-8 grid gap-3 sm:max-w-md">
+			<div className="mx-auto mt-8 grid w-full gap-3 sm:max-w-md">
 				{building.map(
 					(r) =>
 						r.building && (
@@ -447,7 +447,7 @@ function View() {
 			)}
 			{/* Compare view with someone still building → inline progress card(s). */}
 			{building.length > 0 && (
-				<div className="mt-6 grid gap-3 sm:max-w-md">
+				<div className="mx-auto mt-6 grid w-full gap-3 sm:max-w-md">
 					{building.map(
 						(r) =>
 							r.building && (


### PR DESCRIPTION
Fixes the "Still building X's history — try again in a few seconds" dead-end (reported for `danicuki`): the page now continues the build by itself and shows live progress.

**Why:** since #57 large accounts build incrementally across requests, but nothing drove the retries — the client showed a static error card, so builds only advanced when a human hit refresh. There are no background workers; requests are the worker.

**How:** the server's 503 now carries `{monthsFetched, monthsTotal}`, surfaced as a non-error `building` field on `UserResult`; the `/$user` page polls its own loader every ~3s via scoped `router.invalidate()` — deliberately through the loader rather than a separate query cache, since `MetricBar` reads `loaderData` directly. UI shows a progress card ("198 of 207 months fetched") full-page or inline in compare view, and gives up into the old error card + Retry after 5 minutes / 5 no-progress polls.

Verified against the dev server: a fresh 2008 account rendered the card advancing 18→35→52/222 months across requests, then auto-completed into the real chart. Post-Coolify this carries over unchanged — the server can then also continue builds in the background and polls become cheap status reads.