### PR TITLE
Durable-cache embed responses on Netlify

### DIFF
--- a/src/routes/embed.$user.tsx
+++ b/src/routes/embed.$user.tsx
@@ -26,6 +26,11 @@ export const Route = createFileRoute("/embed/$user")({
 							"content-type": "image/svg+xml; charset=utf-8",
 							// Long-ish cache: our data is monthly and the cache layer keeps it fresh.
 							"cache-control": "public, max-age=3600, s-maxage=3600",
+							// `durable` = one shared cache entry across all Netlify edge nodes instead of
+							// one per node, so Camo traffic stops invoking the function. Netlify-only
+							// header; other CDNs/servers ignore it.
+							"netlify-cdn-cache-control":
+								"public, durable, s-maxage=3600, stale-while-revalidate=86400",
 						},
 					});
 				} catch (e) {
@@ -36,6 +41,10 @@ export const Route = createFileRoute("/embed/$user")({
 						headers: {
 							"content-type": "image/svg+xml; charset=utf-8",
 							"cache-control": "public, max-age=60",
+							// Short durable cache so a rate-limit storm doesn't hammer the function,
+							// while real data still replaces the message card quickly.
+							"netlify-cdn-cache-control":
+								"public, durable, s-maxage=60, stale-while-revalidate=300",
 						},
 					});
 				}


### PR DESCRIPTION
Closes #67. Adds a `Netlify-CDN-Cache-Control: public, durable, ...` header to the `/embed/*` responses.

**Why:** the embed's existing `s-maxage` only fills Netlify's per-edge-node caches, which miss constantly (per-PoP entries, full invalidation on every deploy, long-tail URL space) — so GitHub Camo's re-fetches keep invoking the billed function. This is the main credit-burn suspect (#31).

**How:** the `durable` directive opts into Netlify's global shared cache tier — one entry per URL network-wide, and hits skip the function entirely. `stale-while-revalidate` serves expired entries instantly while refreshing in the background. Deliberate call: the error card also gets a short durable TTL (60s) so a GitHub rate-limit storm can't hammer the function either. The header is Netlify-specific and ignored by the Coolify/Cloudflare deployment, so this is safe to merge independently of the migration (peetzweg/devops#1).

Also a measurement: if the credit burn drops hard after this deploys, the embed-invocation theory is confirmed with data. Longer-term tuning tracked in #68.
