### PR TITLE
Serve host-aware robots.txt: deny crawlers on PR preview hosts

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: *
-Allow: /
-
-Sitemap: https://commit-history.com/sitemap.xml

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as UserRouteImport } from './routes/$user'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OrganizationsSlugRouteImport } from './routes/organizations.$slug'
@@ -18,6 +19,11 @@ import { Route as EmbedUserRouteImport } from './routes/embed.$user'
 import { Route as CompanySlugRouteImport } from './routes/company.$slug'
 import { Route as OgKindLoginRouteImport } from './routes/og.$kind.$login'
 
+const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
+  id: '/robots.txt',
+  path: '/robots.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const UserRoute = UserRouteImport.update({
   id: '/$user',
   path: '/$user',
@@ -62,6 +68,7 @@ const OgKindLoginRoute = OgKindLoginRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
+  '/robots.txt': typeof RobotsDottxtRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
@@ -72,6 +79,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
+  '/robots.txt': typeof RobotsDottxtRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
@@ -83,6 +91,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
+  '/robots.txt': typeof RobotsDottxtRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
@@ -95,6 +104,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/$user'
+    | '/robots.txt'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
@@ -105,6 +115,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/$user'
+    | '/robots.txt'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
@@ -115,6 +126,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/$user'
+    | '/robots.txt'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
@@ -126,6 +138,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   UserRoute: typeof UserRoute
+  RobotsDottxtRoute: typeof RobotsDottxtRoute
   CompanySlugRoute: typeof CompanySlugRoute
   EmbedUserRoute: typeof EmbedUserRoute
   MetricsSlugRoute: typeof MetricsSlugRoute
@@ -136,6 +149,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/robots.txt': {
+      id: '/robots.txt'
+      path: '/robots.txt'
+      fullPath: '/robots.txt'
+      preLoaderRoute: typeof RobotsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/$user': {
       id: '/$user'
       path: '/$user'
@@ -198,6 +218,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   UserRoute: UserRoute,
+  RobotsDottxtRoute: RobotsDottxtRoute,
   CompanySlugRoute: CompanySlugRoute,
   EmbedUserRoute: EmbedUserRoute,
   MetricsSlugRoute: MetricsSlugRoute,

--- a/src/routes/robots[.]txt.tsx
+++ b/src/routes/robots[.]txt.tsx
@@ -1,0 +1,45 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+/**
+ * Host-aware robots.txt (replaces the old static public/robots.txt).
+ *
+ * The app answers on hostnames besides the production domain — Coolify PR previews
+ * (`<pr>.next.commit-history.com`) and the bare origin IP. Crawlers found the previews and
+ * farm them (each SSR page view burns GitHub quota and writes into the shared prod DB), so
+ * every non-production host gets a full Disallow. Production keeps the exact policy the
+ * static file had: everything allowed, sitemap advertised. A static segment outranks the
+ * `$user` catch-all, so no GitHub login is shadowed except the literal "robots.txt".
+ */
+const PROD_HOSTS = new Set(["commit-history.com", "www.commit-history.com"]);
+
+const ALLOW_ALL = `# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+
+Sitemap: https://commit-history.com/sitemap.xml
+`;
+
+const DENY_ALL = `# Non-production host (PR preview) — not for crawlers.
+User-agent: *
+Disallow: /
+`;
+
+export const Route = createFileRoute("/robots.txt")({
+	server: {
+		handlers: {
+			GET: ({ request }) => {
+				// Host header, not URL: behind the proxies the URL host can be internal.
+				const host = (request.headers.get("host") ?? "")
+					.split(":")[0]
+					?.toLowerCase();
+				const isProd = host !== undefined && PROD_HOSTS.has(host);
+				return new Response(isProd ? ALLOW_ALL : DENY_ALL, {
+					headers: {
+						"content-type": "text/plain; charset=utf-8",
+						"cache-control": "public, max-age=3600",
+					},
+				});
+			},
+		},
+	},
+});


### PR DESCRIPTION
Traefik access logs showed ClaudeBot crawling `120.next.commit-history.com/<user>` — bots found the Coolify preview subdomains and farm them, and every preview SSR page view burns GitHub quota and writes into the shared prod DB.

**Why:** previews sit outside the Cloudflare zone protections and the RPC rate limiter, so crawler traffic there is unthrottled and invisible.

**How:** the static `public/robots.txt` becomes a server route (`src/routes/robots[.]txt.tsx`) keyed on the Host header: production hosts (`commit-history.com`, `www`) get the **byte-identical** allow-all + sitemap policy as before — SEO/indexing unchanged — while any other host (previews, bare origin IP) gets `Disallow: /`. A static segment outranks the `$user` catch-all, so only the literal login "robots.txt" is shadowed, same as with the static file.

Verified against the built server with forged Host headers: prod + www → allow-all with sitemap, preview host + bare IP → deny-all, static assets unaffected, sitemap still emitted.