### PR TITLE
Block scripted abuse of server-fn endpoints (same-origin check + per-IP rate limit)

### DIFF
--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { clientIpFrom, createRateLimiter } from "#/lib/rate-limit";
+
+/** Manually advanced clock so refill math is exact and tests never sleep. */
+const fakeClock = () => {
+	let ms = 0;
+	return {
+		now: () => ms,
+		advanceSeconds: (s: number) => {
+			ms += s * 1000;
+		},
+	};
+};
+
+describe("createRateLimiter", () => {
+	it("allows a full burst, then rejects", () => {
+		const clock = fakeClock();
+		const limiter = createRateLimiter({
+			capacity: 3,
+			refillPerSecond: 1,
+			now: clock.now,
+		});
+		expect(limiter.take("ip")).toEqual({ ok: true });
+		expect(limiter.take("ip")).toEqual({ ok: true });
+		expect(limiter.take("ip")).toEqual({ ok: true });
+		expect(limiter.take("ip").ok).toBe(false);
+	});
+
+	it("refills over time and tells the caller when to retry", () => {
+		const clock = fakeClock();
+		const limiter = createRateLimiter({
+			capacity: 2,
+			refillPerSecond: 0.5, // one token every 2s
+			now: clock.now,
+		});
+		limiter.take("ip");
+		limiter.take("ip");
+		const rejected = limiter.take("ip");
+		expect(rejected).toEqual({ ok: false, retryAfterSeconds: 2 });
+		clock.advanceSeconds(2);
+		expect(limiter.take("ip")).toEqual({ ok: true });
+	});
+
+	it("never refills past capacity", () => {
+		const clock = fakeClock();
+		const limiter = createRateLimiter({
+			capacity: 2,
+			refillPerSecond: 1,
+			now: clock.now,
+		});
+		clock.advanceSeconds(60); // long idle must not bank 60 tokens
+		limiter.take("ip");
+		limiter.take("ip");
+		expect(limiter.take("ip").ok).toBe(false);
+	});
+
+	it("tracks each key independently", () => {
+		const clock = fakeClock();
+		const limiter = createRateLimiter({
+			capacity: 1,
+			refillPerSecond: 1,
+			now: clock.now,
+		});
+		expect(limiter.take("a")).toEqual({ ok: true });
+		expect(limiter.take("a").ok).toBe(false);
+		expect(limiter.take("b")).toEqual({ ok: true });
+	});
+
+	it("prunes fully-refilled buckets instead of growing forever", () => {
+		const clock = fakeClock();
+		const limiter = createRateLimiter({
+			capacity: 1,
+			refillPerSecond: 1,
+			maxBuckets: 3,
+			now: clock.now,
+		});
+		limiter.take("a");
+		limiter.take("b");
+		limiter.take("c");
+		clock.advanceSeconds(10); // everyone refilled → all forgettable
+		limiter.take("d");
+		expect(limiter.size()).toBe(1);
+	});
+
+	it("keeps still-draining buckets when pruning", () => {
+		const clock = fakeClock();
+		const limiter = createRateLimiter({
+			capacity: 5,
+			refillPerSecond: 0.01, // refills far slower than the test advances
+			maxBuckets: 2,
+			now: clock.now,
+		});
+		limiter.take("hot"); // 4 tokens left, nowhere near refilled
+		limiter.take("cold");
+		clock.advanceSeconds(1);
+		limiter.take("new"); // triggers prune; "hot" and "cold" must survive
+		expect(limiter.size()).toBe(3);
+		expect(limiter.take("hot").ok).toBe(true);
+	});
+});
+
+describe("clientIpFrom", () => {
+	const headers = (xff?: string) =>
+		new Headers(xff === undefined ? {} : { "x-forwarded-for": xff });
+
+	it("takes the last hop — the one Traefik appended", () => {
+		expect(clientIpFrom(headers("203.0.113.7"))).toBe("203.0.113.7");
+		// Earlier entries are client-supplied and must not shift the bucket key.
+		expect(clientIpFrom(headers("1.1.1.1, 2.2.2.2, 203.0.113.7"))).toBe(
+			"203.0.113.7",
+		);
+	});
+
+	it("falls back to a shared bucket without a proxy (dev)", () => {
+		expect(clientIpFrom(headers())).toBe("local");
+		expect(clientIpFrom(headers("  "))).toBe("local");
+	});
+});

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -100,19 +100,27 @@ describe("createRateLimiter", () => {
 });
 
 describe("clientIpFrom", () => {
-	const headers = (xff?: string) =>
-		new Headers(xff === undefined ? {} : { "x-forwarded-for": xff });
+	it("prefers CF-Connecting-IP — behind the Cloudflare proxy the XFF tail is an edge IP", () => {
+		const proxied = new Headers({
+			"cf-connecting-ip": "203.0.113.7",
+			"x-forwarded-for": "203.0.113.7, 172.68.1.1",
+		});
+		expect(clientIpFrom(proxied)).toBe("203.0.113.7");
+	});
 
-	it("takes the last hop — the one Traefik appended", () => {
-		expect(clientIpFrom(headers("203.0.113.7"))).toBe("203.0.113.7");
+	it("falls back to the last XFF hop — the one Traefik appended", () => {
+		const direct = (xff: string) => new Headers({ "x-forwarded-for": xff });
+		expect(clientIpFrom(direct("203.0.113.7"))).toBe("203.0.113.7");
 		// Earlier entries are client-supplied and must not shift the bucket key.
-		expect(clientIpFrom(headers("1.1.1.1, 2.2.2.2, 203.0.113.7"))).toBe(
+		expect(clientIpFrom(direct("1.1.1.1, 2.2.2.2, 203.0.113.7"))).toBe(
 			"203.0.113.7",
 		);
 	});
 
 	it("falls back to a shared bucket without a proxy (dev)", () => {
-		expect(clientIpFrom(headers())).toBe("local");
-		expect(clientIpFrom(headers("  "))).toBe("local");
+		expect(clientIpFrom(new Headers())).toBe("local");
+		expect(clientIpFrom(new Headers({ "x-forwarded-for": "  " }))).toBe(
+			"local",
+		);
 	});
 });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -76,19 +76,26 @@ export function createRateLimiter(opts: RateLimiterOptions) {
 }
 
 /**
- * Client IP as seen by our Traefik (Coolify's proxy).
+ * Client IP for bucket keying. Prod traffic arrives Cloudflare → Traefik → app, so:
  *
- * Traefik APPENDS the connecting peer to any client-supplied X-Forwarded-For, so only
- * the LAST entry is trustworthy — earlier entries are attacker-controlled and using
- * them would let one machine spread across arbitrary buckets. When the Cloudflare
- * proxy (orange cloud) is enabled later, the last hop becomes Cloudflare's IP and this
- * must switch to reading the entry Cloudflare appended (or CF-Connecting-IP, which is
- * only trustworthy once CF is guaranteed to be in front).
+ * - CF-Connecting-IP is the real visitor on every proxied request. Without it the
+ *   last X-Forwarded-For hop would be a Cloudflare edge IP and ALL users would pile
+ *   into a handful of buckets — instant false 429s.
+ * - The fallback is the LAST X-Forwarded-For entry: Traefik APPENDS the connecting
+ *   peer to any client-supplied list, so earlier entries are attacker-controlled.
+ *   This covers unproxied paths (preview subdomains, direct origin hits).
  *
- * Dev serves without a proxy, so no header exists — every request shares one bucket,
+ * Caveat until the planned Cloudflare-IP origin lockdown (devops#2) lands: whoever
+ * hits the origin directly can spoof CF-Connecting-IP and hop between buckets. That
+ * weakens the ceiling for a determined attacker but never mis-buckets legit users,
+ * and is strictly better than today's no-limit.
+ *
+ * Dev serves without a proxy, so no headers exist — every request shares one bucket,
  * which is fine locally.
  */
 export function clientIpFrom(headers: Headers): string {
+	const cloudflare = headers.get("cf-connecting-ip")?.trim();
+	if (cloudflare) return cloudflare;
 	const forwarded = headers.get("x-forwarded-for");
 	if (!forwarded) return "local";
 	const hops = forwarded.split(",");

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-IP token-bucket rate limiter for the server-function RPC endpoints.
+ *
+ * Server functions are public GET endpoints: every call burns GITHUB_TOKEN quota and
+ * writes lookups into the shared prod DB, so a curl loop can drain the token and game
+ * the leaderboard. The app runs as a single long-lived Node process on Coolify, which
+ * is what makes a plain in-memory Map sufficient — no Redis, no cross-instance state.
+ *
+ * Kept free of TanStack imports so the bucket math is unit-testable with a fake clock.
+ */
+
+interface Bucket {
+	/** Fractional tokens remaining; refills continuously up to `capacity`. */
+	tokens: number;
+	/** Epoch ms of the last take() — refill is computed lazily from this. */
+	last: number;
+}
+
+export interface RateLimiterOptions {
+	/** Burst size: calls allowed instantly from a fresh IP. */
+	capacity: number;
+	/** Sustained rate — tokens regained per second. */
+	refillPerSecond: number;
+	/**
+	 * Prune trigger. The Map grows one entry per distinct client IP; past this size
+	 * every take() first drops buckets that have fully refilled (they are
+	 * indistinguishable from fresh ones, so forgetting them changes nothing).
+	 */
+	maxBuckets?: number;
+	/** Injectable clock for tests. */
+	now?: () => number;
+}
+
+export type TakeResult =
+	| { ok: true }
+	| { ok: false; retryAfterSeconds: number };
+
+export function createRateLimiter(opts: RateLimiterOptions) {
+	const { capacity, refillPerSecond, maxBuckets = 10_000 } = opts;
+	const clock = opts.now ?? Date.now;
+	const buckets = new Map<string, Bucket>();
+
+	function prune(now: number) {
+		for (const [key, b] of buckets) {
+			const refilled = b.tokens + ((now - b.last) / 1000) * refillPerSecond;
+			if (refilled >= capacity) buckets.delete(key);
+		}
+	}
+
+	function take(key: string): TakeResult {
+		const now = clock();
+		if (buckets.size >= maxBuckets) prune(now);
+		let bucket = buckets.get(key);
+		if (bucket === undefined) {
+			bucket = { tokens: capacity, last: now };
+			buckets.set(key, bucket);
+		} else {
+			const elapsedSeconds = (now - bucket.last) / 1000;
+			bucket.tokens = Math.min(
+				capacity,
+				bucket.tokens + elapsedSeconds * refillPerSecond,
+			);
+			bucket.last = now;
+		}
+		if (bucket.tokens >= 1) {
+			bucket.tokens -= 1;
+			return { ok: true };
+		}
+		return {
+			ok: false,
+			retryAfterSeconds: Math.ceil((1 - bucket.tokens) / refillPerSecond),
+		};
+	}
+
+	return { take, size: () => buckets.size };
+}
+
+/**
+ * Client IP as seen by our Traefik (Coolify's proxy).
+ *
+ * Traefik APPENDS the connecting peer to any client-supplied X-Forwarded-For, so only
+ * the LAST entry is trustworthy — earlier entries are attacker-controlled and using
+ * them would let one machine spread across arbitrary buckets. When the Cloudflare
+ * proxy (orange cloud) is enabled later, the last hop becomes Cloudflare's IP and this
+ * must switch to reading the entry Cloudflare appended (or CF-Connecting-IP, which is
+ * only trustworthy once CF is guaranteed to be in front).
+ *
+ * Dev serves without a proxy, so no header exists — every request shares one bucket,
+ * which is fine locally.
+ */
+export function clientIpFrom(headers: Headers): string {
+	const forwarded = headers.get("x-forwarded-for");
+	if (!forwarded) return "local";
+	const hops = forwarded.split(",");
+	return hops[hops.length - 1]?.trim() || "local";
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -189,10 +189,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,49 @@
+import {
+	createCsrfMiddleware,
+	createMiddleware,
+	createStart,
+} from "@tanstack/react-start";
+import { clientIpFrom, createRateLimiter } from "#/lib/rate-limit";
+
+/**
+ * Guards against scripted abuse of the server-function RPC endpoints (they burn
+ * GITHUB_TOKEN quota and write lookups into prod — see rate-limit.ts).
+ *
+ * IMPORTANT: the moment this file exists, TanStack Start hands the whole request
+ * middleware chain to us and stops injecting its default CSRF middleware — so the
+ * same-origin check below is not optional hardening, it re-applies protection the
+ * framework was providing implicitly before.
+ */
+
+/**
+ * Same-origin check: server functions are only ever called by our own frontend, so a
+ * request with no browser-origin evidence (Sec-Fetch-Site / Origin / Referer) or with
+ * a foreign origin gets a 403. Kills naive curl/scripting; both checks apply only to
+ * `serverFn` requests so SSR page loads (Googlebot included) stay untouched.
+ */
+const csrfMiddleware = createCsrfMiddleware({
+	filter: (ctx) => ctx.handlerType === "serverFn",
+});
+
+// ~5 RPC calls per client-side navigation → a human browsing hard stays inside the
+// burst; a lookup loop flattens to 20/min. First SSR page load doesn't count (server
+// functions run in-process there, handlerType "router").
+const limiter = createRateLimiter({ capacity: 40, refillPerSecond: 20 / 60 });
+
+const rateLimitMiddleware = createMiddleware({ type: "request" }).server(
+	({ request, next, handlerType }) => {
+		if (handlerType !== "serverFn") return next();
+		const result = limiter.take(clientIpFrom(request.headers));
+		if (!result.ok) {
+			return new Response("Too Many Requests", {
+				status: 429,
+				headers: { "Retry-After": String(result.retryAfterSeconds) },
+			});
+		}
+		return next();
+	},
+);
+
+export const startInstance = createStart(() => ({
+	requestMiddleware: [csrfMiddleware, rateLimitMiddleware],
+}));


### PR DESCRIPTION
Blocks automated calls to the server-function RPC endpoints — they are public GET endpoints today, so a curl loop can drain the `GITHUB_TOKEN` quota and write junk lookups into the prod DB (gamed leaderboard).

**Why:** Plausible only sees JS-executing browsers, so scripted traffic is invisible and unthrottled. This is the app-level backstop; Cloudflare WAF/bot rules can come later on top.

**How:** Adds `src/start.ts` with two request middlewares scoped to `handlerType === "serverFn"` (SSR page loads and prerender untouched): TanStack's own CSRF middleware (403 without same-origin evidence — note this had to become explicit, because adding a start entry replaces the framework's implicit default), and an in-memory per-IP token bucket in `src/lib/rate-limit.ts` (burst 40, sustained 20/min). Buckets are keyed by `CF-Connecting-IP` since prod is behind the Cloudflare proxy, falling back to the Traefik-appended last `X-Forwarded-For` hop for unproxied paths; spoofing on direct origin hits stays possible until the Cloudflare-IP origin lockdown (devops#2). Judgment call: in-memory over Redis since Coolify runs a single long-lived process.

Verified against the built server: bare/cross-origin curl → 403, protocol-aware curl without origin headers → 403, real RPC call → 200, 45-request hammer → 429 with `Retry-After`, homepage still 200 from the throttled IP, and two clients behind the same Cloudflare edge IP get independent buckets. Limiter has unit tests.