### PR TITLE
Fix pnpm dev crash: exclude @resvg/resvg-js from dep optimization

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,12 @@ const orgSlugs = contentSlugs("organizations");
 
 const config = defineConfig({
 	resolve: { tsconfigPaths: true },
+	// @resvg/resvg-js is a native Node addon (.node binary). The dev-mode dependency
+	// optimizer scans it via the OG route's imports and crashes trying to parse the
+	// binary as JS (UNLOADABLE_DEPENDENCY). It only ever runs in server handlers, so
+	// keep it out of prebundling; prod builds were never affected (handlers are
+	// tree-shaken out of the client there).
+	optimizeDeps: { exclude: ["@resvg/resvg-js"] },
 	plugins: [
 		devtools(),
 		tailwindcss(),


### PR DESCRIPTION
`pnpm dev` has been unable to start since the dynamic OG images (#111 merge): vite's client dep optimizer follows the OG route's imports into `@resvg/resvg-js` and rolldown crashes parsing the native `.node` binary as JS.

**Why:** the addon only ever executes in server handlers — dev's scanner just doesn't know that; prod builds tree-shake the handler imports and were never affected. Same import-graph disease as the postgres.js client leak in #128, dev-only variant.

**How:** `optimizeDeps.exclude` in vite.config. Verified: dev boots clean, homepage queries work, and `/og/user/peetzweg` renders a real PNG in dev (the feature itself is untouched).