### PR TITLE
Drop "All-time" from the Organization leaderboard heading

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -671,7 +671,6 @@ function OrgBoard({ rows }: { rows: OrgLeaderEntry[] }) {
 			{/* Same sticky-heading treatment as the developer board (see Leaderboard above). */}
 			<div className="sticky top-0 z-20 border-border border-b bg-background pt-3 pb-3">
 				<h2 className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-2xl font-bold tracking-tight">
-					All-time
 					<span className="font-hand font-normal text-3xl text-primary leading-none">
 						Organization
 					</span>


### PR DESCRIPTION
Renames the org board heading from "All-time Organization leaderboard" to just "Organization leaderboard".

**Why:** The org board is not all-time. It ranks orgs by summing commits from their *current* public members (`queryOrgMembers` joins `orgMembers` on live membership). If a top contributor leaves the org, their commits drop off the board — so the number is a live snapshot of current membership, not a lifetime tally. Calling it "All-time" is misleading.

**How:** Removed the `All-time` text node from the `OrgBoard` `<h2>`. The developer leaderboard is left untouched — it genuinely is all-time (a user's own lifetime commits).