### PR TITLE
Thin crowded x-axis year labels to round steps

### DIFF
--- a/src/components/CommitChart.tsx
+++ b/src/components/CommitChart.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChartAttribution } from "#/components/ChartAttribution";
 import { ChartLegend } from "#/components/ChartLegend";
+import { pickYearTicks } from "#/lib/chart-ticks";
 import type { CommitPoint } from "#/lib/github";
 import { useIsMobile } from "#/lib/useIsMobile";
 
@@ -174,9 +175,11 @@ export function CommitChart({
 	const area = `${line} L${x(n - 1).toFixed(1)},${baseline} L${x(0).toFixed(1)},${baseline} Z`;
 
 	const yTicks = Array.from({ length: 5 }, (_, i) => Math.round((max / 4) * i));
-	const xTicks = points
+	const yearTicks = points
 		.map((p, i) => ({ i, year: p.date.slice(0, 4) }))
 		.filter((t, idx, arr) => idx === 0 || t.year !== arr[idx - 1].year);
+	// Thin the year row so labels never crowd (bad on mobile, where the axis font is much larger).
+	const xTicks = pickYearTicks(yearTicks, innerW, FONT.axis);
 
 	// Show a dot per point, but thin out when there are many months so it stays sketchy, not noisy.
 	const dotEvery = Math.max(1, Math.ceil(n / 60));

--- a/src/components/MultiCommitChart.tsx
+++ b/src/components/MultiCommitChart.tsx
@@ -8,6 +8,7 @@ import {
 	cumulativeSeries,
 	metricDelta,
 } from "#/components/CommitChart";
+import { niceYearStep } from "#/lib/chart-ticks";
 import type { CommitPoint } from "#/lib/github";
 import { useIsMobile } from "#/lib/useIsMobile";
 
@@ -147,14 +148,17 @@ export function MultiCommitChart({
 	if (mode === "date") {
 		const y0 = Math.ceil(t0 / 12);
 		const y1 = Math.floor(t1 / 12);
-		const span = Math.max(1, y1 - y0);
-		const step = span > 12 ? 2 : 1;
-		for (let yr = y0; yr <= y1; yr += step) {
-			xTicks.push({ x: xDate(yr * 12), label: String(yr) });
+		// Thin to a "nice" step so labels never crowd, anchoring survivors to round years (…2015,
+		// 2020) — see niceYearStep. The mobile axis font is large, so wide ranges need this.
+		const step = niceYearStep(y1 - y0, innerW, FONT.axis);
+		for (let yr = y0; yr <= y1; yr++) {
+			if (yr % step === 0)
+				xTicks.push({ x: xDate(yr * 12), label: String(yr) });
 		}
 	} else {
 		const years = Math.floor((maxLen - 1) / 12);
-		const step = years > 12 ? 2 : 1;
+		// "Ny" labels are up to 3 chars ("start" is only at 0); size the step to that.
+		const step = niceYearStep(years, innerW, FONT.axis, 3);
 		for (let yr = 0; yr <= years; yr += step) {
 			xTicks.push({
 				x: xAligned(yr * 12),

--- a/src/lib/chart-svg.ts
+++ b/src/lib/chart-svg.ts
@@ -1,3 +1,4 @@
+import { pickYearTicks } from "#/lib/chart-ticks";
 import {
 	CROWN_ASPECT,
 	CROWN_FILL,
@@ -162,9 +163,11 @@ export function renderChartSvg(
 	const area = `${line} L${x(n - 1).toFixed(1)},${baseline} L${x(0).toFixed(1)},${baseline} Z`;
 
 	const yTicks = Array.from({ length: 5 }, (_, i) => Math.round((max / 4) * i));
-	const xTicks = points
+	const yearTicks = points
 		.map((p, i) => ({ i, year: p.date.slice(0, 4) }))
 		.filter((t, idx, arr) => idx === 0 || t.year !== arr[idx - 1].year);
+	// Axis labels use font-size 14 below; thin the year row to that so it never crowds.
+	const xTicks = pickYearTicks(yearTicks, innerW, 14);
 	const dotEvery = Math.max(1, Math.ceil(n / 60));
 
 	const gridY = yTicks

--- a/src/lib/chart-ticks.test.ts
+++ b/src/lib/chart-ticks.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { niceYearStep, pickYearTicks } from "#/lib/chart-ticks";
+
+const years = (from: number, to: number) =>
+	Array.from({ length: to - from + 1 }, (_, k) => ({
+		i: k,
+		year: String(from + k),
+	}));
+
+describe("niceYearStep", () => {
+	it("keeps every year when they all fit", () => {
+		// 800px / (14px axis) fits well over 5 labels.
+		expect(niceYearStep(4, 800, 14)).toBe(1);
+	});
+
+	it("climbs the nice ladder (1→2→5…) as the range outgrows the width", () => {
+		// Gavin's ~17-year span on the cramped mobile axis (26px, ~776px plot).
+		expect(niceYearStep(17, 776, 26)).toBe(2);
+		// A far longer range forces a bigger, still-round step.
+		expect(niceYearStep(60, 776, 26)).toBe(10);
+	});
+
+	it("never returns 0 or below 1", () => {
+		expect(niceYearStep(100, 100, 40)).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("pickYearTicks", () => {
+	it("returns short lists untouched", () => {
+		const t = years(2024, 2025);
+		expect(pickYearTicks(t, 776, 26)).toEqual(t);
+	});
+
+	it("thins a crowded mobile axis to round years only", () => {
+		const kept = pickYearTicks(years(2009, 2026), 776, 26).map((t) => t.year);
+		// step 2 → even years survive; the 2009 partial year drops.
+		expect(kept).toEqual([
+			"2010",
+			"2012",
+			"2014",
+			"2016",
+			"2018",
+			"2020",
+			"2022",
+			"2024",
+			"2026",
+		]);
+	});
+
+	it("leaves a roomy desktop axis showing every year when it fits", () => {
+		const kept = pickYearTicks(years(2021, 2026), 796, 16).map((t) => t.year);
+		expect(kept).toEqual(["2021", "2022", "2023", "2024", "2025", "2026"]);
+	});
+});

--- a/src/lib/chart-ticks.ts
+++ b/src/lib/chart-ticks.ts
@@ -1,0 +1,50 @@
+// Shared x-axis year-label thinning for the commit charts. On a phone (and sometimes even on the
+// web) a label-per-year row overflows: 17+ four-digit years can't fit across an 880-unit viewBox
+// once the mobile axis font jumps to 26. So we keep only as many labels as the width allows,
+// choosing a "nice" step (every 1 / 2 / 5 / 10 … years) and anchoring the survivors to round years
+// (…2015, 2020, 2025). Round multiples read as deliberate year markers, not an arbitrary offset.
+
+// Nice steps, in years. We climb this ladder until the kept labels fit.
+const STEPS = [1, 2, 5, 10, 25, 50, 100];
+
+// Rough advance width of a digit in the xkcd hand-drawn font, as a fraction of the font size, plus
+// a fixed gap so neighbouring labels never kiss. Deliberately generous — over-estimating width just
+// drops a label, which is far safer than letting two overlap.
+const GLYPH = 0.6;
+const GAP = 14;
+
+/**
+ * How many years to skip between kept labels so `spanYears + 1` labels fit within `innerW`.
+ * Returns a value from {@link STEPS} (1 = show every year). `labelChars` is the widest label's
+ * character count (4 for a calendar year like "2026").
+ */
+export function niceYearStep(
+	spanYears: number,
+	innerW: number,
+	fontSize: number,
+	labelChars = 4,
+): number {
+	const labelW = fontSize * labelChars * GLYPH + GAP;
+	const maxLabels = Math.max(2, Math.floor(innerW / labelW));
+	const count = spanYears + 1;
+	if (count <= maxLabels) return 1;
+	return STEPS.find((s) => Math.ceil(count / s) <= maxLabels) ?? 100;
+}
+
+/**
+ * Filter a one-entry-per-year tick list down to a non-crowding subset. Keeps years that are
+ * multiples of the {@link niceYearStep}, so the labels that remain are round (…2015, 2020). Lists of
+ * two or fewer are returned untouched.
+ */
+export function pickYearTicks<T extends { year: string }>(
+	ticks: T[],
+	innerW: number,
+	fontSize: number,
+): T[] {
+	if (ticks.length <= 2) return ticks;
+	const first = Number(ticks[0].year);
+	const last = Number(ticks[ticks.length - 1].year);
+	const step = niceYearStep(last - first, innerW, fontSize);
+	if (step === 1) return ticks;
+	return ticks.filter((t) => Number(t.year) % step === 0);
+}


### PR DESCRIPTION
Makes the chart's x-axis year labels dynamic so they stop overlapping — especially on mobile.

**Why:** The charts rendered one label per year, always. A 15+ year span in a fixed viewBox — with a bigger axis font on mobile — crushed the labels into an unreadable mush (see the reported screenshot).

**How:** New shared `lib/chart-ticks` helper keeps only as many labels as fit the plot width, picking a *nice* step (every 1/2/5/10… years) and anchoring the survivors to round years (…2015, 2020, 2025) so they read as deliberate markers. Wired into `CommitChart`, the embed SVG, and `MultiCommitChart` so all three behave identically. Deliberate call: labels anchor to round multiples rather than pinning the latest year, so on very long ranges + narrow screens the current year can fall off — traded for the cleaner look.

Pure helper is unit-tested (`chart-ticks.test.ts`).