### PR TITLE
Advertise the empty org-board sponsor slot via a new /sponsoring page

### DIFF
--- a/scripts/generate-og.ts
+++ b/scripts/generate-og.ts
@@ -3,7 +3,8 @@
  *
  * Two families, both rendered from the shared card builders in src/lib/og-card.ts (satori →
  * resvg, in the site's hand-drawn xkcd/star-history style):
- *   • /metrics/<slug> + the /metrics/explained hub → public/og/metrics/<slug>.png
+ *   • /-/metrics/<slug> + the /-/metrics hub → public/og/metrics/<slug>.png (the asset
+ *     directory keeps its historical og/metrics/ name — URLs and assets are decoupled)
  *   • the two leaderboard boards (developer / organization) → public/og/leaderboard/<board>.png
  *
  * Per-developer and per-org cards are NOT here — they're DB/GitHub-driven and rendered at
@@ -59,7 +60,8 @@ function frontmatterOf(file: string): Frontmatter {
 mkdirSync(metricsOutDir, { recursive: true });
 mkdirSync(boardOutDir, { recursive: true });
 
-// The /metrics/explained hub itself — keep in sync with src/routes/metrics.explained.tsx.
+// The /-/metrics hub itself — keep in sync with src/routes/[-].metrics.index.tsx.
+// The card's asset name stays "explained.png" from the hub's old URL.
 await renderMetricsCard(
 	"explained",
 	"GitHub contribution metrics, explained",

--- a/scripts/generate-og.ts
+++ b/scripts/generate-og.ts
@@ -5,6 +5,7 @@
  * resvg, in the site's hand-drawn xkcd/star-history style):
  *   • /-/metrics/<slug> + the /-/metrics hub → public/og/metrics/<slug>.png (the asset
  *     directory keeps its historical og/metrics/ name — URLs and assets are decoupled)
+ *   • the /-/sponsoring pitch page → public/og/sponsoring.png
  *   • the two leaderboard boards (developer / organization) → public/og/leaderboard/<board>.png
  *
  * Per-developer and per-org cards are NOT here — they're DB/GitHub-driven and rendered at
@@ -20,7 +21,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
-import { boardCard, metricsCard, renderPng } from "#/lib/og-card";
+import { boardCard, contentCard, renderPng } from "#/lib/og-card";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const contentDir = join(root, "src/content/metrics");
@@ -37,7 +38,7 @@ async function renderMetricsCard(
 	title: string,
 	description: string,
 ) {
-	const png = await renderPng(metricsCard(title, description));
+	const png = await renderPng(contentCard("/ metrics, explained", title, description));
 	write(join(metricsOutDir, `${slug}.png`), png, `metrics/${slug}.png`);
 }
 
@@ -73,6 +74,19 @@ for (const file of readdirSync(contentDir)) {
 	const { title, description } = frontmatterOf(file);
 	await renderMetricsCard(file.replace(/\.mdx$/, ""), title, description);
 }
+
+// The /-/sponsoring pitch card — keep in sync with src/routes/[-].sponsoring.tsx.
+write(
+	join(root, "public/og/sponsoring.png"),
+	await renderPng(
+		contentCard(
+			"/ sponsoring",
+			"Sponsoring commit-history.com",
+			"Put your product in front of a developer-first audience: 15k unique visitors and 57k page views in under a month, in a sponsor slot on both leaderboards.",
+		),
+	),
+	"sponsoring.png",
+);
 
 // The two leaderboard share cards — fixed content, chosen by `?kind` in src/routes/index.tsx.
 write(

--- a/src/components/ExplainerLink.tsx
+++ b/src/components/ExplainerLink.tsx
@@ -3,14 +3,14 @@ import type { LeaderMode } from "#/lib/commit-history";
 import { METRIC_EXPLAINER } from "#/lib/metrics";
 
 /**
- * Tertiary "What is this?" link to the /metrics explainer article for the given metric.
+ * Tertiary "What is this?" link to the /-/metrics explainer article for the given metric.
  * Deliberately quiet: it inherits the muted small-print style of the caption/subtitle
  * it sits in, with only a dotted underline announcing it's clickable.
  */
 export function ExplainerLink({ metric }: { metric: LeaderMode }) {
 	return (
 		<Link
-			to="/metrics/$slug"
+			to="/-/metrics/$slug"
 			params={{ slug: METRIC_EXPLAINER[metric] }}
 			className="whitespace-nowrap underline decoration-dotted underline-offset-2 hover:text-foreground"
 		>

--- a/src/components/OrgView.tsx
+++ b/src/components/OrgView.tsx
@@ -268,7 +268,7 @@ function LoadedOrg({
 				repositories, as attributed by GitHub. Private members and private
 				contributions aren’t included.{" "}
 				<Link
-					to="/organizations/$slug"
+					to="/-/organizations/$slug"
 					params={{ slug: "stats" }}
 					className="whitespace-nowrap underline decoration-dotted underline-offset-2 hover:text-foreground"
 				>
@@ -306,7 +306,7 @@ function MemberBoard({
 					Public members ranked by their lifetime commits to {org.login}’s
 					repositories.{" "}
 					<Link
-						to="/organizations/$slug"
+						to="/-/organizations/$slug"
 						params={{ slug: "members" }}
 						className="whitespace-nowrap underline decoration-dotted underline-offset-2 hover:text-foreground"
 					>

--- a/src/content/metrics/commits.mdx
+++ b/src/content/metrics/commits.mdx
@@ -25,7 +25,7 @@ only when all of these hold:
   count after they're merged upstream.
 
 The count we show is the public one; work in private repositories shows up
-separately as [private contributions](/metrics/private-contributions), if the
+separately as [private contributions](/-/metrics/private-contributions), if the
 user has enabled that.
 
 ## Why workflow dominates the number
@@ -42,8 +42,8 @@ How a team merges is worth more commits than how much it codes:
 
 So a huge commit count can mean a prolific engineer — or a granular committer,
 a monorepo bot operator, or someone whose repo gets an automated commit every
-night. Cross-check it against [pull requests](/metrics/pull-requests) and
-[reviews](/metrics/reviews): a human pattern usually shows activity across
+night. Cross-check it against [pull requests](/-/metrics/pull-requests) and
+[reviews](/-/metrics/reviews): a human pattern usually shows activity across
 several types.
 
 ## What it doesn't measure

--- a/src/content/metrics/followers.mdx
+++ b/src/content/metrics/followers.mdx
@@ -15,7 +15,7 @@ worth having next to the others.
 
 The current follower count on a user's GitHub profile — a snapshot, not a
 history. GitHub doesn't expose when each follow happened, so unlike
-[commits](/metrics/commits) there's no lifetime curve to draw; followers
+[commits](/-/metrics/commits) there's no lifetime curve to draw; followers
 appear on the [leaderboard](/?metric=followers) but have no chart on profile
 pages. We refresh the count when a profile's data is refreshed.
 
@@ -32,7 +32,7 @@ Follower counts obey attention dynamics, not effort dynamics:
 
 The result is that followers and contribution counts are **nearly independent
 axes**. There are engineers with tens of thousands of
-[total contributions](/metrics/total-contributions) and three hundred
+[total contributions](/-/metrics/total-contributions) and three hundred
 followers, and developer-educators with the inverse. Neither number debunks
 the other; together they locate someone on a builder ↔ broadcaster map.
 
@@ -47,7 +47,7 @@ counts as differences in audience, not ability.
 ## Why we include it anyway
 
 Because the contrast is informative. Sorting the same population of
-developers by followers and then by [reviews](/metrics/reviews) produces
+developers by followers and then by [reviews](/-/metrics/reviews) produces
 almost comically different leaderboards — one is who you've *heard of*, the
 other is who keeps the code flowing. Having both on one site is the point.
 

--- a/src/content/metrics/issues.mdx
+++ b/src/content/metrics/issues.mdx
@@ -16,7 +16,7 @@ your issue fixed.
 - **Opening an issue** in a public repository: +1.
 - Commenting on issues, closing them, or being assigned: not counted.
 - Issues in private repositories: absorbed into
-  [private contributions](/metrics/private-contributions).
+  [private contributions](/-/metrics/private-contributions).
 
 That narrowness makes the metric easy to read literally: it measures how often
 someone *starts* a written conversation about a problem.
@@ -35,7 +35,7 @@ High lifetime issue counts cluster around a few recognisable profiles:
   issues rather than commits.
 
 That's the key insight: **a high issue count with a modest
-[commit count](/metrics/commits) is not a red flag.** It often marks someone
+[commit count](/-/metrics/commits) is not a red flag.** It often marks someone
 whose contribution is finding and describing problems precisely — which is
 frequently harder than fixing them.
 
@@ -45,7 +45,7 @@ Quality of the reports, whether they were valid, or whether they were ever
 resolved. A hundred careful reproductions and a hundred "doesn't work, plz
 fix" weigh the same. It also misses all the issue *work* that isn't opening:
 triaging, deduplicating, and answering — labor that currently has no number
-anywhere on GitHub except partially in [reviews](/metrics/reviews).
+anywhere on GitHub except partially in [reviews](/-/metrics/reviews).
 
 ## How commit-history.com tracks it
 
@@ -57,5 +57,5 @@ someone becomes a maintainer and the issue tracker becomes their desk.
 ## See it in action
 
 [Look up a maintainer you know](/) and switch the chart to **Issues** — then
-check their [Total](/metrics/total-contributions) to see how the types stack
+check their [Total](/-/metrics/total-contributions) to see how the types stack
 together.

--- a/src/content/metrics/pull-requests.mdx
+++ b/src/content/metrics/pull-requests.mdx
@@ -15,12 +15,12 @@ the day it was opened.
 
 - **Opening a pull request** in a public repository: +1, immediately.
 - Getting it merged: no extra credit — the merge shows up in the *author's*
-  [commit count](/metrics/commits) instead (if it lands on the default
+  [commit count](/-/metrics/commits) instead (if it lands on the default
   branch).
 - Reviewing someone else's PR: counted separately, under
-  [reviews](/metrics/reviews).
+  [reviews](/-/metrics/reviews).
 - PRs in private repositories: folded into the opaque
-  [private contributions](/metrics/private-contributions) count.
+  [private contributions](/-/metrics/private-contributions) count.
 
 ## Reading the number
 

--- a/src/content/metrics/repositories.mdx
+++ b/src/content/metrics/repositories.mdx
@@ -18,7 +18,7 @@ match what their profile page shows.
   forkers can show a much lower number here than their profile suggests.
 - Repositories created inside private accounts or orgs you can't see:
   invisible here (creation events in private contexts are part of
-  [private contributions](/metrics/private-contributions)).
+  [private contributions](/-/metrics/private-contributions)).
 
 This is also why our number can differ from the repository count on a GitHub
 profile: the profile's "Repositories" tab shows what a user currently *owns*
@@ -40,15 +40,15 @@ one. It tends to mark:
 The inverse profile is just as meaningful: some of the most prolific
 engineers on GitHub have a *tiny* repo count, because a decade of their work
 lives inside two or three big projects. Check the
-[commit count](/metrics/commits) next to it — thousands of commits across few
+[commit count](/-/metrics/commits) next to it — thousands of commits across few
 repos reads very differently from few commits across a thousand repos.
 
 ## What it doesn't measure
 
 Whether anything happened after `git init`. Creating a repository is the
 cheapest contribution GitHub counts — it weighs the same as a commit or a
-[review](/metrics/reviews) in the
-[Total](/metrics/total-contributions) sum, while representing the least
+[review](/-/metrics/reviews) in the
+[Total](/-/metrics/total-contributions) sum, while representing the least
 guaranteed work.
 
 ## How commit-history.com tracks it

--- a/src/content/metrics/reviews.mdx
+++ b/src/content/metrics/reviews.mdx
@@ -18,7 +18,7 @@ changes, or submits a review comment on someone else's PR.
 - Plain inline comments outside a review, issue discussions, or mentoring in
   chat: not counted.
 - Reviews in private repositories: folded into
-  [private contributions](/metrics/private-contributions).
+  [private contributions](/-/metrics/private-contributions).
 
 ## Why this number matters more than it looks
 
@@ -26,8 +26,8 @@ Reviewing is the classic case of engineering work that's essential and
 invisible. A thorough review of a complex change can take longer than writing
 it — reading the diff, checking the edge cases, testing locally, writing
 feedback that lands well. None of that produces a commit under the reviewer's
-name. The author gets the [commit](/metrics/commits) and the
-[PR](/metrics/pull-requests); the reviewer gets… this number.
+name. The author gets the [commit](/-/metrics/commits) and the
+[PR](/-/metrics/pull-requests); the reviewer gets… this number.
 
 That's why review counts skew toward a specific profile: **senior engineers
 and maintainers**. As people grow in a codebase, their output shifts from
@@ -56,5 +56,5 @@ being mostly-author and became mostly-editor.
 
 [Look up a profile](/) and switch to Reviews, or
 [compare an author-heavy and a reviewer-heavy developer](/torvalds,gaearon) —
-then check [Total](/metrics/total-contributions), which is where
+then check [Total](/-/metrics/total-contributions), which is where
 review-heavy engineers finally get full credit.

--- a/src/content/metrics/total-contributions.mdx
+++ b/src/content/metrics/total-contributions.mdx
@@ -16,12 +16,12 @@ Total is the sum of six non-overlapping buckets:
 
 | Bucket | What it counts |
 | --- | --- |
-| [Commits](/metrics/commits) | public commits on default branches |
-| [Issues](/metrics/issues) | public issues opened |
-| [Pull requests](/metrics/pull-requests) | public PRs opened |
-| [Reviews](/metrics/reviews) | public PR reviews submitted |
-| [Repositories](/metrics/repositories) | public repos created (no forks) |
-| [Private contributions](/metrics/private-contributions) | everything above, in private repos — if the user exposes it |
+| [Commits](/-/metrics/commits) | public commits on default branches |
+| [Issues](/-/metrics/issues) | public issues opened |
+| [Pull requests](/-/metrics/pull-requests) | public PRs opened |
+| [Reviews](/-/metrics/reviews) | public PR reviews submitted |
+| [Repositories](/-/metrics/repositories) | public repos created (no forks) |
+| [Private contributions](/-/metrics/private-contributions) | everything above, in private repos — if the user exposes it |
 
 The buckets are disjoint, so nothing is double-counted: a pull request counts
 once as a PR, and its commits count as commits only when they land on the
@@ -39,7 +39,7 @@ in private company repositories look like ghosts on every public metric.
 Total absorbs those biases into one number: the squash-merge engineer gets
 their PRs and reviews counted, the reviewer gets their reviews, the
 private-repo engineer gets their private count (once they
-[enable it](/metrics/private-contributions)). It's the metric we'd suggest
+[enable it](/-/metrics/private-contributions)). It's the metric we'd suggest
 for comparing two developers with *different* working styles.
 
 ## The honest caveat

--- a/src/content/organizations/members.mdx
+++ b/src/content/organizations/members.mdx
@@ -22,7 +22,7 @@ see that you're a member at all.
 GitHub only lets *you* do this for yourself — an org admin can't publish your
 membership for you. Once it's public, you'll appear the next time the
 organization's data is refreshed, and your contributions start counting toward
-the [organization totals](/organizations/stats) too.
+the [organization totals](/-/organizations/stats) too.
 
 ## Other reasons someone is missing
 
@@ -39,6 +39,6 @@ the [organization totals](/organizations/stats) too.
 
 Being on the list with a **0** is normal and not a bug. The numbers are
 contributions **to this organization's public repositories** only — see
-[how organization stats are calculated](/organizations/stats). A member shows
+[how organization stats are calculated](/-/organizations/stats). A member shows
 zero when their work in the org happens in private repositories, under an email
 not linked to their GitHub account, or simply in other places entirely.

--- a/src/content/organizations/stats.mdx
+++ b/src/content/organizations/stats.mdx
@@ -36,7 +36,7 @@ things are excluded, and they can make the totals smaller than you'd expect:
 - **Private members.** GitHub keeps organization membership private by
   default, and we can only see members who made theirs public. An active
   organization whose people all keep membership private shows a total of zero —
-  see [why am I not on this member list?](/organizations/members).
+  see [why am I not on this member list?](/-/organizations/members).
 - **Outside contributors.** Someone who sends pull requests to the org's
   repos without being a member isn't counted. The measure is about the
   organization's people, not its repos' traffic.

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,7 +1,8 @@
 /**
- * The MDX content collections:
- * - src/content/metrics/<slug>.mdx → /metrics/<slug> (individual metrics, /metrics/explained hub)
- * - src/content/organizations/<slug>.mdx → /organizations/<slug> (organization context —
+ * The MDX content collections (all under the reserved /-/ namespace — "-" can never be a
+ * GitHub login, so editorial pages never shadow the $user route):
+ * - src/content/metrics/<slug>.mdx → /-/metrics/<slug> (individual metrics, /-/metrics hub)
+ * - src/content/organizations/<slug>.mdx → /-/organizations/<slug> (organization context —
  *   deliberately its own collection, NOT mixed into the individuals' hub: the definitions differ,
  *   e.g. org-scoped vs global contributions)
  *
@@ -23,7 +24,7 @@ export interface ArticleFrontmatter {
 	/** ISO date strings ("2026-07-07") — kept as strings by the YAML core schema. */
 	publishedAt: string;
 	updatedAt: string;
-	/** Position in the /metrics/explained hub list (unset sorts last, then by title). */
+	/** Position in the /-/metrics hub list (unset sorts last, then by title). */
 	order?: number;
 }
 
@@ -48,7 +49,7 @@ export interface ArticleMeta extends ArticleFrontmatter {
 	slug: string;
 }
 
-/** All articles in curated reading order — for the /metrics/explained hub. */
+/** All articles in curated reading order — for the /-/metrics hub. */
 export const articles: ArticleMeta[] = Object.entries(frontmatters)
 	.map(([path, fm]) => ({ slug: slugOf(path), ...fm }))
 	.sort(
@@ -69,7 +70,7 @@ export function loadArticle(
 	return load?.();
 }
 
-// ── Organization collection (/organizations/<slug>) ──────────────────────────
+// ── Organization collection (/-/organizations/<slug>) ────────────────────────
 
 const orgFrontmatters = import.meta.glob<ArticleFrontmatter>(
 	"../content/organizations/*.mdx",

--- a/src/lib/og-card.ts
+++ b/src/lib/og-card.ts
@@ -357,8 +357,15 @@ export function boardCard(kind: "user" | "org"): OgNode {
 	);
 }
 
-/** The /metrics explainer card — title + description, matching the metrics hub style. */
-export function metricsCard(title: string, description: string): OgNode {
+/**
+ * Card for editorial pages (metric explainers, the sponsoring pitch) — a section kicker
+ * next to the wordmark, then title + description.
+ */
+export function contentCard(
+	kicker: string,
+	title: string,
+	description: string,
+): OgNode {
 	return frame(
 		el(
 			"div",
@@ -367,7 +374,7 @@ export function metricsCard(title: string, description: string): OgNode {
 			el(
 				"div",
 				{ style: { display: "flex", fontSize: 32, color: MUTED } },
-				"/ metrics, explained",
+				kicker,
 			),
 		),
 		el(

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,7 +18,11 @@ import { Route as MetricsExplainedRouteImport } from './routes/metrics.explained
 import { Route as MetricsSlugRouteImport } from './routes/metrics.$slug'
 import { Route as EmbedUserRouteImport } from './routes/embed.$user'
 import { Route as CompanySlugRouteImport } from './routes/company.$slug'
+import { Route as Char91Char93SponsoringRouteImport } from './routes/[-].sponsoring'
+import { Route as Char91Char93MetricsIndexRouteImport } from './routes/[-].metrics.index'
 import { Route as OgKindLoginRouteImport } from './routes/og.$kind.$login'
+import { Route as Char91Char93OrganizationsSlugRouteImport } from './routes/[-].organizations.$slug'
+import { Route as Char91Char93MetricsSlugRouteImport } from './routes/[-].metrics.$slug'
 
 const SponsoringRoute = SponsoringRouteImport.update({
   id: '/sponsoring',
@@ -65,9 +69,31 @@ const CompanySlugRoute = CompanySlugRouteImport.update({
   path: '/company/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const Char91Char93SponsoringRoute = Char91Char93SponsoringRouteImport.update({
+  id: '/-/sponsoring',
+  path: '/-/sponsoring',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Char91Char93MetricsIndexRoute =
+  Char91Char93MetricsIndexRouteImport.update({
+    id: '/-/metrics/',
+    path: '/-/metrics/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const OgKindLoginRoute = OgKindLoginRouteImport.update({
   id: '/og/$kind/$login',
   path: '/og/$kind/$login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Char91Char93OrganizationsSlugRoute =
+  Char91Char93OrganizationsSlugRouteImport.update({
+    id: '/-/organizations/$slug',
+    path: '/-/organizations/$slug',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const Char91Char93MetricsSlugRoute = Char91Char93MetricsSlugRouteImport.update({
+  id: '/-/metrics/$slug',
+  path: '/-/metrics/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -76,24 +102,32 @@ export interface FileRoutesByFullPath {
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sponsoring': typeof SponsoringRoute
+  '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
+  '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
+  '/-/organizations/$slug': typeof Char91Char93OrganizationsSlugRoute
   '/og/$kind/$login': typeof OgKindLoginRoute
+  '/-/metrics/': typeof Char91Char93MetricsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sponsoring': typeof SponsoringRoute
+  '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
+  '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
+  '/-/organizations/$slug': typeof Char91Char93OrganizationsSlugRoute
   '/og/$kind/$login': typeof OgKindLoginRoute
+  '/-/metrics': typeof Char91Char93MetricsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -101,12 +135,16 @@ export interface FileRoutesById {
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sponsoring': typeof SponsoringRoute
+  '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
+  '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
+  '/-/organizations/$slug': typeof Char91Char93OrganizationsSlugRoute
   '/og/$kind/$login': typeof OgKindLoginRoute
+  '/-/metrics/': typeof Char91Char93MetricsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -115,36 +153,48 @@ export interface FileRouteTypes {
     | '/$user'
     | '/robots.txt'
     | '/sponsoring'
+    | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
     | '/metrics/explained'
     | '/organizations/$slug'
+    | '/-/metrics/$slug'
+    | '/-/organizations/$slug'
     | '/og/$kind/$login'
+    | '/-/metrics/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/$user'
     | '/robots.txt'
     | '/sponsoring'
+    | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
     | '/metrics/explained'
     | '/organizations/$slug'
+    | '/-/metrics/$slug'
+    | '/-/organizations/$slug'
     | '/og/$kind/$login'
+    | '/-/metrics'
   id:
     | '__root__'
     | '/'
     | '/$user'
     | '/robots.txt'
     | '/sponsoring'
+    | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
     | '/metrics/explained'
     | '/organizations/$slug'
+    | '/-/metrics/$slug'
+    | '/-/organizations/$slug'
     | '/og/$kind/$login'
+    | '/-/metrics/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -152,12 +202,16 @@ export interface RootRouteChildren {
   UserRoute: typeof UserRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
   SponsoringRoute: typeof SponsoringRoute
+  Char91Char93SponsoringRoute: typeof Char91Char93SponsoringRoute
   CompanySlugRoute: typeof CompanySlugRoute
   EmbedUserRoute: typeof EmbedUserRoute
   MetricsSlugRoute: typeof MetricsSlugRoute
   MetricsExplainedRoute: typeof MetricsExplainedRoute
   OrganizationsSlugRoute: typeof OrganizationsSlugRoute
+  Char91Char93MetricsSlugRoute: typeof Char91Char93MetricsSlugRoute
+  Char91Char93OrganizationsSlugRoute: typeof Char91Char93OrganizationsSlugRoute
   OgKindLoginRoute: typeof OgKindLoginRoute
+  Char91Char93MetricsIndexRoute: typeof Char91Char93MetricsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -225,11 +279,39 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CompanySlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/-/sponsoring': {
+      id: '/-/sponsoring'
+      path: '/-/sponsoring'
+      fullPath: '/-/sponsoring'
+      preLoaderRoute: typeof Char91Char93SponsoringRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/-/metrics/': {
+      id: '/-/metrics/'
+      path: '/-/metrics'
+      fullPath: '/-/metrics/'
+      preLoaderRoute: typeof Char91Char93MetricsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/og/$kind/$login': {
       id: '/og/$kind/$login'
       path: '/og/$kind/$login'
       fullPath: '/og/$kind/$login'
       preLoaderRoute: typeof OgKindLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/-/organizations/$slug': {
+      id: '/-/organizations/$slug'
+      path: '/-/organizations/$slug'
+      fullPath: '/-/organizations/$slug'
+      preLoaderRoute: typeof Char91Char93OrganizationsSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/-/metrics/$slug': {
+      id: '/-/metrics/$slug'
+      path: '/-/metrics/$slug'
+      fullPath: '/-/metrics/$slug'
+      preLoaderRoute: typeof Char91Char93MetricsSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -240,12 +322,16 @@ const rootRouteChildren: RootRouteChildren = {
   UserRoute: UserRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,
   SponsoringRoute: SponsoringRoute,
+  Char91Char93SponsoringRoute: Char91Char93SponsoringRoute,
   CompanySlugRoute: CompanySlugRoute,
   EmbedUserRoute: EmbedUserRoute,
   MetricsSlugRoute: MetricsSlugRoute,
   MetricsExplainedRoute: MetricsExplainedRoute,
   OrganizationsSlugRoute: OrganizationsSlugRoute,
+  Char91Char93MetricsSlugRoute: Char91Char93MetricsSlugRoute,
+  Char91Char93OrganizationsSlugRoute: Char91Char93OrganizationsSlugRoute,
   OgKindLoginRoute: OgKindLoginRoute,
+  Char91Char93MetricsIndexRoute: Char91Char93MetricsIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SponsoringRouteImport } from './routes/sponsoring'
 import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as UserRouteImport } from './routes/$user'
 import { Route as IndexRouteImport } from './routes/index'
@@ -19,6 +20,11 @@ import { Route as EmbedUserRouteImport } from './routes/embed.$user'
 import { Route as CompanySlugRouteImport } from './routes/company.$slug'
 import { Route as OgKindLoginRouteImport } from './routes/og.$kind.$login'
 
+const SponsoringRoute = SponsoringRouteImport.update({
+  id: '/sponsoring',
+  path: '/sponsoring',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
   id: '/robots.txt',
   path: '/robots.txt',
@@ -69,6 +75,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
+  '/sponsoring': typeof SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
@@ -80,6 +87,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
+  '/sponsoring': typeof SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
@@ -92,6 +100,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
+  '/sponsoring': typeof SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
@@ -105,6 +114,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/robots.txt'
+    | '/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
@@ -116,6 +126,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/robots.txt'
+    | '/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
@@ -127,6 +138,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/robots.txt'
+    | '/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
     | '/metrics/$slug'
@@ -139,6 +151,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   UserRoute: typeof UserRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
+  SponsoringRoute: typeof SponsoringRoute
   CompanySlugRoute: typeof CompanySlugRoute
   EmbedUserRoute: typeof EmbedUserRoute
   MetricsSlugRoute: typeof MetricsSlugRoute
@@ -149,6 +162,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/sponsoring': {
+      id: '/sponsoring'
+      path: '/sponsoring'
+      fullPath: '/sponsoring'
+      preLoaderRoute: typeof SponsoringRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/robots.txt': {
       id: '/robots.txt'
       path: '/robots.txt'
@@ -219,6 +239,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   UserRoute: UserRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,
+  SponsoringRoute: SponsoringRoute,
   CompanySlugRoute: CompanySlugRoute,
   EmbedUserRoute: EmbedUserRoute,
   MetricsSlugRoute: MetricsSlugRoute,

--- a/src/routes/[-].metrics.$slug.tsx
+++ b/src/routes/[-].metrics.$slug.tsx
@@ -1,0 +1,148 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { type ComponentType, lazy, Suspense } from "react";
+import { mdxComponents } from "#/components/MdxComponents";
+import { getArticleMeta, loadArticle } from "#/lib/content";
+
+const SITE = "https://commit-history.com";
+
+// One stable lazy component per slug — created on demand, cached at module level so
+// re-renders don't recreate (and thereby remount) the article body.
+type BodyComponent = ComponentType<{ components?: typeof mdxComponents }>;
+const bodies = new Map<string, BodyComponent>();
+function articleBody(slug: string): BodyComponent {
+	let body = bodies.get(slug);
+	if (!body) {
+		body = lazy(() => {
+			const load = loadArticle(slug);
+			if (!load) throw notFound();
+			return load;
+		});
+		bodies.set(slug, body);
+	}
+	return body;
+}
+
+function formatDate(iso: string) {
+	return new Date(iso).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
+export const Route = createFileRoute("/-/metrics/$slug")({
+	loader: ({ params }) => {
+		const meta = getArticleMeta(params.slug);
+		if (!meta) throw notFound();
+		return meta;
+	},
+	head: ({ params }) => {
+		const meta = getArticleMeta(params.slug);
+		if (!meta) return {};
+		const url = `${SITE}/-/metrics/${meta.slug}`;
+		const ogImage = `${SITE}/og/metrics/${meta.slug}.png`;
+		return {
+			meta: [
+				{ title: `${meta.title} · Commit History` },
+				{ name: "description", content: meta.description },
+				// Open Graph — article type; image/url/alt override the site-wide card.
+				{ property: "og:type", content: "article" },
+				{ property: "og:title", content: meta.title },
+				{ property: "og:description", content: meta.description },
+				{ property: "og:url", content: url },
+				{ property: "og:image", content: ogImage },
+				{ property: "og:image:alt", content: meta.title },
+				{ property: "article:published_time", content: meta.publishedAt },
+				{ property: "article:modified_time", content: meta.updatedAt },
+				{ name: "twitter:title", content: meta.title },
+				{ name: "twitter:description", content: meta.description },
+				{ name: "twitter:image", content: ogImage },
+				{ name: "twitter:image:alt", content: meta.title },
+			],
+			links: [{ rel: "canonical", href: url }],
+			scripts: [
+				{
+					type: "application/ld+json",
+					children: JSON.stringify([
+						{
+							"@context": "https://schema.org",
+							"@type": "TechArticle",
+							headline: meta.title,
+							description: meta.description,
+							datePublished: meta.publishedAt,
+							dateModified: meta.updatedAt,
+							image: ogImage,
+							mainEntityOfPage: url,
+							author: {
+								"@type": "Person",
+								name: "Philip Poloczek",
+								url: "https://github.com/peetzweg",
+							},
+							publisher: {
+								"@type": "Organization",
+								name: "Commit History",
+								url: SITE,
+								logo: {
+									"@type": "ImageObject",
+									url: `${SITE}/crown-180.png`,
+								},
+							},
+						},
+						{
+							"@context": "https://schema.org",
+							"@type": "BreadcrumbList",
+							itemListElement: [
+								{
+									"@type": "ListItem",
+									position: 1,
+									name: "Commit History",
+									item: SITE,
+								},
+								{
+									"@type": "ListItem",
+									position: 2,
+									name: "Metrics, explained",
+									item: `${SITE}/-/metrics`,
+								},
+								{ "@type": "ListItem", position: 3, name: meta.title },
+							],
+						},
+					]),
+				},
+			],
+		};
+	},
+	component: ArticlePage,
+});
+
+function ArticlePage() {
+	const meta = Route.useLoaderData();
+	const Body = articleBody(meta.slug);
+	return (
+		<main className="mx-auto max-w-3xl px-6 py-12">
+			<nav aria-label="Breadcrumb">
+				<Link
+					to="/-/metrics"
+					className="text-sm text-muted-foreground hover:text-foreground"
+				>
+					← metrics, explained
+				</Link>
+			</nav>
+			<article className="mt-6">
+				<header>
+					<h1 className="text-3xl font-bold leading-tight">{meta.title}</h1>
+					<p className="mt-3 text-muted-foreground">{meta.description}</p>
+					<p className="mt-2 text-xs text-muted-foreground">
+						Updated{" "}
+						<time dateTime={meta.updatedAt}>{formatDate(meta.updatedAt)}</time>
+					</p>
+				</header>
+				<div className="prose prose-neutral mt-8 max-w-none">
+					<Suspense fallback={null}>
+						<Body components={mdxComponents} />
+					</Suspense>
+				</div>
+			</article>
+		</main>
+	);
+}

--- a/src/routes/[-].metrics.index.tsx
+++ b/src/routes/[-].metrics.index.tsx
@@ -1,0 +1,88 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { articles } from "#/lib/content";
+
+const SITE = "https://commit-history.com";
+const TITLE = "GitHub contribution metrics, explained";
+const DESCRIPTION =
+	"What the numbers on a commit-history.com profile actually mean: commits, pull requests, reviews, repositories, and private contributions — in detail.";
+// URL policy: all editorial content lives under the reserved /-/ namespace — "-" can
+// never be a GitHub login (logins can't start or end with a hyphen), so nothing under
+// it can ever shadow the single-segment $user route. Inside the namespace the hub may
+// own its bare prefix, so it lives at /-/metrics directly (the old /metrics/explained
+// workaround 301s here). The OG image keeps its historical asset name (explained.png).
+const URL = `${SITE}/-/metrics`;
+const OG_IMAGE = `${SITE}/og/metrics/explained.png`;
+
+export const Route = createFileRoute("/-/metrics/")({
+	head: () => ({
+		meta: [
+			{ title: `${TITLE} · Commit History` },
+			{ name: "description", content: DESCRIPTION },
+			{ property: "og:title", content: TITLE },
+			{ property: "og:description", content: DESCRIPTION },
+			{ property: "og:url", content: URL },
+			{ property: "og:image", content: OG_IMAGE },
+			{ property: "og:image:alt", content: TITLE },
+			{ name: "twitter:title", content: TITLE },
+			{ name: "twitter:description", content: DESCRIPTION },
+			{ name: "twitter:image", content: OG_IMAGE },
+			{ name: "twitter:image:alt", content: TITLE },
+		],
+		links: [{ rel: "canonical", href: URL }],
+		scripts: [
+			{
+				type: "application/ld+json",
+				children: JSON.stringify({
+					"@context": "https://schema.org",
+					"@type": "CollectionPage",
+					name: TITLE,
+					description: DESCRIPTION,
+					url: URL,
+					mainEntity: {
+						"@type": "ItemList",
+						itemListElement: articles.map((a, i) => ({
+							"@type": "ListItem",
+							position: i + 1,
+							name: a.title,
+							url: `${SITE}/-/metrics/${a.slug}`,
+						})),
+					},
+				}),
+			},
+		],
+	}),
+	component: MetricsIndex,
+});
+
+function MetricsIndex() {
+	return (
+		<main className="mx-auto max-w-3xl px-6 py-12">
+			<Link
+				to="/"
+				className="text-sm text-muted-foreground hover:text-foreground"
+			>
+				← commit-history
+			</Link>
+			<h1 className="mt-6 text-3xl font-bold leading-tight">{TITLE}</h1>
+			<p className="mt-3 text-muted-foreground">{DESCRIPTION}</p>
+			<ul className="mt-10 flex flex-col divide-y divide-border">
+				{articles.map((a) => (
+					<li key={a.slug} className="py-6 first:pt-0 last:pb-0">
+						<Link
+							to="/-/metrics/$slug"
+							params={{ slug: a.slug }}
+							className="group block"
+						>
+							<h2 className="text-lg font-semibold group-hover:underline">
+								{a.title}
+							</h2>
+							<p className="mt-1 text-sm text-muted-foreground">
+								{a.description}
+							</p>
+						</Link>
+					</li>
+				))}
+			</ul>
+		</main>
+	);
+}

--- a/src/routes/[-].organizations.$slug.tsx
+++ b/src/routes/[-].organizations.$slug.tsx
@@ -1,0 +1,145 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { type ComponentType, lazy, Suspense } from "react";
+import { mdxComponents } from "#/components/MdxComponents";
+import { getOrgArticleMeta, loadOrgArticle } from "#/lib/content";
+
+/**
+ * Organization-context explainer articles (src/content/organizations/*.mdx) — the org twins of
+ * the /-/metrics/$slug pages. A separate collection on purpose: organization numbers are org-scoped
+ * and public-member-only, so their definitions differ from the individual metric explainers.
+ * Lives under the reserved /-/ namespace like all editorial content (see [-].metrics.index.tsx).
+ * No per-article OG images (yet) — these fall back to the site-wide card.
+ * Old /company/<slug> and /organizations/<slug> URLs 301 here via their redirect routes.
+ */
+
+const SITE = "https://commit-history.com";
+
+// One stable lazy component per slug — created on demand, cached at module level so
+// re-renders don't recreate (and thereby remount) the article body.
+type BodyComponent = ComponentType<{ components?: typeof mdxComponents }>;
+const bodies = new Map<string, BodyComponent>();
+function articleBody(slug: string): BodyComponent {
+	let body = bodies.get(slug);
+	if (!body) {
+		body = lazy(() => {
+			const load = loadOrgArticle(slug);
+			if (!load) throw notFound();
+			return load;
+		});
+		bodies.set(slug, body);
+	}
+	return body;
+}
+
+function formatDate(iso: string) {
+	return new Date(iso).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
+export const Route = createFileRoute("/-/organizations/$slug")({
+	loader: ({ params }) => {
+		const meta = getOrgArticleMeta(params.slug);
+		if (!meta) throw notFound();
+		return meta;
+	},
+	head: ({ params }) => {
+		const meta = getOrgArticleMeta(params.slug);
+		if (!meta) return {};
+		const url = `${SITE}/-/organizations/${meta.slug}`;
+		return {
+			meta: [
+				{ title: `${meta.title} · Commit History` },
+				{ name: "description", content: meta.description },
+				{ property: "og:type", content: "article" },
+				{ property: "og:title", content: meta.title },
+				{ property: "og:description", content: meta.description },
+				{ property: "og:url", content: url },
+				{ property: "article:published_time", content: meta.publishedAt },
+				{ property: "article:modified_time", content: meta.updatedAt },
+				{ name: "twitter:title", content: meta.title },
+				{ name: "twitter:description", content: meta.description },
+			],
+			links: [{ rel: "canonical", href: url }],
+			scripts: [
+				{
+					type: "application/ld+json",
+					children: JSON.stringify([
+						{
+							"@context": "https://schema.org",
+							"@type": "TechArticle",
+							headline: meta.title,
+							description: meta.description,
+							datePublished: meta.publishedAt,
+							dateModified: meta.updatedAt,
+							mainEntityOfPage: url,
+							author: {
+								"@type": "Person",
+								name: "Philip Poloczek",
+								url: "https://github.com/peetzweg",
+							},
+							publisher: {
+								"@type": "Organization",
+								name: "Commit History",
+								url: SITE,
+								logo: {
+									"@type": "ImageObject",
+									url: `${SITE}/crown-180.png`,
+								},
+							},
+						},
+						{
+							"@context": "https://schema.org",
+							"@type": "BreadcrumbList",
+							itemListElement: [
+								{
+									"@type": "ListItem",
+									position: 1,
+									name: "Commit History",
+									item: SITE,
+								},
+								{ "@type": "ListItem", position: 2, name: meta.title },
+							],
+						},
+					]),
+				},
+			],
+		};
+	},
+	component: ArticlePage,
+});
+
+function ArticlePage() {
+	const meta = Route.useLoaderData();
+	const Body = articleBody(meta.slug);
+	return (
+		<main className="mx-auto max-w-3xl px-6 py-12">
+			<nav aria-label="Breadcrumb">
+				<Link
+					to="/"
+					search={{ kind: "org" }}
+					className="text-sm text-muted-foreground hover:text-foreground"
+				>
+					← organization leaderboard
+				</Link>
+			</nav>
+			<article className="mt-6">
+				<header>
+					<h1 className="text-3xl font-bold leading-tight">{meta.title}</h1>
+					<p className="mt-3 text-muted-foreground">{meta.description}</p>
+					<p className="mt-2 text-xs text-muted-foreground">
+						Updated{" "}
+						<time dateTime={meta.updatedAt}>{formatDate(meta.updatedAt)}</time>
+					</p>
+				</header>
+				<div className="prose prose-neutral mt-8 max-w-none">
+					<Suspense fallback={null}>
+						<Body components={mdxComponents} />
+					</Suspense>
+				</div>
+			</article>
+		</main>
+	);
+}

--- a/src/routes/[-].sponsoring.tsx
+++ b/src/routes/[-].sponsoring.tsx
@@ -1,0 +1,120 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+const SITE = "https://commit-history.com";
+const TITLE = "Sponsoring commit-history.com";
+const DESCRIPTION =
+	"Put your product in front of a developer-first audience: 15k unique visitors and 57k page views in under a month, in a sponsor slot on both leaderboards.";
+// Lives under the reserved /-/ namespace like all editorial content: "-" can never be a
+// GitHub login, so this page can't shadow the $user route (the old single-segment
+// /sponsoring URL 301s here — see sponsoring.tsx).
+const URL = `${SITE}/-/sponsoring`;
+
+const CONTACT = "phil.czek@gmail.com";
+const MAILTO = `mailto:${CONTACT}?subject=${encodeURIComponent("Sponsoring commit-history.com")}`;
+
+// Site analytics, collected since June 27, 2026. Update LAST_UPDATED when refreshing numbers.
+const LAST_UPDATED = "July 14, 2026";
+const STATS = [
+	{ value: "15k", label: "unique visitors" },
+	{ value: "57k", label: "page views" },
+	{ value: "1:32", label: "avg. visit duration" },
+	{ value: "38%", label: "bounce rate" },
+] as const;
+
+export const Route = createFileRoute("/-/sponsoring")({
+	head: () => ({
+		meta: [
+			{ title: `${TITLE} · Commit History` },
+			{ name: "description", content: DESCRIPTION },
+			{ property: "og:title", content: TITLE },
+			{ property: "og:description", content: DESCRIPTION },
+			{ property: "og:url", content: URL },
+			{ name: "twitter:title", content: TITLE },
+			{ name: "twitter:description", content: DESCRIPTION },
+		],
+		links: [{ rel: "canonical", href: URL }],
+	}),
+	component: SponsoringPage,
+});
+
+function SponsoringPage() {
+	return (
+		<main className="mx-auto max-w-3xl px-6 py-12">
+			<Link
+				to="/"
+				className="text-sm text-muted-foreground hover:text-foreground"
+			>
+				← commit-history
+			</Link>
+			<h1 className="mt-6 text-3xl font-bold leading-tight">
+				Sponsoring{" "}
+				<span className="font-hand font-normal text-primary">
+					commit-history.com
+				</span>
+			</h1>
+			<p className="mt-3 text-muted-foreground">
+				One sponsor slot, rendered like a leaderboard entry, in 5th place of
+				both the developer and the organization leaderboard — the first thing
+				people scroll past on every visit.
+			</p>
+
+			{/* CTA up top: interested sponsors shouldn't have to scroll to find the contact. */}
+			<div className="mt-6 flex flex-wrap items-center gap-3">
+				<a href={MAILTO} className="btn-primary">
+					Get in touch
+				</a>
+				<span className="text-sm text-muted-foreground">{CONTACT}</span>
+			</div>
+
+			<h2 className="mt-12 text-xl font-semibold">The numbers</h2>
+			<p className="mt-2 text-muted-foreground">
+				We’ve been collecting analytics since June 27, 2026 — so in not even a
+				month (last updated {LAST_UPDATED}):
+			</p>
+			<dl className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+				{STATS.map((s) => (
+					<div key={s.label} className="rounded-md border p-4 text-center">
+						<dd className="text-2xl font-bold tabular-nums">{s.value}</dd>
+						<dt className="mt-1 text-xs text-muted-foreground">{s.label}</dt>
+					</div>
+				))}
+			</dl>
+
+			<h2 className="mt-12 text-xl font-semibold">The audience</h2>
+			<p className="mt-2 text-muted-foreground">
+				Mainly developers — people plotting their own commit history, comparing
+				themselves on the leaderboards, and sharing profiles with each other. A
+				visit duration of a minute and a half and a bounce rate as low as 38%
+				mean visitors actually stick around and explore. Beyond developers, the
+				leaderboards also draw companies and recruiters looking for talent — an
+				audience that’s hard to reach anywhere else.
+			</p>
+
+			<h2 className="mt-12 text-xl font-semibold">The slot</h2>
+			<p className="mt-2 text-muted-foreground">
+				Your logo, product name, and a one-line tagline, clearly disclosed as
+				sponsored, linking out to your site. It sits in 5th place of the{" "}
+				<Link to="/" className="underline hover:text-foreground">
+					developer leaderboard
+				</Link>{" "}
+				and the{" "}
+				<Link
+					to="/"
+					search={{ kind: "org" }}
+					className="underline hover:text-foreground"
+				>
+					organization leaderboard
+				</Link>
+				, so it’s on screen right where everyone looks.
+			</p>
+
+			<p className="mt-12 text-muted-foreground">
+				Interested?{" "}
+				<a href={MAILTO} className="font-medium text-foreground underline">
+					Send a mail to {CONTACT}
+				</a>{" "}
+				and we’ll figure out the rest.
+			</p>
+		</main>
+	);
+}

--- a/src/routes/[-].sponsoring.tsx
+++ b/src/routes/[-].sponsoring.tsx
@@ -8,6 +8,8 @@ const DESCRIPTION =
 // GitHub login, so this page can't shadow the $user route (the old single-segment
 // /sponsoring URL 301s here — see sponsoring.tsx).
 const URL = `${SITE}/-/sponsoring`;
+// Static card built by scripts/generate-og.ts — keep its copy in sync with TITLE/DESCRIPTION.
+const OG_IMAGE = `${SITE}/og/sponsoring.png`;
 
 const CONTACT = "phil.czek@gmail.com";
 const MAILTO = `mailto:${CONTACT}?subject=${encodeURIComponent("Sponsoring commit-history.com")}`;
@@ -29,8 +31,12 @@ export const Route = createFileRoute("/-/sponsoring")({
 			{ property: "og:title", content: TITLE },
 			{ property: "og:description", content: DESCRIPTION },
 			{ property: "og:url", content: URL },
+			{ property: "og:image", content: OG_IMAGE },
+			{ property: "og:image:alt", content: TITLE },
 			{ name: "twitter:title", content: TITLE },
 			{ name: "twitter:description", content: DESCRIPTION },
+			{ name: "twitter:image", content: OG_IMAGE },
+			{ name: "twitter:image:alt", content: TITLE },
 		],
 		links: [{ rel: "canonical", href: URL }],
 	}),

--- a/src/routes/company.$slug.tsx
+++ b/src/routes/company.$slug.tsx
@@ -1,15 +1,16 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 /**
- * Permanent redirect from the old /company/<slug> explainer URLs to their new /organizations/<slug>
- * home (the collection was renamed when "companies" became "organizations" site-wide). Kept as a
- * thin route so existing links and search-engine results don't 404. Bare /company still falls
- * through to the $user route as a valid GitHub login — same policy as /organizations.
+ * Permanent redirect from the old /company/<slug> explainer URLs to their current
+ * /-/organizations/<slug> home (the collection was renamed when "companies" became
+ * "organizations" site-wide, then moved under the reserved /-/ namespace). Points straight
+ * at the final home so old links don't hop through two redirects. Bare /company still
+ * falls through to the $user route as a valid GitHub login — same policy as /organizations.
  */
 export const Route = createFileRoute("/company/$slug")({
 	beforeLoad: ({ params }) => {
 		throw redirect({
-			to: "/organizations/$slug",
+			to: "/-/organizations/$slug",
 			params: { slug: params.slug },
 			statusCode: 301,
 		});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -169,10 +169,7 @@ function Home() {
 			)}
 			<p className="mt-14 text-center text-sm text-muted-foreground">
 				Wondering what these numbers mean?{" "}
-				<Link
-					to="/metrics/explained"
-					className="underline hover:text-foreground"
-				>
+				<Link to="/-/metrics" className="underline hover:text-foreground">
 					The metrics, explained
 				</Link>
 			</p>
@@ -412,7 +409,7 @@ function EmptySponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
 			className="border-border border-b bg-muted/40"
 		>
 			<Link
-				to="/sponsoring"
+				to="/-/sponsoring"
 				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
 			>
 				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
@@ -748,7 +745,7 @@ function OrgBoard({ rows }: { rows: OrgLeaderEntry[] }) {
 				<p className="mt-1.5 text-xs text-muted-foreground">
 					Public members’ lifetime commits to the organization’s repositories.{" "}
 					<Link
-						to="/organizations/$slug"
+						to="/-/organizations/$slug"
 						params={{ slug: "stats" }}
 						className="whitespace-nowrap underline decoration-dotted underline-offset-2 hover:text-foreground"
 					>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -319,13 +319,88 @@ function RecentSection({ recent }: { recent: RecentEntry[] }) {
 }
 
 /**
- * The empty sponsor slot, shown in the slot after rank 5 on both boards.
+ * A single hardcoded sponsor row, shown in the slot after rank 5 on the developer board.
  *
- * The paid creative (previously Rebates.ai) is deactivated; until a new sponsor signs,
- * the slot advertises itself and links to the /sponsoring pitch page. Same row treatment
- * as a booked sponsor so buyers see exactly what they'd get.
+ * Same visual treatment as the (parked) DB-driven sponsorship system on `feat/sponsorships`,
+ * but with no database — the creative is hardcoded for now. Uses the sponsor's own favicon and
+ * page title, and links out with rel="sponsored nofollow".
  */
+// A/B test on the Rebates ad subtitle. "a" is the control (original copy), "b" the
+// challenger. utm_content carries the variant so clicks are attributable per arm.
+const REBATES_VARIANTS = {
+	a: {
+		subtitle: "The ads in your terminal pay you",
+		utmContent: "slot5-test-79-a",
+	},
+	b: {
+		subtitle: "Watch ads while coding. Get paid.",
+		utmContent: "slot5-test-79-b",
+	},
+} as const;
+
+function rebatesHref(utmContent: string): string {
+	return `https://rebates.ai/?utm_source=commit-history.com&utm_medium=leaderboard&utm_campaign=commit-history_sponsorship&utm_content=${utmContent}`;
+}
+
 function SponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
+	// Default to the control on the server/first paint so hydration matches, then flip
+	// to a random 50/50 arm on the client. Math.random() during render would desync SSR.
+	const [variant, setVariant] = useState<"a" | "b">("a");
+	useEffect(() => {
+		setVariant(Math.random() < 0.5 ? "a" : "b");
+	}, []);
+	const { subtitle, utmContent } = REBATES_VARIANTS[variant];
+
+	return (
+		<motion.li
+			ref={ref}
+			layout
+			initial={{ opacity: 0 }}
+			animate={{ opacity: 1 }}
+			exit={{ opacity: 0 }}
+			transition={{ type: "spring", stiffness: 600, damping: 40 }}
+			className="border-border border-b bg-muted/40"
+		>
+			<a
+				href={rebatesHref(utmContent)}
+				target="_blank"
+				rel="sponsored nofollow noopener"
+				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
+			>
+				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
+				    "Sponsored" on the right keeps the disclosure. */}
+				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
+					Ad
+				</span>
+				<img
+					src="https://rebates.ai/brand/rebates-bandit.svg"
+					alt="Rebates.ai"
+					className="h-8 w-8 shrink-0 rounded-full border border-border object-cover"
+				/>
+				{/* Title + tagline on two lines in a lighter weight than the usernames, so the block
+				    matches the logo height and doesn't shout as loud as a real leaderboard entry. */}
+				<span className="min-w-0 flex-1">
+					<span className="block truncate">Rebates.ai</span>
+					<span className="block truncate text-xs text-muted-foreground">
+						{subtitle}
+					</span>
+				</span>
+				<span className="shrink-0 text-right text-xs text-muted-foreground">
+					Sponsored
+				</span>
+			</a>
+		</motion.li>
+	);
+}
+
+/**
+ * The empty sponsor slot, shown in the slot after rank 5 on the organization board.
+ *
+ * That slot has no paid creative yet; until a sponsor signs, it advertises itself and
+ * links to the /sponsoring pitch page. Same row treatment as a booked sponsor so buyers
+ * see exactly what they'd get.
+ */
+function EmptySponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
 	return (
 		<motion.li
 			ref={ref}
@@ -732,9 +807,10 @@ function OrgBoard({ rows }: { rows: OrgLeaderEntry[] }) {
 							</Link>
 						</li>,
 					];
-					// Same sponsor slot after rank 5 as on the developer board.
+					// Sponsor slot after rank 5, mirroring the developer board — but this one
+					// is unbooked, so it advertises itself.
 					if (i === 4 && rows.length > 5)
-						items.push(<SponsorRow key="sponsor" />);
+						items.push(<EmptySponsorRow key="sponsor" />);
 					return items;
 				})}
 			</ol>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -319,38 +319,13 @@ function RecentSection({ recent }: { recent: RecentEntry[] }) {
 }
 
 /**
- * A single hardcoded sponsor row, shown in the slot after rank 5.
+ * The empty sponsor slot, shown in the slot after rank 5 on both boards.
  *
- * Same visual treatment as the (parked) DB-driven sponsorship system on `feat/sponsorships`,
- * but with no database — the creative is hardcoded for now. Uses the sponsor's own favicon and
- * page title, and links out with rel="sponsored nofollow".
+ * The paid creative (previously Rebates.ai) is deactivated; until a new sponsor signs,
+ * the slot advertises itself and links to the /sponsoring pitch page. Same row treatment
+ * as a booked sponsor so buyers see exactly what they'd get.
  */
-// A/B test on the Rebates ad subtitle. "a" is the control (original copy), "b" the
-// challenger. utm_content carries the variant so clicks are attributable per arm.
-const REBATES_VARIANTS = {
-	a: {
-		subtitle: "The ads in your terminal pay you",
-		utmContent: "slot5-test-79-a",
-	},
-	b: {
-		subtitle: "Watch ads while coding. Get paid.",
-		utmContent: "slot5-test-79-b",
-	},
-} as const;
-
-function rebatesHref(utmContent: string): string {
-	return `https://rebates.ai/?utm_source=commit-history.com&utm_medium=leaderboard&utm_campaign=commit-history_sponsorship&utm_content=${utmContent}`;
-}
-
 function SponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
-	// Default to the control on the server/first paint so hydration matches, then flip
-	// to a random 50/50 arm on the client. Math.random() during render would desync SSR.
-	const [variant, setVariant] = useState<"a" | "b">("a");
-	useEffect(() => {
-		setVariant(Math.random() < 0.5 ? "a" : "b");
-	}, []);
-	const { subtitle, utmContent } = REBATES_VARIANTS[variant];
-
 	return (
 		<motion.li
 			ref={ref}
@@ -361,34 +336,27 @@ function SponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
 			transition={{ type: "spring", stiffness: 600, damping: 40 }}
 			className="border-border border-b bg-muted/40"
 		>
-			<a
-				href={rebatesHref(utmContent)}
-				target="_blank"
-				rel="sponsored nofollow noopener"
+			<Link
+				to="/sponsoring"
 				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
 			>
 				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
-				    "Sponsored" on the right keeps the disclosure. */}
+				    the right-hand label keeps the disclosure. */}
 				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
 					Ad
 				</span>
-				<img
-					src="https://rebates.ai/brand/rebates-bandit.svg"
-					alt="Rebates.ai"
-					className="h-8 w-8 shrink-0 rounded-full border border-border object-cover"
-				/>
-				{/* Title + tagline on two lines in a lighter weight than the usernames, so the block
-				    matches the logo height and doesn't shout as loud as a real leaderboard entry. */}
+				{/* Dashed placeholder where the sponsor's logo would sit — reads as "empty". */}
+				<span className="h-8 w-8 shrink-0 rounded-full border border-border border-dashed" />
 				<span className="min-w-0 flex-1">
-					<span className="block truncate">Rebates.ai</span>
+					<span className="block truncate">This sponsor slot is empty</span>
 					<span className="block truncate text-xs text-muted-foreground">
-						{subtitle}
+						Put your product in front of thousands of developers
 					</span>
 				</span>
 				<span className="shrink-0 text-right text-xs text-muted-foreground">
-					Sponsored
+					Sponsoring
 				</span>
-			</a>
+			</Link>
 		</motion.li>
 	);
 }
@@ -714,55 +682,61 @@ function OrgBoard({ rows }: { rows: OrgLeaderEntry[] }) {
 				</p>
 			</div>
 			<ol>
-				{rows.map((org, i) => (
-					<li key={org.login} className="border-border border-b">
-						<Link
-							to="/$user"
-							params={{ user: org.login }}
-							preload={false}
-							className="group flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
-						>
-							<span className="flex w-6 items-center justify-center text-sm tabular-nums text-muted-foreground">
-								{i === 0 ? (
-									<img
-										src="/crown.svg"
-										alt="1st place"
-										className="h-4 w-auto"
-									/>
-								) : (
-									i + 1
-								)}
-							</span>
-							<img
-								src={org.avatarUrl ?? ""}
-								alt=""
-								className="h-8 w-8 rounded-lg border border-border"
-							/>
-							<span className="flex min-w-0 flex-1 items-center gap-1.5 truncate font-medium">
-								{org.login}
-								{org.isVerified && (
-									<BadgeCheck
-										className="h-4 w-4 shrink-0 text-primary"
-										aria-label="Verified organization"
-									/>
-								)}
-								{org.name && (
-									<span className="hidden truncate font-normal text-muted-foreground opacity-0 transition-opacity duration-200 sm:inline desktop:group-hover:opacity-100 desktop:group-focus-within:opacity-100">
-										{org.name}
+				{rows.flatMap((org, i) => {
+					const items = [
+						<li key={org.login} className="border-border border-b">
+							<Link
+								to="/$user"
+								params={{ user: org.login }}
+								preload={false}
+								className="group flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
+							>
+								<span className="flex w-6 items-center justify-center text-sm tabular-nums text-muted-foreground">
+									{i === 0 ? (
+										<img
+											src="/crown.svg"
+											alt="1st place"
+											className="h-4 w-auto"
+										/>
+									) : (
+										i + 1
+									)}
+								</span>
+								<img
+									src={org.avatarUrl ?? ""}
+									alt=""
+									className="h-8 w-8 rounded-lg border border-border"
+								/>
+								<span className="flex min-w-0 flex-1 items-center gap-1.5 truncate font-medium">
+									{org.login}
+									{org.isVerified && (
+										<BadgeCheck
+											className="h-4 w-4 shrink-0 text-primary"
+											aria-label="Verified organization"
+										/>
+									)}
+									{org.name && (
+										<span className="hidden truncate font-normal text-muted-foreground opacity-0 transition-opacity duration-200 sm:inline desktop:group-hover:opacity-100 desktop:group-focus-within:opacity-100">
+											{org.name}
+										</span>
+									)}
+								</span>
+								<span className="text-right">
+									<span className="block font-semibold tabular-nums">
+										{org.totalCommits.toLocaleString()}
 									</span>
-								)}
-							</span>
-							<span className="text-right">
-								<span className="block font-semibold tabular-nums">
-									{org.totalCommits.toLocaleString()}
+									<span className="block text-xs text-muted-foreground tabular-nums">
+										commits
+									</span>
 								</span>
-								<span className="block text-xs text-muted-foreground tabular-nums">
-									commits
-								</span>
-							</span>
-						</Link>
-					</li>
-				))}
+							</Link>
+						</li>,
+					];
+					// Same sponsor slot after rank 5 as on the developer board.
+					if (i === 4 && rows.length > 5)
+						items.push(<SponsorRow key="sponsor" />);
+					return items;
+				})}
 			</ol>
 		</section>
 	);

--- a/src/routes/metrics.$slug.tsx
+++ b/src/routes/metrics.$slug.tsx
@@ -1,148 +1,17 @@
-import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { type ComponentType, lazy, Suspense } from "react";
-import { mdxComponents } from "#/components/MdxComponents";
-import { getArticleMeta, loadArticle } from "#/lib/content";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-const SITE = "https://commit-history.com";
-
-// One stable lazy component per slug — created on demand, cached at module level so
-// re-renders don't recreate (and thereby remount) the article body.
-type BodyComponent = ComponentType<{ components?: typeof mdxComponents }>;
-const bodies = new Map<string, BodyComponent>();
-function articleBody(slug: string): BodyComponent {
-	let body = bodies.get(slug);
-	if (!body) {
-		body = lazy(() => {
-			const load = loadArticle(slug);
-			if (!load) throw notFound();
-			return load;
-		});
-		bodies.set(slug, body);
-	}
-	return body;
-}
-
-function formatDate(iso: string) {
-	return new Date(iso).toLocaleDateString("en-US", {
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-	});
-}
-
+/**
+ * Permanent redirect from the old /metrics/<slug> explainer URLs to their new home under
+ * the reserved /-/ namespace. Kept as a thin route so existing links and search-engine
+ * results don't 404. Bare /metrics still falls through to the $user route as a valid
+ * GitHub login.
+ */
 export const Route = createFileRoute("/metrics/$slug")({
-	loader: ({ params }) => {
-		const meta = getArticleMeta(params.slug);
-		if (!meta) throw notFound();
-		return meta;
+	beforeLoad: ({ params }) => {
+		throw redirect({
+			to: "/-/metrics/$slug",
+			params: { slug: params.slug },
+			statusCode: 301,
+		});
 	},
-	head: ({ params }) => {
-		const meta = getArticleMeta(params.slug);
-		if (!meta) return {};
-		const url = `${SITE}/metrics/${meta.slug}`;
-		const ogImage = `${SITE}/og/metrics/${meta.slug}.png`;
-		return {
-			meta: [
-				{ title: `${meta.title} · Commit History` },
-				{ name: "description", content: meta.description },
-				// Open Graph — article type; image/url/alt override the site-wide card.
-				{ property: "og:type", content: "article" },
-				{ property: "og:title", content: meta.title },
-				{ property: "og:description", content: meta.description },
-				{ property: "og:url", content: url },
-				{ property: "og:image", content: ogImage },
-				{ property: "og:image:alt", content: meta.title },
-				{ property: "article:published_time", content: meta.publishedAt },
-				{ property: "article:modified_time", content: meta.updatedAt },
-				{ name: "twitter:title", content: meta.title },
-				{ name: "twitter:description", content: meta.description },
-				{ name: "twitter:image", content: ogImage },
-				{ name: "twitter:image:alt", content: meta.title },
-			],
-			links: [{ rel: "canonical", href: url }],
-			scripts: [
-				{
-					type: "application/ld+json",
-					children: JSON.stringify([
-						{
-							"@context": "https://schema.org",
-							"@type": "TechArticle",
-							headline: meta.title,
-							description: meta.description,
-							datePublished: meta.publishedAt,
-							dateModified: meta.updatedAt,
-							image: ogImage,
-							mainEntityOfPage: url,
-							author: {
-								"@type": "Person",
-								name: "Philip Poloczek",
-								url: "https://github.com/peetzweg",
-							},
-							publisher: {
-								"@type": "Organization",
-								name: "Commit History",
-								url: SITE,
-								logo: {
-									"@type": "ImageObject",
-									url: `${SITE}/crown-180.png`,
-								},
-							},
-						},
-						{
-							"@context": "https://schema.org",
-							"@type": "BreadcrumbList",
-							itemListElement: [
-								{
-									"@type": "ListItem",
-									position: 1,
-									name: "Commit History",
-									item: SITE,
-								},
-								{
-									"@type": "ListItem",
-									position: 2,
-									name: "Metrics, explained",
-									item: `${SITE}/metrics/explained`,
-								},
-								{ "@type": "ListItem", position: 3, name: meta.title },
-							],
-						},
-					]),
-				},
-			],
-		};
-	},
-	component: ArticlePage,
 });
-
-function ArticlePage() {
-	const meta = Route.useLoaderData();
-	const Body = articleBody(meta.slug);
-	return (
-		<main className="mx-auto max-w-3xl px-6 py-12">
-			<nav aria-label="Breadcrumb">
-				<Link
-					to="/metrics/explained"
-					className="text-sm text-muted-foreground hover:text-foreground"
-				>
-					← metrics, explained
-				</Link>
-			</nav>
-			<article className="mt-6">
-				<header>
-					<h1 className="text-3xl font-bold leading-tight">{meta.title}</h1>
-					<p className="mt-3 text-muted-foreground">{meta.description}</p>
-					<p className="mt-2 text-xs text-muted-foreground">
-						Updated{" "}
-						<time dateTime={meta.updatedAt}>{formatDate(meta.updatedAt)}</time>
-					</p>
-				</header>
-				<div className="prose prose-neutral mt-8 max-w-none">
-					<Suspense fallback={null}>
-						<Body components={mdxComponents} />
-					</Suspense>
-				</div>
-			</article>
-		</main>
-	);
-}

--- a/src/routes/metrics.explained.tsx
+++ b/src/routes/metrics.explained.tsx
@@ -1,87 +1,12 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { articles } from "#/lib/content";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-const SITE = "https://commit-history.com";
-const TITLE = "GitHub contribution metrics, explained";
-const DESCRIPTION =
-	"What the numbers on a commit-history.com profile actually mean: commits, pull requests, reviews, repositories, and private contributions — in detail.";
-// URL policy: content sections never own their bare prefix — /metrics (one segment)
-// falls through to the $user route, so the GitHub account "metrics" isn't locked out
-// (same reason bare /embed doesn't exist). The hub lives at /metrics/explained; the
-// slug "explained" is therefore reserved (don't create src/content/metrics/explained.mdx).
-const URL = `${SITE}/metrics/explained`;
-const OG_IMAGE = `${SITE}/og/metrics/explained.png`;
-
+/**
+ * Permanent redirect from the old hub URL to /-/metrics. "explained" only existed because
+ * content sections couldn't own their bare prefix outside the reserved /-/ namespace;
+ * inside it the hub lives at the prefix directly. Static, so it outranks /metrics/$slug.
+ */
 export const Route = createFileRoute("/metrics/explained")({
-	head: () => ({
-		meta: [
-			{ title: `${TITLE} · Commit History` },
-			{ name: "description", content: DESCRIPTION },
-			{ property: "og:title", content: TITLE },
-			{ property: "og:description", content: DESCRIPTION },
-			{ property: "og:url", content: URL },
-			{ property: "og:image", content: OG_IMAGE },
-			{ property: "og:image:alt", content: TITLE },
-			{ name: "twitter:title", content: TITLE },
-			{ name: "twitter:description", content: DESCRIPTION },
-			{ name: "twitter:image", content: OG_IMAGE },
-			{ name: "twitter:image:alt", content: TITLE },
-		],
-		links: [{ rel: "canonical", href: URL }],
-		scripts: [
-			{
-				type: "application/ld+json",
-				children: JSON.stringify({
-					"@context": "https://schema.org",
-					"@type": "CollectionPage",
-					name: TITLE,
-					description: DESCRIPTION,
-					url: URL,
-					mainEntity: {
-						"@type": "ItemList",
-						itemListElement: articles.map((a, i) => ({
-							"@type": "ListItem",
-							position: i + 1,
-							name: a.title,
-							url: `${SITE}/metrics/${a.slug}`,
-						})),
-					},
-				}),
-			},
-		],
-	}),
-	component: MetricsIndex,
+	beforeLoad: () => {
+		throw redirect({ to: "/-/metrics", statusCode: 301 });
+	},
 });
-
-function MetricsIndex() {
-	return (
-		<main className="mx-auto max-w-3xl px-6 py-12">
-			<Link
-				to="/"
-				className="text-sm text-muted-foreground hover:text-foreground"
-			>
-				← commit-history
-			</Link>
-			<h1 className="mt-6 text-3xl font-bold leading-tight">{TITLE}</h1>
-			<p className="mt-3 text-muted-foreground">{DESCRIPTION}</p>
-			<ul className="mt-10 flex flex-col divide-y divide-border">
-				{articles.map((a) => (
-					<li key={a.slug} className="py-6 first:pt-0 last:pb-0">
-						<Link
-							to="/metrics/$slug"
-							params={{ slug: a.slug }}
-							className="group block"
-						>
-							<h2 className="text-lg font-semibold group-hover:underline">
-								{a.title}
-							</h2>
-							<p className="mt-1 text-sm text-muted-foreground">
-								{a.description}
-							</p>
-						</Link>
-					</li>
-				))}
-			</ul>
-		</main>
-	);
-}

--- a/src/routes/organizations.$slug.tsx
+++ b/src/routes/organizations.$slug.tsx
@@ -1,145 +1,17 @@
-import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { type ComponentType, lazy, Suspense } from "react";
-import { mdxComponents } from "#/components/MdxComponents";
-import { getOrgArticleMeta, loadOrgArticle } from "#/lib/content";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 /**
- * Organization-context explainer articles (src/content/organizations/*.mdx) — the org twins of
- * the /metrics/$slug pages. A separate collection on purpose: organization numbers are org-scoped
- * and public-member-only, so their definitions differ from the individual metric explainers.
- * Same URL policy as /metrics: bare /organizations stays a valid GitHub login on the $user route.
- * No per-article OG images (yet) — these fall back to the site-wide card.
- * Old /company/<slug> URLs 301 here via the company.$slug route.
+ * Permanent redirect from the old /organizations/<slug> explainer URLs to their new home
+ * under the reserved /-/ namespace. Kept as a thin route so existing links and
+ * search-engine results don't 404. Bare /organizations still falls through to the $user
+ * route as a valid GitHub login.
  */
-
-const SITE = "https://commit-history.com";
-
-// One stable lazy component per slug — created on demand, cached at module level so
-// re-renders don't recreate (and thereby remount) the article body.
-type BodyComponent = ComponentType<{ components?: typeof mdxComponents }>;
-const bodies = new Map<string, BodyComponent>();
-function articleBody(slug: string): BodyComponent {
-	let body = bodies.get(slug);
-	if (!body) {
-		body = lazy(() => {
-			const load = loadOrgArticle(slug);
-			if (!load) throw notFound();
-			return load;
-		});
-		bodies.set(slug, body);
-	}
-	return body;
-}
-
-function formatDate(iso: string) {
-	return new Date(iso).toLocaleDateString("en-US", {
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-	});
-}
-
 export const Route = createFileRoute("/organizations/$slug")({
-	loader: ({ params }) => {
-		const meta = getOrgArticleMeta(params.slug);
-		if (!meta) throw notFound();
-		return meta;
+	beforeLoad: ({ params }) => {
+		throw redirect({
+			to: "/-/organizations/$slug",
+			params: { slug: params.slug },
+			statusCode: 301,
+		});
 	},
-	head: ({ params }) => {
-		const meta = getOrgArticleMeta(params.slug);
-		if (!meta) return {};
-		const url = `${SITE}/organizations/${meta.slug}`;
-		return {
-			meta: [
-				{ title: `${meta.title} · Commit History` },
-				{ name: "description", content: meta.description },
-				{ property: "og:type", content: "article" },
-				{ property: "og:title", content: meta.title },
-				{ property: "og:description", content: meta.description },
-				{ property: "og:url", content: url },
-				{ property: "article:published_time", content: meta.publishedAt },
-				{ property: "article:modified_time", content: meta.updatedAt },
-				{ name: "twitter:title", content: meta.title },
-				{ name: "twitter:description", content: meta.description },
-			],
-			links: [{ rel: "canonical", href: url }],
-			scripts: [
-				{
-					type: "application/ld+json",
-					children: JSON.stringify([
-						{
-							"@context": "https://schema.org",
-							"@type": "TechArticle",
-							headline: meta.title,
-							description: meta.description,
-							datePublished: meta.publishedAt,
-							dateModified: meta.updatedAt,
-							mainEntityOfPage: url,
-							author: {
-								"@type": "Person",
-								name: "Philip Poloczek",
-								url: "https://github.com/peetzweg",
-							},
-							publisher: {
-								"@type": "Organization",
-								name: "Commit History",
-								url: SITE,
-								logo: {
-									"@type": "ImageObject",
-									url: `${SITE}/crown-180.png`,
-								},
-							},
-						},
-						{
-							"@context": "https://schema.org",
-							"@type": "BreadcrumbList",
-							itemListElement: [
-								{
-									"@type": "ListItem",
-									position: 1,
-									name: "Commit History",
-									item: SITE,
-								},
-								{ "@type": "ListItem", position: 2, name: meta.title },
-							],
-						},
-					]),
-				},
-			],
-		};
-	},
-	component: ArticlePage,
 });
-
-function ArticlePage() {
-	const meta = Route.useLoaderData();
-	const Body = articleBody(meta.slug);
-	return (
-		<main className="mx-auto max-w-3xl px-6 py-12">
-			<nav aria-label="Breadcrumb">
-				<Link
-					to="/"
-					search={{ kind: "org" }}
-					className="text-sm text-muted-foreground hover:text-foreground"
-				>
-					← organization leaderboard
-				</Link>
-			</nav>
-			<article className="mt-6">
-				<header>
-					<h1 className="text-3xl font-bold leading-tight">{meta.title}</h1>
-					<p className="mt-3 text-muted-foreground">{meta.description}</p>
-					<p className="mt-2 text-xs text-muted-foreground">
-						Updated{" "}
-						<time dateTime={meta.updatedAt}>{formatDate(meta.updatedAt)}</time>
-					</p>
-				</header>
-				<div className="prose prose-neutral mt-8 max-w-none">
-					<Suspense fallback={null}>
-						<Body components={mdxComponents} />
-					</Suspense>
-				</div>
-			</article>
-		</main>
-	);
-}

--- a/src/routes/sponsoring.tsx
+++ b/src/routes/sponsoring.tsx
@@ -1,120 +1,12 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
-const SITE = "https://commit-history.com";
-const TITLE = "Sponsoring commit-history.com";
-const DESCRIPTION =
-	"Put your product in front of a developer-first audience: 15k unique visitors and 57k page views in under a month, in a sponsor slot on both leaderboards.";
-// URL policy exception: single-segment paths normally fall through to the $user route so no
-// GitHub username is locked out (see vite.config.ts). "sponsoring" is safe to claim — GitHub
-// has no such account and sponsor-related names are reserved by GitHub itself.
-const URL = `${SITE}/sponsoring`;
-
-const CONTACT = "phil.czek@gmail.com";
-const MAILTO = `mailto:${CONTACT}?subject=${encodeURIComponent("Sponsoring commit-history.com")}`;
-
-// Site analytics, collected since June 27, 2026. Update LAST_UPDATED when refreshing numbers.
-const LAST_UPDATED = "July 14, 2026";
-const STATS = [
-	{ value: "15k", label: "unique visitors" },
-	{ value: "57k", label: "page views" },
-	{ value: "1:32", label: "avg. visit duration" },
-	{ value: "38%", label: "bounce rate" },
-] as const;
-
+/**
+ * Permanent redirect from the old single-segment /sponsoring URL to its home under the
+ * reserved /-/ namespace. The old URL was a deliberate exception to the "single segments
+ * belong to the $user route" policy; the namespace move retires that exception.
+ */
 export const Route = createFileRoute("/sponsoring")({
-	head: () => ({
-		meta: [
-			{ title: `${TITLE} · Commit History` },
-			{ name: "description", content: DESCRIPTION },
-			{ property: "og:title", content: TITLE },
-			{ property: "og:description", content: DESCRIPTION },
-			{ property: "og:url", content: URL },
-			{ name: "twitter:title", content: TITLE },
-			{ name: "twitter:description", content: DESCRIPTION },
-		],
-		links: [{ rel: "canonical", href: URL }],
-	}),
-	component: SponsoringPage,
+	beforeLoad: () => {
+		throw redirect({ to: "/-/sponsoring", statusCode: 301 });
+	},
 });
-
-function SponsoringPage() {
-	return (
-		<main className="mx-auto max-w-3xl px-6 py-12">
-			<Link
-				to="/"
-				className="text-sm text-muted-foreground hover:text-foreground"
-			>
-				← commit-history
-			</Link>
-			<h1 className="mt-6 text-3xl font-bold leading-tight">
-				Sponsoring{" "}
-				<span className="font-hand font-normal text-primary">
-					commit-history.com
-				</span>
-			</h1>
-			<p className="mt-3 text-muted-foreground">
-				One sponsor slot, rendered like a leaderboard entry, in 5th place of
-				both the developer and the organization leaderboard — the first thing
-				people scroll past on every visit.
-			</p>
-
-			{/* CTA up top: interested sponsors shouldn't have to scroll to find the contact. */}
-			<div className="mt-6 flex flex-wrap items-center gap-3">
-				<a href={MAILTO} className="btn-primary">
-					Get in touch
-				</a>
-				<span className="text-sm text-muted-foreground">{CONTACT}</span>
-			</div>
-
-			<h2 className="mt-12 text-xl font-semibold">The numbers</h2>
-			<p className="mt-2 text-muted-foreground">
-				We’ve been collecting analytics since June 27, 2026 — so in not even a
-				month (last updated {LAST_UPDATED}):
-			</p>
-			<dl className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
-				{STATS.map((s) => (
-					<div key={s.label} className="rounded-md border p-4 text-center">
-						<dd className="text-2xl font-bold tabular-nums">{s.value}</dd>
-						<dt className="mt-1 text-xs text-muted-foreground">{s.label}</dt>
-					</div>
-				))}
-			</dl>
-
-			<h2 className="mt-12 text-xl font-semibold">The audience</h2>
-			<p className="mt-2 text-muted-foreground">
-				Mainly developers — people plotting their own commit history, comparing
-				themselves on the leaderboards, and sharing profiles with each other. A
-				visit duration of a minute and a half and a bounce rate as low as 38%
-				mean visitors actually stick around and explore. Beyond developers, the
-				leaderboards also draw companies and recruiters looking for talent — an
-				audience that’s hard to reach anywhere else.
-			</p>
-
-			<h2 className="mt-12 text-xl font-semibold">The slot</h2>
-			<p className="mt-2 text-muted-foreground">
-				Your logo, product name, and a one-line tagline, clearly disclosed as
-				sponsored, linking out to your site. It sits in 5th place of the{" "}
-				<Link to="/" className="underline hover:text-foreground">
-					developer leaderboard
-				</Link>{" "}
-				and the{" "}
-				<Link
-					to="/"
-					search={{ kind: "org" }}
-					className="underline hover:text-foreground"
-				>
-					organization leaderboard
-				</Link>
-				, so it’s on screen right where everyone looks.
-			</p>
-
-			<p className="mt-12 text-muted-foreground">
-				Interested?{" "}
-				<a href={MAILTO} className="font-medium text-foreground underline">
-					Send a mail to {CONTACT}
-				</a>{" "}
-				and we’ll figure out the rest.
-			</p>
-		</main>
-	);
-}

--- a/src/routes/sponsoring.tsx
+++ b/src/routes/sponsoring.tsx
@@ -1,0 +1,120 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+const SITE = "https://commit-history.com";
+const TITLE = "Sponsoring commit-history.com";
+const DESCRIPTION =
+	"Put your product in front of a developer-first audience: 15k unique visitors and 57k page views in under a month, in a sponsor slot on both leaderboards.";
+// URL policy exception: single-segment paths normally fall through to the $user route so no
+// GitHub username is locked out (see vite.config.ts). "sponsoring" is safe to claim — GitHub
+// has no such account and sponsor-related names are reserved by GitHub itself.
+const URL = `${SITE}/sponsoring`;
+
+const CONTACT = "phil.czek@gmail.com";
+const MAILTO = `mailto:${CONTACT}?subject=${encodeURIComponent("Sponsoring commit-history.com")}`;
+
+// Site analytics, collected since June 27, 2026. Update LAST_UPDATED when refreshing numbers.
+const LAST_UPDATED = "July 14, 2026";
+const STATS = [
+	{ value: "15k", label: "unique visitors" },
+	{ value: "57k", label: "page views" },
+	{ value: "1:32", label: "avg. visit duration" },
+	{ value: "38%", label: "bounce rate" },
+] as const;
+
+export const Route = createFileRoute("/sponsoring")({
+	head: () => ({
+		meta: [
+			{ title: `${TITLE} · Commit History` },
+			{ name: "description", content: DESCRIPTION },
+			{ property: "og:title", content: TITLE },
+			{ property: "og:description", content: DESCRIPTION },
+			{ property: "og:url", content: URL },
+			{ name: "twitter:title", content: TITLE },
+			{ name: "twitter:description", content: DESCRIPTION },
+		],
+		links: [{ rel: "canonical", href: URL }],
+	}),
+	component: SponsoringPage,
+});
+
+function SponsoringPage() {
+	return (
+		<main className="mx-auto max-w-3xl px-6 py-12">
+			<Link
+				to="/"
+				className="text-sm text-muted-foreground hover:text-foreground"
+			>
+				← commit-history
+			</Link>
+			<h1 className="mt-6 text-3xl font-bold leading-tight">
+				Sponsoring{" "}
+				<span className="font-hand font-normal text-primary">
+					commit-history.com
+				</span>
+			</h1>
+			<p className="mt-3 text-muted-foreground">
+				One sponsor slot, rendered like a leaderboard entry, in 5th place of
+				both the developer and the organization leaderboard — the first thing
+				people scroll past on every visit.
+			</p>
+
+			{/* CTA up top: interested sponsors shouldn't have to scroll to find the contact. */}
+			<div className="mt-6 flex flex-wrap items-center gap-3">
+				<a href={MAILTO} className="btn-primary">
+					Get in touch
+				</a>
+				<span className="text-sm text-muted-foreground">{CONTACT}</span>
+			</div>
+
+			<h2 className="mt-12 text-xl font-semibold">The numbers</h2>
+			<p className="mt-2 text-muted-foreground">
+				We’ve been collecting analytics since June 27, 2026 — so in not even a
+				month (last updated {LAST_UPDATED}):
+			</p>
+			<dl className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+				{STATS.map((s) => (
+					<div key={s.label} className="rounded-md border p-4 text-center">
+						<dd className="text-2xl font-bold tabular-nums">{s.value}</dd>
+						<dt className="mt-1 text-xs text-muted-foreground">{s.label}</dt>
+					</div>
+				))}
+			</dl>
+
+			<h2 className="mt-12 text-xl font-semibold">The audience</h2>
+			<p className="mt-2 text-muted-foreground">
+				Mainly developers — people plotting their own commit history, comparing
+				themselves on the leaderboards, and sharing profiles with each other. A
+				visit duration of a minute and a half and a bounce rate as low as 38%
+				mean visitors actually stick around and explore. Beyond developers, the
+				leaderboards also draw companies and recruiters looking for talent — an
+				audience that’s hard to reach anywhere else.
+			</p>
+
+			<h2 className="mt-12 text-xl font-semibold">The slot</h2>
+			<p className="mt-2 text-muted-foreground">
+				Your logo, product name, and a one-line tagline, clearly disclosed as
+				sponsored, linking out to your site. It sits in 5th place of the{" "}
+				<Link to="/" className="underline hover:text-foreground">
+					developer leaderboard
+				</Link>{" "}
+				and the{" "}
+				<Link
+					to="/"
+					search={{ kind: "org" }}
+					className="underline hover:text-foreground"
+				>
+					organization leaderboard
+				</Link>
+				, so it’s on screen right where everyone looks.
+			</p>
+
+			<p className="mt-12 text-muted-foreground">
+				Interested?{" "}
+				<a href={MAILTO} className="font-medium text-foreground underline">
+					Send a mail to {CONTACT}
+				</a>{" "}
+				and we’ll figure out the rest.
+			</p>
+		</main>
+	);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,14 @@ const config = defineConfig({
 					prerender: { enabled: true, crawlLinks: false },
 					sitemap: { changefreq: "monthly", priority: 0.8 },
 				},
+				// The sponsor pitch page — static content, so prerendered like the explainers.
+				// Single-segment exception to the bare-prefix rule: no GitHub account
+				// "sponsoring" exists (GitHub reserves sponsor-related names).
+				{
+					path: "/sponsoring",
+					prerender: { enabled: true, crawlLinks: false },
+					sitemap: { changefreq: "monthly", priority: 0.5 },
+				},
 				...metricSlugs.map((slug) => ({
 					path: `/metrics/${slug}`,
 					prerender: { enabled: true, crawlLinks: false },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import { defineConfig } from "vite";
 
-// Static MDX articles: every src/content/<collection>/<slug>.mdx becomes /<collection>/<slug>.
+// Static MDX articles: every src/content/<collection>/<slug>.mdx becomes /-/<collection>/<slug>.
 // Listed here so the build prerenders them to plain HTML (no SSR invocation per crawl —
 // see #70's cost concern) and emits them into the generated sitemap.
 function contentSlugs(collection: string): string[] {
@@ -57,30 +57,31 @@ const config = defineConfig({
 				// `crawlLinks` (default true) must be off, or in-article links to live pages
 				// (e.g. /torvalds,gaearon) get baked into stale static HTML at build time.
 				//
-				// The hub is /metrics/explained, NOT bare /metrics: content sections never
-				// own their bare prefix, so single-segment paths keep falling through to
-				// the $user route and no GitHub username is ever locked out.
+				// All editorial content lives under the reserved /-/ namespace: "-" can never
+				// be a GitHub login (no leading/trailing hyphens), so nothing here can shadow
+				// the single-segment $user route — and inside the namespace sections may own
+				// their bare prefix, so the metrics hub is /-/metrics directly. Old URLs
+				// (/sponsoring, /metrics/*, /organizations/*) 301 via thin redirect routes
+				// and are deliberately absent from this list.
 				{
-					path: "/metrics/explained",
+					path: "/-/metrics",
 					prerender: { enabled: true, crawlLinks: false },
 					sitemap: { changefreq: "monthly", priority: 0.8 },
 				},
 				// The sponsor pitch page — static content, so prerendered like the explainers.
-				// Single-segment exception to the bare-prefix rule: no GitHub account
-				// "sponsoring" exists (GitHub reserves sponsor-related names).
 				{
-					path: "/sponsoring",
+					path: "/-/sponsoring",
 					prerender: { enabled: true, crawlLinks: false },
 					sitemap: { changefreq: "monthly", priority: 0.5 },
 				},
 				...metricSlugs.map((slug) => ({
-					path: `/metrics/${slug}`,
+					path: `/-/metrics/${slug}`,
 					prerender: { enabled: true, crawlLinks: false },
 					sitemap: { changefreq: "monthly" as const, priority: 0.7 },
 				})),
-				// Organization-context explainers — same policy (bare /organizations stays a login).
+				// Organization-context explainers.
 				...orgSlugs.map((slug) => ({
-					path: `/organizations/${slug}`,
+					path: `/-/organizations/${slug}`,
 					prerender: { enabled: true, crawlLinks: false },
 					sitemap: { changefreq: "monthly" as const, priority: 0.7 },
 				})),


### PR DESCRIPTION
Adds a sponsor slot to the organization board, a `/-/sponsoring` pitch page, and moves all editorial pages under a reserved `/-/` URL namespace. The Rebates.ai ad on the developer board stays as is.

**Why:** The org board had no sponsor slot; until someone books it, the slot should sell itself. And editorial pages were squatting in the root path that belongs to GitHub logins — every new page reopened the "is this word a safe username?" debate.

**How:** The org board gets the same after-rank-5 row as the developer board, rendered as `EmptySponsorRow` (dashed placeholder, "This sponsor slot is empty") linking to the new prerendered sponsoring pitch page. Judgment call: all content now lives under `/-/` — a bare hyphen can never be a GitHub login, so nothing there can ever shadow the `$user` route (GitLab uses the same trick). That also lets the metrics hub own its bare prefix: `/metrics/explained` → `/-/metrics`. Old URLs 301 via thin redirect routes (same pattern as `/company/*`); sitemap, canonicals, breadcrumbs, and all internal links updated.

Typecheck, biome, tests and a full prerender build pass; redirects and new pages verified against the built server.