### PR TITLE
feat: add a new public tab which shows cumulative the public contributions (commits + issues + prs)

### DIFF
--- a/src/components/CommitChart.tsx
+++ b/src/components/CommitChart.tsx
@@ -37,19 +37,22 @@ function monthLabel(date: string) {
 }
 
 export type ChartMode =
-	| "public"
+	| "commits"
 	| "private"
 	| "total"
 	| "prs"
 	| "issues"
 	| "reviews"
-	| "repos";
+	| "repos"
+	| "public";
 
 /** Hand-drawn graph heading for the metric on show — the one switch point for chart titles. */
 export function chartTitle(mode: ChartMode): string {
 	switch (mode) {
 		case "private":
 			return "Private Contributions";
+		case "public":
+			return "Public Contributions";
 		case "total":
 			return "Total Contributions";
 		case "prs":
@@ -70,6 +73,8 @@ export function chartCaption(mode: ChartMode): string {
 	switch (mode) {
 		case "private":
 			return "Cumulative private contributions";
+		case "public":
+			return "Cumulative public contributions";
 		case "total":
 			return "Cumulative total contributions";
 		case "prs":
@@ -90,14 +95,16 @@ export function chartCaption(mode: ChartMode): string {
 /**
  * The month's raw count for the selected metric. "total" is every contribution type summed:
  * public commits + issues + PRs + reviews + repos, plus the opaque private (restricted) count —
- * all disjoint buckets, so nothing is double-counted.
+ * all disjoint buckets, so nothing is double-counted. "public" is the same without private.
  */
 export function metricDelta(p: CommitPoint, mode: ChartMode): number {
 	switch (mode) {
-		case "public":
+		case "commits":
 			return p.commits;
 		case "private":
 			return p.restricted;
+		case "public":
+			return p.commits + p.issues + p.pullRequests + p.reviews + p.repos;
 		case "total":
 			return (
 				p.commits +
@@ -136,7 +143,7 @@ export function cumulativeSeries(
 
 export function CommitChart({
 	points,
-	mode = "public",
+	mode = "commits",
 	label,
 	title = chartTitle(mode),
 }: {

--- a/src/components/MetricBar.tsx
+++ b/src/components/MetricBar.tsx
@@ -5,11 +5,12 @@ import { ALL_METRICS, availableMetrics, METRIC_LABEL } from "#/lib/metrics";
 
 // The leaderboard offers every metric; the chart offers the subset a profile actually has data for.
 const LEADER_MODES: LeaderMode[] = [
-	"public",
+	"commits",
 	"prs",
 	"issues",
 	"reviews",
 	"repos",
+	"public",
 	"private",
 	"total",
 	"followers",
@@ -59,15 +60,15 @@ export function MetricBar() {
 		value: m,
 		label: METRIC_LABEL[m],
 	}));
-	const current = (metric ?? "public") as LeaderMode;
-	const value = options.some((o) => o.value === current) ? current : "public";
+	const current = (metric ?? "commits") as LeaderMode;
+	const value = options.some((o) => o.value === current) ? current : "commits";
 
 	const onChange = (m: LeaderMode) =>
 		navigate({
 			to: ".",
 			search: (prev) => ({
 				...prev,
-				metric: m === "public" ? undefined : m,
+				metric: m === "commits" ? undefined : m,
 			}),
 			replace: true,
 			resetScroll: false,

--- a/src/components/MultiCommitChart.tsx
+++ b/src/components/MultiCommitChart.tsx
@@ -82,7 +82,7 @@ function alignedStepLabel(i: number) {
 export function MultiCommitChart({
 	series,
 	mode,
-	chartMode = "public",
+	chartMode = "commits",
 	title = chartTitle(chartMode),
 }: {
 	series: ChartSeries[];

--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -118,11 +118,12 @@ export interface StartPageData {
 }
 
 export type LeaderMode =
-	| "public"
+	| "commits"
 	| "prs"
 	| "issues"
 	| "reviews"
 	| "repos"
+	| "public"
 	| "private"
 	| "total"
 	| "followers";
@@ -147,13 +148,14 @@ async function queryLeaderboard(
 	if (!db) return [];
 	// The column each mode ranks by. `total` is the one that isn't a single column (see below).
 	const rankCol = {
-		public: entities.totalCommits,
+		commits: entities.totalCommits,
 		prs: entities.totalPullRequests,
 		issues: entities.totalIssues,
 		reviews: entities.totalReviews,
 		repos: entities.totalRepos,
 		private: entities.totalRestricted,
 		followers: entities.followers,
+		public: entities.totalCommits, // unused — `public` orders by a sum, handled below
 		total: entities.totalCommits, // unused — `total` orders by a sum, handled below
 	}[mode];
 	// `total` = every contribution type summed. The per-type columns are nullable (null until a
@@ -165,7 +167,11 @@ async function queryLeaderboard(
 			? desc(
 					sql`${entities.totalCommits} + coalesce(${entities.totalIssues}, 0) + coalesce(${entities.totalPullRequests}, 0) + coalesce(${entities.totalReviews}, 0) + coalesce(${entities.totalRepos}, 0) + ${entities.totalRestricted}`,
 				)
-			: sql`${rankCol} desc nulls last`;
+			: mode === "public"
+				? desc(
+						sql`${entities.totalCommits} + coalesce(${entities.totalIssues}, 0) + coalesce(${entities.totalPullRequests}, 0) + coalesce(${entities.totalReviews}, 0) + coalesce(${entities.totalRepos}, 0)`,
+					)
+				: sql`${rankCol} desc nulls last`;
 	// Deterministic tiebreaker. Without it, Postgres returns tied rows in arbitrary,
 	// query-to-query-different order — and since each scroll stop is a separate OFFSET query,
 	// a tie group straddling a page boundary gets shuffled between fetches: some users appear
@@ -187,8 +193,8 @@ async function queryLeaderboard(
 	// Suspended entities (gamed/under-investigation) are hidden from every mode.
 	const active = isNull(entities.suspendedAt);
 	// The per-type, private and followers boards only list users with a positive count — no point
-	// ranking a wall of zeros, and it naturally excludes not-yet-backfilled (null) rows. `public`
-	// and `both` list everyone active.
+	// ranking a wall of zeros, and it naturally excludes not-yet-backfilled (null) rows. `commits`,
+	// `public` and `total` list everyone active.
 	const positive = {
 		prs: entities.totalPullRequests,
 		issues: entities.totalIssues,
@@ -256,12 +262,12 @@ export const getRepoStars = createServerFn({ method: "GET" }).handler(
 	},
 );
 
-/** First-paint data for the start page: recent lookups + leaderboard page 1 (Both). */
+/** First-paint data for the start page: recent lookups + leaderboard page 1 (Commits). */
 export const getStartPageData = createServerFn({ method: "GET" }).handler(
 	async (): Promise<StartPageData> => {
 		const [recent, leaderboard] = await Promise.all([
 			queryRecent(RECENT_LIMIT),
-			queryLeaderboard("public", 0, LEADERBOARD_PAGE_STOPS[0]),
+			queryLeaderboard("commits", 0, LEADERBOARD_PAGE_STOPS[0]),
 		]);
 		return { recent, leaderboard };
 	},

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -6,22 +6,29 @@ import type { CommitHistory } from "#/lib/github";
 // superset — it adds "followers"; the chart's `ChartMode` is everything else.
 
 export const METRIC_LABEL: Record<LeaderMode, string> = {
-	public: "Commits",
+	commits: "Commits",
 	prs: "PRs",
 	issues: "Issues",
 	reviews: "Reviews",
 	repos: "Repos",
+	public: "Public",
 	private: "Private",
 	total: "Total",
 	followers: "Followers",
 };
 
 export const METRIC_TOTAL: Record<ChartMode, (h: CommitHistory) => number> = {
-	public: (h) => h.total,
+	commits: (h) => h.total,
 	prs: (h) => h.totalPullRequests,
 	issues: (h) => h.totalIssues,
 	reviews: (h) => h.totalReviews,
 	repos: (h) => h.totalRepos,
+	public: (h) =>
+		h.total +
+		h.totalIssues +
+		h.totalPullRequests +
+		h.totalReviews +
+		h.totalRepos,
 	private: (h) => h.totalRestricted,
 	// Every contribution type summed (disjoint buckets — no double-counting).
 	total: (h) =>
@@ -35,14 +42,17 @@ export const METRIC_TOTAL: Record<ChartMode, (h: CommitHistory) => number> = {
 
 /**
  * Which metrics are worth offering for these histories: commits always; each public type and
- * private only when at least one developer has any; and "total" only when there's something beyond
- * commits to add up (else it would just duplicate the commits line).
+ * private only when at least one developer has any; "public" (sum of all public types) only when
+ * there's something beyond commits to add up; and "total" only when there's something beyond
+ * public contributions to add up (else it would just duplicate the public line).
  */
 export function availableMetrics(histories: CommitHistory[]): ChartMode[] {
 	const any = (m: ChartMode) => histories.some((h) => METRIC_TOTAL[m](h) > 0);
-	const list: ChartMode[] = ["public"];
+	const list: ChartMode[] = ["commits"];
 	for (const m of ["prs", "issues", "reviews", "repos"] as const)
 		if (any(m)) list.push(m);
+	if (["prs", "issues", "reviews", "repos"].some((m) => any(m as ChartMode)))
+		list.push("public");
 	if (any("private")) list.push("private");
 	if (
 		["prs", "issues", "reviews", "repos", "private"].some((m) =>
@@ -56,11 +66,12 @@ export function availableMetrics(histories: CommitHistory[]): ChartMode[] {
 // Full metric set shown by the floating bar while a not-yet-cached profile loads (we don't know the
 // real availability until the data arrives, so we show everything and it narrows on load).
 export const ALL_METRICS: ChartMode[] = [
-	"public",
+	"commits",
 	"prs",
 	"issues",
 	"reviews",
 	"repos",
+	"public",
 	"private",
 	"total",
 ];

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -28,13 +28,14 @@ import { availableMetrics, METRIC_TOTAL } from "#/lib/metrics";
 
 // ── Chart metrics ─────────────────────────────────────────────────────────────
 
-// Metrics that live in the URL as `?metric=…`. "public" (commits) is the default and is
+// Metrics that live in the URL as `?metric=…`. "commits" (public commits) is the default and is
 // deliberately omitted so the common case keeps a clean URL — only a non-default pick is stored.
 const METRIC_PARAMS: readonly ChartMode[] = [
 	"prs",
 	"issues",
 	"reviews",
 	"repos",
+	"public",
 	"private",
 	"total",
 ];
@@ -94,14 +95,14 @@ function useMetric(): [ChartMode, (m: ChartMode) => void] {
 	const navigate = Route.useNavigate();
 	const setMetric = (m: ChartMode) =>
 		navigate({
-			search: (prev) => ({ ...prev, metric: m === "public" ? undefined : m }),
+			search: (prev) => ({ ...prev, metric: m === "commits" ? undefined : m }),
 			replace: true,
 			// It's the same page with a different series — don't scroll to top like a fresh load,
 			// and keep the live thumb animation instead of a view-transition morph of the bar.
 			resetScroll: false,
 			viewTransition: false,
 		});
-	return [metric ?? "public", setMetric];
+	return [metric ?? "commits", setMetric];
 }
 
 // A generic rising curve, blurred behind the loading state — gives the page real shape while
@@ -172,7 +173,7 @@ function PendingUser() {
 
 			<div className="-mx-4 mt-3 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
 				<div className="pointer-events-none opacity-40 blur-[6px]">
-					<CommitChart points={GENERIC_POINTS} mode="public" />
+					<CommitChart points={GENERIC_POINTS} mode="commits" />
 				</div>
 			</div>
 		</main>
@@ -369,7 +370,7 @@ function BuildingView({
 			</div>
 			<div className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
 				<div className="pointer-events-none opacity-40 blur-[6px]">
-					<CommitChart points={GENERIC_POINTS} mode="public" />
+					<CommitChart points={GENERIC_POINTS} mode="commits" />
 				</div>
 			</div>
 			{failed.length > 0 && (
@@ -629,7 +630,7 @@ function SingleView({
 	const [requested] = useMetric();
 	const available = availableMetrics([history]);
 	// Fall back to commits if the requested metric isn't available for this user.
-	const effectiveMode = available.includes(requested) ? requested : "public";
+	const effectiveMode = available.includes(requested) ? requested : "commits";
 	const since = monthYear(user.createdAt);
 
 	return (
@@ -764,7 +765,7 @@ function ComparisonView({
 	const available = availableMetrics(histories);
 	const effectiveChartMode = available.includes(requested)
 		? requested
-		: "public";
+		: "commits";
 
 	const series: ChartSeries[] = results.map((r, i) => ({
 		login: r.login,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,13 +13,14 @@ import {
 } from "#/lib/commit-history";
 import { cn } from "#/lib/utils";
 
-// Leaderboard metrics that live in the URL as `?metric=…`. "public" (commits) is the default and
-// is omitted so the common case stays a clean, copy-pasteable URL.
+// Leaderboard metrics that live in the URL as `?metric=…`. "commits" (public commits) is the default
+// and is omitted so the common case stays a clean, copy-pasteable URL.
 const LB_METRIC_PARAMS: readonly LeaderMode[] = [
 	"prs",
 	"issues",
 	"reviews",
 	"repos",
+	"public",
 	"private",
 	"total",
 	"followers",
@@ -282,24 +283,32 @@ function SelfPromoRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
 // Singular label for the heading chip ("All-time Commit leaderboard") — reads better as a
 // noun-modifier than the plural tab-bar labels.
 const HEADING_LABEL: Record<LeaderMode, string> = {
-	public: "Commit",
+	commits: "Commit",
 	prs: "PR",
 	issues: "Issue",
 	reviews: "Review",
 	repos: "Repo",
+	public: "Public",
 	private: "Private",
 	total: "Total",
 	followers: "Follower",
 };
 
 const LB_VALUE: Record<LeaderMode, (u: LeaderEntry) => number> = {
-	public: (u) => u.totalCommits,
+	commits: (u) => u.totalCommits,
 	prs: (u) => u.totalPullRequests ?? 0,
 	issues: (u) => u.totalIssues ?? 0,
 	reviews: (u) => u.totalReviews ?? 0,
 	repos: (u) => u.totalRepos ?? 0,
+	// Every public contribution type summed (null type totals coalesced to 0 until backfilled).
+	public: (u) =>
+		u.totalCommits +
+		(u.totalIssues ?? 0) +
+		(u.totalPullRequests ?? 0) +
+		(u.totalReviews ?? 0) +
+		(u.totalRepos ?? 0),
 	private: (u) => u.totalRestricted,
-	// Every contribution type summed (null type totals coalesced to 0 until backfilled).
+	// Every contribution type summed — same as public + private.
 	total: (u) =>
 		u.totalCommits +
 		(u.totalIssues ?? 0) +
@@ -312,11 +321,12 @@ const LB_VALUE: Record<LeaderMode, (u: LeaderEntry) => number> = {
 
 /** Singular-ish unit shown under each row's number, per mode. */
 const LB_UNIT: Record<LeaderMode, string> = {
-	public: "commits",
+	commits: "commits",
 	prs: "pull requests",
 	issues: "issues",
 	reviews: "reviews",
 	repos: "repos",
+	public: "contributions",
 	private: "private",
 	total: "contributions",
 	followers: "followers",
@@ -326,12 +336,12 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 	// The leaderboard metric lives in `?metric=` (written by the shared MetricBar); we just read it
 	// here to rank the list. Commits is the default and stays param-free.
 	const { metric } = Route.useSearch();
-	const mode = metric ?? "public";
+	const mode = metric ?? "commits";
 	const value = LB_VALUE[mode];
 	// Carry the selected metric into the profile links so a click keeps the current view. Commits is
 	// the profile default (clean URL, no param), and followers has no chart, so both omit it.
 	const linkMetric =
-		mode === "public" || mode === "followers" ? undefined : mode;
+		mode === "commits" || mode === "followers" ? undefined : mode;
 
 	const query = useInfiniteQuery({
 		queryKey: ["leaderboard", mode],
@@ -352,7 +362,7 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 		},
 		// Seed page 1 of the default (Public) mode from the SSR loader — no flash.
 		initialData:
-			mode === "public"
+			mode === "commits"
 				? {
 						pages: [initialPage],
 						pageParams: [{ offset: 0, limit: LEADERBOARD_PAGE_STOPS[0] }],
@@ -391,11 +401,13 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
 	const subtitle = {
-		public: "Public commits.",
+		commits: "Public commits.",
 		prs: "Public pull requests opened.",
 		issues: "Public issues opened.",
 		reviews: "Public pull-request reviews.",
 		repos: "Public repositories created — forks don’t count.",
+		public:
+			"All public contributions — commits, PRs, issues, reviews, and repos.",
 		private: "Private contributions (only users who expose them).",
 		total:
 			"Every contribution type — commits, PRs, issues, reviews, repos, plus private.",


### PR DESCRIPTION
closes #71 