### PR TITLE
Make profile stats dynamic per selected metric

### DIFF
--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
 import {
+	type AnyColumn,
 	and,
 	asc,
 	desc,
@@ -10,6 +11,7 @@ import {
 	isNull,
 	sql,
 } from "drizzle-orm";
+import type { ChartMode } from "#/components/CommitChart";
 import { getCommitHistory as getCachedCommitHistory } from "#/lib/cache";
 import { db } from "#/lib/db";
 import { entities, lookups } from "#/lib/db/schema";
@@ -18,6 +20,7 @@ import {
 	type CommitHistory,
 	GitHubError,
 } from "#/lib/github";
+import { availableMetrics, METRIC_TOTAL } from "#/lib/metrics";
 
 /**
  * Server function: resolves a username's lifetime commit history.
@@ -86,9 +89,10 @@ export interface UserResult {
 	// True when the entity is suspended (under investigation) — the profile is still shown, but
 	// with an under-review notice. The internal reason is never sent to the client.
 	suspended: boolean;
-	// Position on the public-commits leaderboard (1 = most public commits), among active entities.
-	// Null when there's no DB; suppressed in the UI for suspended profiles (hidden from the board).
-	publicRank: number | null;
+	// Leaderboard position per metric (1 = top), among active entities, mirroring each metric's
+	// board ordering. Keyed by the metrics this profile has data for (always includes "public").
+	// Empty without a DB; suppressed in the UI for suspended profiles (hidden from every board).
+	ranks: Partial<Record<ChartMode, number | null>>;
 	// Non-null while the initial server-side build is still in progress — each poll of the loader
 	// advances it. Mutually exclusive with `error`: a building result is progress, not a failure.
 	building: BuildProgress | null;
@@ -294,24 +298,56 @@ async function suspendedSet(logins: string[]): Promise<Set<string>> {
 	return new Set(rows.map((r) => r.login.toLowerCase()));
 }
 
+// The column each single-column metric ranks by — mirrors the leaderboard ordering in
+// `queryLeaderboard`. "total" isn't a single column (it's a sum) and is handled inline below.
+const RANK_COL: Record<Exclude<ChartMode, "total">, AnyColumn> = {
+	public: entities.totalCommits,
+	prs: entities.totalPullRequests,
+	issues: entities.totalIssues,
+	reviews: entities.totalReviews,
+	repos: entities.totalRepos,
+	private: entities.totalRestricted,
+};
+
 /**
- * Public-leaderboard position for a user with `publicCommits` public commits: how many active
- * entities sit ahead of them, plus one. Same ordering as the "public" leaderboard (`total_commits`
- * DESC), so the number matches where you'd land on the start page. Ties share a rank — two users
- * with equal commits both count the same crowd ahead. Null without a DB.
+ * Leaderboard position for a user with `value` in `mode`: how many active entities sit ahead of
+ * them, plus one — same ordering as that metric's leaderboard, so the number matches where you'd
+ * land on the board. Ties share a rank. Nullable per-type columns COALESCE to 0 (a not-yet-
+ * backfilled row can't be "ahead"), and `total` compares the same summed expression the board does.
+ * Null without a DB.
  */
-async function publicRankFor(publicCommits: number): Promise<number | null> {
+async function metricRankFor(
+	mode: ChartMode,
+	value: number,
+): Promise<number | null> {
 	if (!db) return null;
+	const ahead =
+		mode === "total"
+			? sql`${entities.totalCommits} + coalesce(${entities.totalIssues}, 0) + coalesce(${entities.totalPullRequests}, 0) + coalesce(${entities.totalReviews}, 0) + coalesce(${entities.totalRepos}, 0) + ${entities.totalRestricted} > ${value}`
+			: gt(RANK_COL[mode], value);
 	const [row] = await db
 		.select({ ahead: sql<number>`count(*)` })
 		.from(entities)
-		.where(
-			and(
-				isNull(entities.suspendedAt),
-				gt(entities.totalCommits, publicCommits),
-			),
-		);
+		.where(and(isNull(entities.suspendedAt), ahead));
 	return Number(row?.ahead ?? 0) + 1;
+}
+
+/** Rank in every metric this profile has data for (always includes "public"), computed in one
+ *  fan-out so the client can switch metrics without a refetch. Ranking failures degrade to null. */
+async function ranksFor(
+	history: CommitHistory,
+): Promise<Partial<Record<ChartMode, number | null>>> {
+	const modes = availableMetrics([history]);
+	const entries = await Promise.all(
+		modes.map(
+			async (m) =>
+				[
+					m,
+					await metricRankFor(m, METRIC_TOTAL[m](history)).catch(() => null),
+				] as const,
+		),
+	);
+	return Object.fromEntries(entries);
 }
 
 /**
@@ -359,19 +395,19 @@ export const getCommitHistories = createServerFn({ method: "GET" })
 								? e.message
 								: "Failed to load",
 						suspended: isSuspended,
-						publicRank: null,
+						ranks: {},
 						building,
 					};
 				}
 				const history = outcome.value;
-				// Rank is supplementary — never let a ranking-query failure drop a loaded profile.
-				const publicRank = await publicRankFor(history.total).catch(() => null);
+				// Ranks are supplementary — never let a ranking-query failure drop a loaded profile.
+				const ranks = await ranksFor(history).catch(() => ({}));
 				return {
 					login,
 					history,
 					error: null,
 					suspended: isSuspended,
-					publicRank,
+					ranks,
 					building: null,
 				};
 			}),

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -11,6 +11,7 @@ import {
 	CommitChart,
 	chartCaption,
 	chartTitle,
+	metricDelta,
 } from "#/components/CommitChart";
 import {
 	type ChartSeries,
@@ -24,7 +25,7 @@ import {
 	type UserResult,
 } from "#/lib/commit-history";
 import type { BuildProgress, CommitPoint } from "#/lib/github";
-import { availableMetrics, METRIC_TOTAL } from "#/lib/metrics";
+import { availableMetrics, METRIC_LABEL, METRIC_TOTAL } from "#/lib/metrics";
 
 // ── Chart metrics ─────────────────────────────────────────────────────────────
 
@@ -132,12 +133,8 @@ const GENERIC_POINTS: CommitPoint[] = (() => {
 function PendingUser() {
 	const { user } = Route.useParams();
 	const login = user.split(",")[0];
-	const labels = [
-		"Public rank",
-		"Public commits",
-		"Followers",
-		"Busiest month",
-	];
+	// Mirror the default-metric (commits) stat layout so nothing jumps when data lands.
+	const labels = ["Commits rank", "Commits", "Busiest month"];
 	return (
 		<main className="mx-auto max-w-4xl px-6 py-12">
 			<Link
@@ -160,12 +157,11 @@ function PendingUser() {
 			<div className="mx-auto mt-8 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
 				{labels.map((label) => (
 					<div key={label}>
-						{/* reserve value + hint heights; they animate in once data arrives */}
+						{/* reserve the value height; it animates in once data arrives */}
 						<div className="h-7" />
 						<div className="text-xs uppercase tracking-wide text-muted-foreground">
 							{label}
 						</div>
-						<div className="h-4" />
 					</div>
 				))}
 			</div>
@@ -506,18 +502,13 @@ function SuspendedNotice() {
 
 // ── Single user: the detailed view ──────────────────────────────────────────
 
-function Stat({
-	label,
-	value,
-	hint,
-}: {
-	label: string;
-	value: string;
-	hint?: string;
-}) {
+function Stat({ label, value }: { label: string; value: string }) {
 	return (
 		<div>
 			<motion.div
+				// Re-key on the value so switching metric re-plays the drop-in — the numbers read as
+				// "refreshed for this metric", not stale.
+				key={value}
 				initial={{ opacity: 0, y: -4 }}
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.35 }}
@@ -528,34 +519,38 @@ function Stat({
 			<div className="text-xs uppercase tracking-wide text-muted-foreground">
 				{label}
 			</div>
-			{hint && (
-				<div className="text-xs tabular-nums text-muted-foreground">{hint}</div>
-			)}
 		</div>
 	);
 }
 
 /** Avatar + name + joined line + the headline stats. Shared by the single
- *  view and (stacked) by the comparison view, so profiles look identical. */
+ *  view and (stacked) by the comparison view, so profiles look identical. The
+ *  stats track `mode` — rank, count and busiest month all reflect the metric the
+ *  chart is currently showing, so they stay in sync as you toggle the metric bar. */
 function ProfilePanel({
 	result,
+	mode,
 	color,
 }: {
 	result: UserResult;
+	mode: ChartMode;
 	color?: string;
 }) {
 	// biome-ignore lint/style/noNonNullAssertion: ok results always have history
-	const { user, points, total, totalRestricted } = result.history!;
-	const hasPrivate = totalRestricted > 0;
+	const history = result.history!;
+	const { user, points } = history;
 	const since = monthYear(user.createdAt);
-	// Public-leaderboard rank — hidden for suspended profiles, which are off the board entirely.
-	const rank = result.suspended ? null : result.publicRank;
-	// Busiest month by total activity (public + private), so it's meaningful for private-heavy users.
+	const label = METRIC_LABEL[mode];
+	const total = METRIC_TOTAL[mode](history);
+	// Leaderboard rank in the selected metric — hidden for suspended profiles (off every board) and
+	// for metrics with no board position (e.g. the profile has none of this contribution type).
+	const rank = result.suspended ? null : (result.ranks[mode] ?? null);
+	// Busiest month in the selected metric.
 	const busiest = points.reduce(
-		(best, p) =>
-			p.commits + p.restricted > best.commits + best.restricted ? p : best,
+		(best, p) => (metricDelta(p, mode) > metricDelta(best, mode) ? p : best),
 		points[0],
 	);
+	const busiestCount = busiest ? metricDelta(busiest, mode) : 0;
 
 	return (
 		<div>
@@ -592,23 +587,15 @@ function ProfilePanel({
 
 			<div className="mx-auto mt-6 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
 				{rank !== null && (
-					<Stat label="Public rank" value={`#${rank.toLocaleString()}`} />
+					<Stat label={`${label} rank`} value={`#${rank.toLocaleString()}`} />
 				)}
-				<Stat label="Public commits" value={total.toLocaleString()} />
-				{hasPrivate && (
-					<Stat
-						label="Private contributions"
-						value={totalRestricted.toLocaleString()}
-					/>
-				)}
-				<Stat label="Followers" value={user.followers.toLocaleString()} />
+				<Stat label={label} value={total.toLocaleString()} />
 				<Stat
 					label="Busiest month"
-					value={busiest ? monthYear(busiest.date) : "—"}
-					hint={
-						busiest
-							? `${(busiest.commits + busiest.restricted).toLocaleString()} ${hasPrivate ? "contributions" : "commits"}`
-							: undefined
+					value={
+						busiest && busiestCount > 0
+							? `${monthYear(busiest.date)} (+${busiestCount.toLocaleString()})`
+							: "—"
 					}
 				/>
 			</div>
@@ -636,7 +623,7 @@ function SingleView({
 		<>
 			{result.suspended && <SuspendedNotice />}
 			<div className="mt-6">
-				<ProfilePanel result={result} />
+				<ProfilePanel result={result} mode={effectiveMode} />
 			</div>
 
 			<motion.div
@@ -865,6 +852,7 @@ function ComparisonView({
 						<div key={r.login} className="py-6 first:pt-0 last:pb-0">
 							<ProfilePanel
 								result={r}
+								mode={effectiveChartMode}
 								color={SERIES_COLORS[i % SERIES_COLORS.length]}
 							/>
 							{r.suspended && <SuspendedNotice />}


### PR DESCRIPTION
Makes the stat fields above the chart follow the selected metric instead of always showing public-commit numbers.

**Why:** With the metric toggle, the chart switched but the stats above it (public rank, public commits, followers, busiest month) stayed fixed on commits — so the headline numbers didn't match the line you were looking at.

**How:** `ProfilePanel` now takes the effective chart `mode` and renders three metric-driven stats — rank, count, and busiest month — using `METRIC_TOTAL`/`metricDelta`. Ranks are computed per available metric server-side in one fan-out (`ranksFor`, mirroring each metric's leaderboard ordering) and returned as a `ranks` map on `UserResult`, so switching metric needs no refetch. The busiest-month count moved inline (`Apr 2026 (+405)`) rather than onto a third row.

Verified in a browser across commits/PRs/reviews/total: rank, count and busiest month all update per metric and match the leaderboard/totals.
