### PR TITLE
Noindex embed/OG images, lowercase canonical user URLs

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
@@ -12,6 +12,7 @@
 			"**/.vscode/**/*",
 			"**/index.html",
 			"**/vite.config.ts",
+			"!**/.output",
 			"!**/src/routeTree.gen.ts",
 			"!**/src/styles.css"
 		]

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -77,10 +77,12 @@ export const Route = createFileRoute("/$user")({
 			: logins.length > 1
 				? `Compare the cumulative GitHub commits of ${logins.join(", ")} over time.`
 				: `${logins[0]}’s cumulative GitHub commits over their whole lifetime.`;
-		const url = `https://commit-history.com/${logins.join(",")}`;
+		// GitHub logins are case-insensitive, so /PeetZweg and /peetzweg serve the same page —
+		// lowercase the canonical (and og:url) so search engines fold case variants into one URL.
+		const url = `https://commit-history.com/${logins.join(",").toLowerCase()}`;
 		// A single login gets a dynamic card (see src/routes/og.$kind.$login.tsx); a comparison
 		// keeps the site-wide card (the root default) — a compare card can follow later.
-		const single = logins.length === 1 ? logins[0] : null;
+		const single = logins.length === 1 ? logins[0].toLowerCase() : null;
 		// Carry the selected chart metric into the user card so a shared `?metric=prs` view shows
 		// that metric's amount + rank. Orgs aren't metric-aware (they rank on commits only).
 		const metric = isOrg ? undefined : match.search.metric;

--- a/src/routes/embed.$user.tsx
+++ b/src/routes/embed.$user.tsx
@@ -28,6 +28,9 @@ export const Route = createFileRoute("/embed/$user")({
 					return new Response(renderChartSvg(history, theme), {
 						headers: {
 							"content-type": "image/svg+xml; charset=utf-8",
+							// Badge image, not a page — keep it (and its ?theme= variants) out of the
+							// search index so it never competes with the /$user profile page.
+							"x-robots-tag": "noindex",
 							// Long-ish cache: our data is monthly and the cache layer keeps it fresh.
 							"cache-control": "public, max-age=3600, s-maxage=3600",
 							// `durable` = one shared cache entry across all Netlify edge nodes instead of
@@ -44,6 +47,7 @@ export const Route = createFileRoute("/embed/$user")({
 					return new Response(renderMessageSvg(message, theme), {
 						headers: {
 							"content-type": "image/svg+xml; charset=utf-8",
+							"x-robots-tag": "noindex",
 							"cache-control": "public, max-age=60",
 							// Short durable cache so a rate-limit storm doesn't hammer the function,
 							// while real data still replaces the message card quickly.

--- a/src/routes/og.$kind.$login.tsx
+++ b/src/routes/og.$kind.$login.tsx
@@ -37,6 +37,9 @@ async function fetchAvatar(url: string | null): Promise<string | null> {
 
 const PNG_HEADERS = {
 	"content-type": "image/png",
+	// Share-card image, not a page — keep it (and its ?metric= variants) out of the search
+	// index so it never competes with the /$user profile page.
+	"x-robots-tag": "noindex",
 	"cache-control": "public, max-age=3600, s-maxage=3600",
 	// `durable` = one shared cache entry across all Netlify edge nodes (see /embed), so scraper
 	// traffic stops re-invoking the render function. Netlify-only; other CDNs ignore it.
@@ -50,6 +53,7 @@ function fallback(request: Request): Response {
 		status: 302,
 		headers: {
 			location: new URL("/og.png", request.url).toString(),
+			"x-robots-tag": "noindex",
 			"cache-control": "public, max-age=60",
 			"netlify-cdn-cache-control": "public, durable, s-maxage=60",
 		},


### PR DESCRIPTION
Google Search Console reported "Duplicate without user-selected canonical" pages after adding the property.

**Why:** `/embed/*` and `/og/*` are crawlable image endpoints with no indexing signal, so Google treats their `?theme=`/`?metric=` variants as duplicate pages and picks winners itself. Case variants of profile URLs (`/PeetZweg` vs `/peetzweg`) also each declared themselves canonical.

**How:** the image routes now send `X-Robots-Tag: noindex` (they're badges/share cards, not pages — the profile keeps the ranking), and the `$user` route lowercases its canonical/`og:url`/`og:image` URLs since GitHub logins are case-insensitive. Display strings keep their casing. Judgment call: lowercase rather than GitHub's canonical casing, so the canonical is stable even while a profile is still building.

Drive-by second commit: `pnpm check` was broken repo-wide (biome was linting `.output/` build artifacts and the config schema lagged the installed CLI) — fixed so the repo lints clean again.

Verified on a local dev server: headers present on both embed responses and the OG fallback, canonical renders lowercased. Biome, tsc and tests pass.