### PR TITLE
Stop counting embed renders as lookups

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -50,14 +50,18 @@ const BUILD_BUDGET_MS = 6_000;
 export async function getCommitHistory(
 	login: string,
 	token: string,
-	now = new Date(),
+	opts: { now?: Date; record?: boolean } = {},
 ): Promise<CommitHistory> {
+	// `record: false` serves the data without writing a lookups row. Embed renders use it:
+	// they're third-party image fetches (GitHub camo, CDN cache misses), not someone searching,
+	// and counting them pollutes "recently looked up" and the all-time leaderboard.
+	const { now = new Date(), record = true } = opts;
 	if (!token) {
 		// Defer to the uncached path so it throws the canonical "missing token" error.
 		return fetchCommitHistory(login, token);
 	}
 	return db
-		? getFromDb(db, login, token, now)
+		? getFromDb(db, login, token, now, record)
 		: getFromMemory(login, token, now);
 }
 
@@ -146,6 +150,7 @@ async function getFromDb(
 	login: string,
 	token: string,
 	now: Date,
+	record: boolean,
 ): Promise<CommitHistory> {
 	const id = entityId(login);
 	const nowMs = now.getTime();
@@ -229,7 +234,7 @@ async function getFromDb(
 		row?.lastFetched &&
 		nowMs - row.lastFetched.getTime() < TAIL_TTL
 	) {
-		await recordLookup(database, id, now);
+		if (record) await recordLookup(database, id, now);
 		return toHistory(profile, head);
 	}
 
@@ -263,7 +268,7 @@ async function getFromDb(
 		// so surface the error and let the retry resume from the frontier.
 		if (!complete) throw err;
 		// Tail-refresh hiccup on an already-built profile: serve what we have.
-		await recordLookup(database, id, now);
+		if (record) await recordLookup(database, id, now);
 		return toHistory(profile, head);
 	}
 
@@ -281,7 +286,7 @@ async function getFromDb(
 			{ monthsFetched: points.length, monthsTotal: windows.length },
 		);
 	}
-	await recordLookup(database, id, now);
+	if (record) await recordLookup(database, id, now);
 	return history;
 }
 

--- a/src/routes/embed.$user.tsx
+++ b/src/routes/embed.$user.tsx
@@ -20,7 +20,11 @@ export const Route = createFileRoute("/embed/$user")({
 				const token = process.env.GITHUB_TOKEN ?? "";
 
 				try {
-					const history = await getCommitHistory(params.user, token);
+					// Embed fetches are README badges / CDN cache misses, not searches — serve
+					// (and build/refresh) the data but never count them as lookups.
+					const history = await getCommitHistory(params.user, token, {
+						record: false,
+					});
 					return new Response(renderChartSvg(history, theme), {
 						headers: {
 							"content-type": "image/svg+xml; charset=utf-8",


### PR DESCRIPTION
Embed fetches (`/embed/<user>`) are README badges served to GitHub camo and CDN cache misses — not searches. Recording them pollutes "recently looked up" and the all-time leaderboard, and they were the phantom traffic that never shows in Plausible (no JS runs in an `<img>`).

**Why:** prod data (last 48h) shows it clearly: `user:screenkite-team` accumulated **16,089 lookup rows at a metronomic ~10s cadence**, and vuln-scanner paths (`wp-admin`, `actuator`, `config`…) resolve into counted lookups too. Roughly half the recorded volume isn't humans.

**How:** `getCommitHistory` in `src/lib/cache.ts` takes `{ now, record }` options (no caller used the old `now` positional); the embed handler passes `record: false` — data is still served, built, and refreshed, only the `lookups` insert is skipped. All three record sites in `getFromDb` honor the flag.

Verified end-to-end against a throwaway local Postgres: embed fetch → 200 SVG, entity built, **0 lookup rows** (cold and cached paths); SSR profile page → exactly 1 row.