### PR TITLE
Rename backup dumps neon-backup-* → db-backup-*

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Dump the Neon production database to a plain-SQL file under backups/.
+# Dump the production database (whatever DATABASE_URL points at) to a plain-SQL file under backups/.
 #
-#   pnpm backup            # -> backups/neon-backup-YYYYMMDD-HHMMSS.sql
+#   pnpm backup            # -> backups/db-backup-YYYYMMDD-HHMMSS.sql
 #
 # Reads DATABASE_URL from .env. The backups/ dir is gitignored — dumps never leave
 # your machine. Requires pg_dump; on macOS this ships with Homebrew's libpq
@@ -35,7 +35,7 @@ if [[ -z "${DATABASE_URL:-}" ]]; then
 fi
 
 mkdir -p backups
-OUT="backups/neon-backup-$(date +%Y%m%d-%H%M%S).sql"
+OUT="backups/db-backup-$(date +%Y%m%d-%H%M%S).sql"
 
 echo "Dumping with $("$PG_DUMP" --version) -> $OUT"
 "$PG_DUMP" "$DATABASE_URL" --no-owner --no-privileges --file "$OUT"


### PR DESCRIPTION
Tiny cleanup after #128: the dump script is a plain `pg_dump` of whatever `DATABASE_URL` points at, and post-cutover (peetzweg/devops#4) that's the self-hosted Postgres — the `neon-` prefix is misleading.

Doubles as the canary for the preview-scoped `DATABASE_URL`: this PR's preview should come up against the **internal Coolify PG** (rehearsal data).