### PR TITLE
Add /-/<slug> ranking posts (7 metrics) + metric-aware embed charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "biome format",
     "lint": "biome lint",
     "check": "biome check",
+    "check:posts": "bun scripts/check-post-people.ts",
     "suspend": "bun scripts/suspend.ts",
     "refresh": "bun scripts/refresh.ts",
     "backfill": "bun scripts/backfill-contributions.ts",

--- a/scripts/check-post-people.ts
+++ b/scripts/check-post-people.ts
@@ -4,10 +4,11 @@
  * snapshots — a person suspended after publication stays frozen in the article and its ItemList
  * structured data unless we catch it — so run this before refreshing or on a schedule.
  *
- * Run with bun, which auto-loads the local `.env` (point DATABASE_URL at the DB you want to check;
- * see CLAUDE.md — normally the dev copy):
+ * IMPORTANT: point DATABASE_URL at PRODUCTION, not the dev copy. Suspensions are applied to prod
+ * (via `pnpm suspend`); the dev DB is a periodic snapshot that lags moderation, so checking it
+ * gives false "all active" results. Run with bun (auto-loads `.env`); override the DB if needed:
  *
- *   bun run check:posts
+ *   DATABASE_URL=<prod-url> bun run check:posts
  *
  * Exits non-zero if any featured login is suspended or missing, listing which post to fix.
  */

--- a/scripts/check-post-people.ts
+++ b/scripts/check-post-people.ts
@@ -1,0 +1,77 @@
+/**
+ * Guard for the ranking posts (src/content/posts/*.mdx): make sure nobody listed in a
+ * "top 10" article has since been suspended (gamed/under-investigation). Those posts are static
+ * snapshots — a person suspended after publication stays frozen in the article and its ItemList
+ * structured data unless we catch it — so run this before refreshing or on a schedule.
+ *
+ * Run with bun, which auto-loads the local `.env` (point DATABASE_URL at the DB you want to check;
+ * see CLAUDE.md — normally the dev copy):
+ *
+ *   bun run check:posts
+ *
+ * Exits non-zero if any featured login is suspended or missing, listing which post to fix.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { parse } from "yaml";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) throw new Error("DATABASE_URL is required (add it to .env)");
+
+const postsDir = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"../src/content/posts",
+);
+
+interface PostPerson {
+	login: string;
+	name: string;
+}
+
+// Collect (post slug, login) pairs from every post's `people` frontmatter.
+const entries: { slug: string; login: string }[] = [];
+for (const file of readdirSync(postsDir)) {
+	if (!file.endsWith(".mdx")) continue;
+	const source = readFileSync(join(postsDir, file), "utf8");
+	const match = source.match(/^---\n([\s\S]*?)\n---/);
+	if (!match) continue;
+	const fm = parse(match[1]) as { people?: PostPerson[] };
+	for (const p of fm.people ?? []) {
+		entries.push({ slug: file.replace(/\.mdx$/, ""), login: p.login });
+	}
+}
+
+if (entries.length === 0) {
+	console.log("No people found in any post — nothing to check.");
+	process.exit(0);
+}
+
+const sql = postgres(DATABASE_URL, { prepare: false });
+const ids = [...new Set(entries.map((e) => `user:${e.login.toLowerCase()}`))];
+const rows = await sql`
+	select id, login, suspended_at from entities where id = any(${ids})`;
+await sql.end();
+
+const byId = new Map(rows.map((r) => [r.id as string, r]));
+
+const problems: string[] = [];
+for (const { slug, login } of entries) {
+	const row = byId.get(`user:${login.toLowerCase()}`);
+	if (!row) {
+		problems.push(`${slug}: @${login} — NOT in the database`);
+	} else if (row.suspended_at) {
+		problems.push(`${slug}: @${login} — SUSPENDED (remove from the post)`);
+	}
+}
+
+if (problems.length > 0) {
+	console.error(`❌ ${problems.length} issue(s) in ranking posts:\n`);
+	for (const p of problems) console.error(`  ${p}`);
+	process.exit(1);
+}
+
+console.log(
+	`✅ All ${entries.length} featured accounts across the ranking posts are active.`,
+);

--- a/scripts/generate-og.ts
+++ b/scripts/generate-og.ts
@@ -25,7 +25,9 @@ import { boardCard, contentCard, renderPng } from "#/lib/og-card";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const contentDir = join(root, "src/content/metrics");
+const postsContentDir = join(root, "src/content/posts");
 const metricsOutDir = join(root, "public/og/metrics");
+const postsOutDir = join(root, "public/og/posts");
 const boardOutDir = join(root, "public/og/leaderboard");
 
 function write(path: string, png: Buffer, label: string) {
@@ -47,8 +49,8 @@ interface Frontmatter {
 	description: string;
 }
 
-function frontmatterOf(file: string): Frontmatter {
-	const source = readFileSync(join(contentDir, file), "utf8");
+function frontmatterOf(dir: string, file: string): Frontmatter {
+	const source = readFileSync(join(dir, file), "utf8");
 	const match = source.match(/^---\n([\s\S]*?)\n---/);
 	if (!match) throw new Error(`${file}: missing frontmatter`);
 	const fm = parse(match[1]) as Partial<Frontmatter>;
@@ -59,6 +61,7 @@ function frontmatterOf(file: string): Frontmatter {
 }
 
 mkdirSync(metricsOutDir, { recursive: true });
+mkdirSync(postsOutDir, { recursive: true });
 mkdirSync(boardOutDir, { recursive: true });
 
 // The /-/metrics hub itself — keep in sync with src/routes/[-].metrics.index.tsx.
@@ -71,8 +74,18 @@ await renderMetricsCard(
 
 for (const file of readdirSync(contentDir)) {
 	if (!file.endsWith(".mdx")) continue;
-	const { title, description } = frontmatterOf(file);
+	const { title, description } = frontmatterOf(contentDir, file);
 	await renderMetricsCard(file.replace(/\.mdx$/, ""), title, description);
+}
+
+// Standalone posts (/-/<slug>) — same card style; the kicker is just the site path.
+for (const file of readdirSync(postsContentDir)) {
+	if (!file.endsWith(".mdx")) continue;
+	const { title, description } = frontmatterOf(postsContentDir, file);
+	const slug = file.replace(/\.mdx$/, "");
+	// No section kicker — these live flat at the site root, so the wordmark stands alone.
+	const png = await renderPng(contentCard("", title, description));
+	write(join(postsOutDir, `${slug}.png`), png, `posts/${slug}.png`);
 }
 
 // The /-/sponsoring pitch card — keep in sync with src/routes/[-].sponsoring.tsx.

--- a/src/components/MdxComponents.tsx
+++ b/src/components/MdxComponents.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import type { MDXComponents } from "mdx/types";
 import type { ComponentProps } from "react";
+import { Person } from "#/components/Person";
 
 /**
  * Element overrides passed to every rendered MDX article.
@@ -32,6 +33,15 @@ function MdxAnchor({ href = "", children, ...rest }: ComponentProps<"a">) {
 	);
 }
 
+/** Article images (e.g. the /embed charts in ranking articles) load lazily — a listicle can
+ *  carry ten of them, and none should compete with the text for bandwidth. */
+function MdxImage({ alt = "", ...rest }: ComponentProps<"img">) {
+	return <img alt={alt} loading="lazy" decoding="async" {...rest} />;
+}
+
 export const mdxComponents: MDXComponents = {
 	a: MdxAnchor,
+	img: MdxImage,
+	// Custom block available to posts (e.g. the per-developer profile header in rankings).
+	Person,
 };

--- a/src/components/MdxComponents.tsx
+++ b/src/components/MdxComponents.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import type { MDXComponents } from "mdx/types";
 import type { ComponentProps } from "react";
 import { Person } from "#/components/Person";
+import { RankBoard } from "#/components/RankBoard";
 
 /**
  * Element overrides passed to every rendered MDX article.
@@ -42,6 +43,8 @@ function MdxImage({ alt = "", ...rest }: ComponentProps<"img">) {
 export const mdxComponents: MDXComponents = {
 	a: MdxAnchor,
 	img: MdxImage,
-	// Custom block available to posts (e.g. the per-developer profile header in rankings).
+	// Custom blocks available to posts: the per-developer profile header and the styled
+	// leaderboard that opens each ranking article (mirrors the homepage board).
 	Person,
+	RankBoard,
 };

--- a/src/components/MdxComponents.tsx
+++ b/src/components/MdxComponents.tsx
@@ -35,9 +35,23 @@ function MdxAnchor({ href = "", children, ...rest }: ComponentProps<"a">) {
 }
 
 /** Article images (e.g. the /embed charts in ranking articles) load lazily — a listicle can
- *  carry ten of them, and none should compete with the text for bandwidth. */
-function MdxImage({ alt = "", ...rest }: ComponentProps<"img">) {
-	return <img alt={alt} loading="lazy" decoding="async" {...rest} />;
+ *  carry ten of them, and none should compete with the text for bandwidth. The embed charts are
+ *  a fixed 800×400 SVG, so declare those intrinsic dimensions: the browser then reserves the
+ *  aspect ratio up front and the page doesn't shift as the charts stream in (avoids CLS). */
+function MdxImage({ alt = "", src, ...rest }: ComponentProps<"img">) {
+	const isChart = typeof src === "string" && src.includes("/embed/");
+	return (
+		<img
+			src={src}
+			alt={alt}
+			loading="lazy"
+			decoding="async"
+			{...(isChart
+				? { width: 800, height: 400, className: "h-auto w-full" }
+				: {})}
+			{...rest}
+		/>
+	);
 }
 
 export const mdxComponents: MDXComponents = {

--- a/src/components/Person.tsx
+++ b/src/components/Person.tsx
@@ -2,21 +2,15 @@ import { Link } from "@tanstack/react-router";
 
 /**
  * Compact profile header for a developer inside a post — avatar, handle linking to their
- * commit-history profile, a follower/commit stat line, and a link out to GitHub. Rendered above
- * each person's chart in ranking articles (used from MDX via the shared component map).
+ * commit-history profile, a free-form stat line, and a link out to GitHub. Rendered above each
+ * person's chart in ranking articles (used from MDX via the shared component map).
  *
- * The avatar comes straight from github.com/<login>.png (a stable public redirect to the CDN
- * avatar — no API call, no token). `not-prose` keeps the typography wrapper from restyling it.
+ * `stats` is authored per post so each ranking can lead with its own metric, e.g.
+ * "1.78M commits · Arch Linux" or "312k followers · 35.7k commits". The avatar comes straight
+ * from github.com/<login>.png (a stable public redirect to the CDN avatar — no API call, no
+ * token). `not-prose` keeps the typography wrapper from restyling it.
  */
-export function Person({
-	login,
-	followers,
-	commits,
-}: {
-	login: string;
-	followers: string;
-	commits: string;
-}) {
+export function Person({ login, stats }: { login: string; stats: string }) {
 	return (
 		<div className="not-prose my-5 flex items-center gap-3">
 			<img
@@ -36,7 +30,7 @@ export function Person({
 					@{login}
 				</Link>
 				<div className="text-muted-foreground">
-					{followers} followers · {commits} commits ·{" "}
+					{stats} ·{" "}
 					<a
 						href={`https://github.com/${login}`}
 						target="_blank"

--- a/src/components/Person.tsx
+++ b/src/components/Person.tsx
@@ -1,0 +1,52 @@
+import { Link } from "@tanstack/react-router";
+
+/**
+ * Compact profile header for a developer inside a post — avatar, handle linking to their
+ * commit-history profile, a follower/commit stat line, and a link out to GitHub. Rendered above
+ * each person's chart in ranking articles (used from MDX via the shared component map).
+ *
+ * The avatar comes straight from github.com/<login>.png (a stable public redirect to the CDN
+ * avatar — no API call, no token). `not-prose` keeps the typography wrapper from restyling it.
+ */
+export function Person({
+	login,
+	followers,
+	commits,
+}: {
+	login: string;
+	followers: string;
+	commits: string;
+}) {
+	return (
+		<div className="not-prose my-5 flex items-center gap-3">
+			<img
+				src={`https://github.com/${login}.png?size=88`}
+				alt=""
+				width={44}
+				height={44}
+				loading="lazy"
+				className="h-11 w-11 shrink-0 rounded-full border border-border bg-muted"
+			/>
+			<div className="min-w-0 text-sm leading-tight">
+				<Link
+					to="/$user"
+					params={{ user: login }}
+					className="font-medium hover:underline"
+				>
+					@{login}
+				</Link>
+				<div className="text-muted-foreground">
+					{followers} followers · {commits} commits ·{" "}
+					<a
+						href={`https://github.com/${login}`}
+						target="_blank"
+						rel="noopener"
+						className="hover:text-foreground hover:underline"
+					>
+						GitHub ↗
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/RankBoard.tsx
+++ b/src/components/RankBoard.tsx
@@ -1,0 +1,70 @@
+import { Link } from "@tanstack/react-router";
+
+/**
+ * A static, presentational leaderboard used at the top of ranking posts. Deliberately mirrors the
+ * live board on the homepage (src/routes/index.tsx): crown for first place, avatar, rank, login
+ * with the display name beside it, and the metric value with its unit underneath. Unlike the live
+ * board it takes plain rows (no data fetching, no animation), so a post can render its snapshot as
+ * MDX. Avatars come from github.com/<login>.png — no API/token — matching <Person>.
+ */
+interface RankRow {
+	login: string;
+	name?: string;
+	/** Pre-formatted value shown big (e.g. "54.0k"); the post controls rounding. */
+	value: string;
+	/** Optional note shown where the name goes (e.g. "bot") when there is no person. */
+	note?: string;
+}
+
+export function RankBoard({ unit, rows }: { unit: string; rows: RankRow[] }) {
+	return (
+		<ol className="not-prose my-6 overflow-hidden rounded-xl border border-border">
+			{rows.map((u, i) => (
+				<li key={u.login} className="border-border border-b last:border-b-0">
+					<Link
+						to="/$user"
+						params={{ user: u.login }}
+						className="group flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-muted"
+					>
+						<span className="flex w-6 shrink-0 items-center justify-center text-sm tabular-nums text-muted-foreground">
+							{i === 0 ? (
+								<img src="/crown.svg" alt="1st place" className="h-4 w-auto" />
+							) : (
+								i + 1
+							)}
+						</span>
+						<img
+							src={`https://github.com/${u.login}.png?size=64`}
+							alt=""
+							width={32}
+							height={32}
+							loading="lazy"
+							className="h-8 w-8 shrink-0 rounded-full border border-border bg-muted"
+						/>
+						<span className="flex-1 truncate">
+							<span className="font-medium">{u.login}</span>
+							{u.name && (
+								<span className="ml-2 font-normal text-muted-foreground">
+									{u.name}
+								</span>
+							)}
+							{u.note && (
+								<span className="ml-2 font-normal text-muted-foreground">
+									({u.note})
+								</span>
+							)}
+						</span>
+						<span className="shrink-0 text-right">
+							<span className="block font-semibold tabular-nums">
+								{u.value}
+							</span>
+							<span className="block text-xs text-muted-foreground">
+								{unit}
+							</span>
+						</span>
+					</Link>
+				</li>
+			))}
+		</ol>
+	);
+}

--- a/src/content/metrics/commits.mdx
+++ b/src/content/metrics/commits.mdx
@@ -66,4 +66,6 @@ selected metric.
 Look up [your own profile](/) — or compare workflow extremes: try a
 squash-merge monorepo dweller against a granular open-source maintainer with
 a [side-by-side comparison](/torvalds,gaearon), and watch the slopes diverge
-for reasons that have little to do with effort.
+for reasons that have little to do with effort. Or meet the
+[developers with the most commits on GitHub](/-/most-commits-on-github): the
+top of the board is a lesson in this whole page, and it isn't who you'd guess.

--- a/src/content/metrics/followers.mdx
+++ b/src/content/metrics/followers.mdx
@@ -2,7 +2,7 @@
 title: "What GitHub follower counts mean (and don't)"
 description: "Followers measure reach, not contribution. Why follower counts and commit counts tell independent stories, and how the followers leaderboard works."
 publishedAt: "2026-07-07"
-updatedAt: "2026-07-07"
+updatedAt: "2026-07-19"
 order: 8
 ---
 
@@ -56,4 +56,6 @@ other is who keeps the code flowing. Having both on one site is the point.
 Open the [followers leaderboard](/?metric=followers), then flip the same
 board to Commits or Total and watch it reshuffle — or
 [look up someone famous](/) and check whether their fame is
-builder-shaped or broadcaster-shaped.
+builder-shaped or broadcaster-shaped. And if you'd rather be introduced:
+we profiled the [ten most-followed developers on the
+board](/-/most-followed-github-users), charts and all.

--- a/src/content/metrics/issues.mdx
+++ b/src/content/metrics/issues.mdx
@@ -58,4 +58,6 @@ someone becomes a maintainer and the issue tracker becomes their desk.
 
 [Look up a maintainer you know](/) and switch the chart to **Issues** — then
 check their [Total](/-/metrics/total-contributions) to see how the types stack
-together.
+together. Or meet the
+[developers who have opened the most issues on GitHub](/-/most-issues-on-github),
+a lineup of framework leads and open-source cartographers.

--- a/src/content/metrics/private-contributions.mdx
+++ b/src/content/metrics/private-contributions.mdx
@@ -77,4 +77,6 @@ that's usually why.
 
 Look up any user on [commit-history.com](/) and switch the metric to
 **Private** or **Total** — or [compare two developers](/torvalds,gaearon) to
-see how public and private activity differ across careers.
+see how public and private activity differ across careers. Or meet the
+[developers with the most private contributions on GitHub](/-/most-private-contributions-on-github),
+the biggest icebergs on the platform.

--- a/src/content/metrics/pull-requests.mdx
+++ b/src/content/metrics/pull-requests.mdx
@@ -63,4 +63,6 @@ commit.
 [Look up a profile](/) and flip the metric to PRs, or
 [compare two developers](/torvalds,gaearon) — a kernel maintainer who
 receives patches by mail and a web-ecosystem author who lives in pull
-requests make for very different curves.
+requests make for very different curves. Or see
+[who's opened the most pull requests on GitHub](/-/most-pull-requests-on-github),
+where automation and package maintenance dominate the top ten.

--- a/src/content/metrics/repositories.mdx
+++ b/src/content/metrics/repositories.mdx
@@ -62,4 +62,6 @@ seasons, with long plateaus between.
 
 [Look up a serial project-starter](/) and switch the chart to **Repos** —
 then compare against a monorepo dweller to see two opposite ways of living on
-GitHub.
+GitHub. Or see
+[who has created the most repositories on GitHub](/-/most-repositories-on-github),
+where prolific tinkering meets outright automation.

--- a/src/content/metrics/reviews.mdx
+++ b/src/content/metrics/reviews.mdx
@@ -57,4 +57,6 @@ being mostly-author and became mostly-editor.
 [Look up a profile](/) and switch to Reviews, or
 [compare an author-heavy and a reviewer-heavy developer](/torvalds,gaearon) —
 then check [Total](/-/metrics/total-contributions), which is where
-review-heavy engineers finally get full credit.
+review-heavy engineers finally get full credit. Or meet
+[the developers with the most code reviews on GitHub](/-/most-code-reviews-on-github),
+the maintainers doing open source's most invisible work.

--- a/src/content/posts/most-code-reviews-on-github.mdx
+++ b/src/content/posts/most-code-reviews-on-github.mdx
@@ -25,18 +25,18 @@ This is the most quietly impressive of our leaderboards. A
 leaves nothing under your own name, and the people here do it tens of
 thousands of times.
 
-| # | Developer | Reviews |
-| --- | --- | ---: |
-| 1 | [Rui Chen](/chenrui333) | 66.4k |
-| 2 | [Franck Nijhof](/frenck) | 61.9k |
-| 3 | [Justin Krehel](/krehel) | 45.9k |
-| 4 | [Vinayak Kulkarni](/vinayakkulkarni) | 36.2k |
-| 5 | [Carlos Panato](/cpanato) | 33.5k |
-| 6 | [Klaus Hipp](/khipp) | 32.9k |
-| 7 | [Sean Molenaar](/SMillerDev) | 31.8k |
-| 8 | [Martin Hjelmare](/MartinHjelmare) | 30.4k |
-| 9 | [Nick Cao](/NickCao) | 29.9k |
-| 10 | [Patrick Linnane](/p-linnane) | 27.2k |
+<RankBoard unit="reviews" rows={[
+	{ login: "chenrui333", name: "Rui Chen", value: "66.4k" },
+	{ login: "frenck", name: "Franck Nijhof", value: "61.9k" },
+	{ login: "krehel", name: "Justin Krehel", value: "45.9k" },
+	{ login: "vinayakkulkarni", name: "Vinayak Kulkarni", value: "36.2k" },
+	{ login: "cpanato", name: "Carlos Panato", value: "33.5k" },
+	{ login: "khipp", name: "Klaus Hipp", value: "32.9k" },
+	{ login: "SMillerDev", name: "Sean Molenaar", value: "31.8k" },
+	{ login: "MartinHjelmare", name: "Martin Hjelmare", value: "30.4k" },
+	{ login: "NickCao", name: "Nick Cao", value: "29.9k" },
+	{ login: "p-linnane", name: "Patrick Linnane", value: "27.2k" },
+]} />
 
 ## 1. Rui Chen
 

--- a/src/content/posts/most-code-reviews-on-github.mdx
+++ b/src/content/posts/most-code-reviews-on-github.mdx
@@ -46,7 +46,7 @@ A Homebrew maintainer and infrastructure engineer at Justworks. Every formula
 update to the macOS package manager is a pull request that a maintainer has to
 review, and Rui Chen has reviewed more of them than anyone on GitHub.
 
-![Lifetime review chart of Rui Chen](/embed/chenrui333)
+![Lifetime review chart of Rui Chen](/embed/chenrui333?metric=reviews)
 
 ## 2. Franck Nijhof
 
@@ -56,7 +56,7 @@ Leads Home Assistant engineering at Nabu Casa and coordinates its releases.
 Home Assistant is one of the busiest projects on GitHub, and reviewing its
 firehose of contributions is a full-time discipline.
 
-![Lifetime review chart of Franck Nijhof](/embed/frenck)
+![Lifetime review chart of Franck Nijhof](/embed/frenck?metric=reviews)
 
 ## 3. Justin Krehel
 
@@ -66,7 +66,7 @@ A lead maintainer at Homebrew. The second of three Homebrew maintainers on
 this board, which tells you almost everything about which projects generate
 review volume at this scale.
 
-![Lifetime review chart of Justin Krehel](/embed/krehel)
+![Lifetime review chart of Justin Krehel](/embed/krehel?metric=reviews)
 
 ## 4. Vinayak Kulkarni
 
@@ -76,7 +76,7 @@ An open-source developer in Pune working across the Vue and Nuxt ecosystem and
 on MapLibre GL components. Proof the pattern is not only package managers:
 active maintainership of busy JavaScript libraries produces reviews too.
 
-![Lifetime review chart of Vinayak Kulkarni](/embed/vinayakkulkarni)
+![Lifetime review chart of Vinayak Kulkarni](/embed/vinayakkulkarni?metric=reviews)
 
 ## 5. Carlos Panato
 
@@ -87,7 +87,7 @@ supply-chain-security world (Kubernetes, Sigstore, and friends). Same story,
 different ecosystem: a maintainer whose job is increasingly to vet other
 people's code.
 
-![Lifetime review chart of Carlos Panato](/embed/cpanato)
+![Lifetime review chart of Carlos Panato](/embed/cpanato?metric=reviews)
 
 ## 6. Klaus Hipp
 
@@ -96,7 +96,7 @@ people's code.
 A prolific contributor and reviewer on Homebrew Cask and the Ghostty terminal
 emulator. Two high-throughput projects, one very busy reviewer.
 
-![Lifetime review chart of Klaus Hipp](/embed/khipp)
+![Lifetime review chart of Klaus Hipp](/embed/khipp?metric=reviews)
 
 ## 7. Sean Molenaar
 
@@ -106,7 +106,7 @@ A Homebrew maintainer (the PHP formulae, among much else) who works at
 Administrate in the Netherlands. The third Homebrew name here, reviewing the
 package manager's endless stream of updates.
 
-![Lifetime review chart of Sean Molenaar](/embed/SMillerDev)
+![Lifetime review chart of Sean Molenaar](/embed/SMillerDev?metric=reviews)
 
 ## 8. Martin Hjelmare
 
@@ -116,7 +116,7 @@ A core Home Assistant developer in Sweden, and the second Home Assistant name
 on the board. Between Homebrew and Home Assistant, two projects account for
 half of this top ten.
 
-![Lifetime review chart of Martin Hjelmare](/embed/MartinHjelmare)
+![Lifetime review chart of Martin Hjelmare](/embed/MartinHjelmare?metric=reviews)
 
 ## 9. Nick Cao
 
@@ -126,7 +126,7 @@ An engineer at Red Hat and a prolific contributor in the Nix ecosystem.
 Distribution and package work again, where a required-review process turns
 maintainers into full-time reviewers.
 
-![Lifetime review chart of Nick Cao](/embed/NickCao)
+![Lifetime review chart of Nick Cao](/embed/NickCao?metric=reviews)
 
 ## 10. Patrick Linnane
 
@@ -136,7 +136,7 @@ A lead maintainer at Homebrew who runs its security program. He appears on the
 [pull-request board](/-/most-pull-requests-on-github) too: opening and
 reviewing at this volume tend to go together.
 
-![Lifetime review chart of Patrick Linnane](/embed/p-linnane)
+![Lifetime review chart of Patrick Linnane](/embed/p-linnane?metric=reviews)
 
 ## Why the review board is the interesting one
 
@@ -175,6 +175,9 @@ accumulate tens of thousands of reviews simply by keeping the project running.
 [reviews](/?metric=reviews) to see how much of your work is the invisible
 kind, and where it puts you on the [global leaderboard](/).
 
-*More rankings: the [most-followed developers](/-/most-followed-github-users),
-the [most commits](/-/most-commits-on-github), and the
-[most pull requests](/-/most-pull-requests-on-github).*
+*More GitHub rankings: [most-followed developers](/-/most-followed-github-users),
+[most commits](/-/most-commits-on-github),
+[most pull requests](/-/most-pull-requests-on-github),
+[most issues](/-/most-issues-on-github),
+[most repositories](/-/most-repositories-on-github), and
+[most private contributions](/-/most-private-contributions-on-github).*

--- a/src/content/posts/most-code-reviews-on-github.mdx
+++ b/src/content/posts/most-code-reviews-on-github.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The 10 developers with the most code reviews on GitHub"
-description: "Who reviews the most pull requests on GitHub? The 2026 top 10 is dominated by Homebrew, Home Assistant, and other package-manager maintainers doing open source's most invisible work. Full ranking with charts."
+description: "Who reviews the most pull requests on GitHub? The 2026 top 10 is dominated by Homebrew and Home Assistant maintainers doing open source's most invisible work. Full ranking, with charts."
 publishedAt: "2026-07-20"
 updatedAt: "2026-07-20"
 order: 4
@@ -18,12 +18,12 @@ people:
 ---
 
 The developer who has submitted the most pull-request reviews on GitHub is
-**Rui Chen** (@chenrui333), a Homebrew maintainer, with more than 66,000,
-just ahead of **Franck Nijhof** (@frenck), who leads engineering on Home
-Assistant. This is the most quietly impressive of our leaderboards. A
+**Rui Chen** (@chenrui333), a Homebrew maintainer, with more than 66,000, just
+ahead of **Franck Nijhof** (@frenck), who leads engineering on Home Assistant.
+This is the most quietly impressive of our leaderboards. A
 [review](/-/metrics/reviews) is the work that keeps a project moving and
-leaves nothing under your own name, and the people at the top of this board
-do it tens of thousands of times.
+leaves nothing under your own name, and the people here do it tens of
+thousands of times.
 
 | # | Developer | Reviews |
 | --- | --- | ---: |
@@ -38,55 +38,114 @@ do it tens of thousands of times.
 | 9 | [Nick Cao](/NickCao) | 29.9k |
 | 10 | [Patrick Linnane](/p-linnane) | 27.2k |
 
-Reviewing is the classic case of essential, invisible engineering. Reading a
-diff, checking the edge cases, testing it, and writing feedback can take
-longer than the change itself, and none of it produces a commit under the
-reviewer's name. What it produces is this number.
-
-## Two ecosystems own this board
-
-Almost every name here is a maintainer of a huge, high-throughput open-source
-project with a required-review workflow: every pull request needs an approval,
-so the active maintainers accumulate reviews as a structural consequence of
-the process.
+## 1. Rui Chen
 
 <Person login="chenrui333" stats="66.4k reviews · Homebrew" />
 
-<Person login="krehel" stats="45.9k reviews · Homebrew" />
+A Homebrew maintainer and infrastructure engineer at Justworks. Every formula
+update to the macOS package manager is a pull request that a maintainer has to
+review, and Rui Chen has reviewed more of them than anyone on GitHub.
 
-<Person login="p-linnane" stats="27.2k reviews · Homebrew" />
+![Lifetime review chart of Rui Chen](/embed/chenrui333)
 
-Homebrew, the macOS package manager, puts three maintainers in the top ten.
-Every formula update is a pull request that another maintainer reviews, and
-the volume is staggering.
+## 2. Franck Nijhof
 
 <Person login="frenck" stats="61.9k reviews · Home Assistant" />
 
-<Person login="MartinHjelmare" stats="30.4k reviews · Home Assistant" />
+Leads Home Assistant engineering at Nabu Casa and coordinates its releases.
+Home Assistant is one of the busiest projects on GitHub, and reviewing its
+firehose of contributions is a full-time discipline.
 
-Franck Nijhof leads Home Assistant engineering at Nabu Casa and coordinates
-its releases; Martin Hjelmare is a fellow core developer. Home Assistant is
-one of the busiest projects on GitHub, and reviewing its firehose of
-contributions is a full-time discipline.
+![Lifetime review chart of Franck Nijhof](/embed/frenck)
 
-![Lifetime review history chart of Franck Nijhof](/embed/frenck)
+## 3. Justin Krehel
+
+<Person login="krehel" stats="45.9k reviews · Homebrew" />
+
+A lead maintainer at Homebrew. The second of three Homebrew maintainers on
+this board, which tells you almost everything about which projects generate
+review volume at this scale.
+
+![Lifetime review chart of Justin Krehel](/embed/krehel)
+
+## 4. Vinayak Kulkarni
+
+<Person login="vinayakkulkarni" stats="36.2k reviews · Vue & MapLibre" />
+
+An open-source developer in Pune working across the Vue and Nuxt ecosystem and
+on MapLibre GL components. Proof the pattern is not only package managers:
+active maintainership of busy JavaScript libraries produces reviews too.
+
+![Lifetime review chart of Vinayak Kulkarni](/embed/vinayakkulkarni)
+
+## 5. Carlos Panato
 
 <Person login="cpanato" stats="33.5k reviews · Chainguard" />
 
-Carlos Panato at Chainguard rounds out the pattern from the cloud-native and
-supply-chain-security world, with Red Hat's Nick Cao close behind. Different
-ecosystem, same story: maintainers whose job is increasingly to vet other
-people's code rather than write their own.
+An engineer at Chainguard, reviewing across the cloud-native and
+supply-chain-security world (Kubernetes, Sigstore, and friends). Same story,
+different ecosystem: a maintainer whose job is increasingly to vet other
+people's code.
+
+![Lifetime review chart of Carlos Panato](/embed/cpanato)
+
+## 6. Klaus Hipp
+
+<Person login="khipp" stats="32.9k reviews · Homebrew & Ghostty" />
+
+A prolific contributor and reviewer on Homebrew Cask and the Ghostty terminal
+emulator. Two high-throughput projects, one very busy reviewer.
+
+![Lifetime review chart of Klaus Hipp](/embed/khipp)
+
+## 7. Sean Molenaar
+
+<Person login="SMillerDev" stats="31.8k reviews · Homebrew" />
+
+A Homebrew maintainer (the PHP formulae, among much else) who works at
+Administrate in the Netherlands. The third Homebrew name here, reviewing the
+package manager's endless stream of updates.
+
+![Lifetime review chart of Sean Molenaar](/embed/SMillerDev)
+
+## 8. Martin Hjelmare
+
+<Person login="MartinHjelmare" stats="30.4k reviews · Home Assistant" />
+
+A core Home Assistant developer in Sweden, and the second Home Assistant name
+on the board. Between Homebrew and Home Assistant, two projects account for
+half of this top ten.
+
+![Lifetime review chart of Martin Hjelmare](/embed/MartinHjelmare)
+
+## 9. Nick Cao
+
+<Person login="NickCao" stats="29.9k reviews · Red Hat" />
+
+An engineer at Red Hat and a prolific contributor in the Nix ecosystem.
+Distribution and package work again, where a required-review process turns
+maintainers into full-time reviewers.
+
+![Lifetime review chart of Nick Cao](/embed/NickCao)
+
+## 10. Patrick Linnane
+
+<Person login="p-linnane" stats="27.2k reviews · Homebrew" />
+
+A lead maintainer at Homebrew who runs its security program. He appears on the
+[pull-request board](/-/most-pull-requests-on-github) too: opening and
+reviewing at this volume tend to go together.
+
+![Lifetime review chart of Patrick Linnane](/embed/p-linnane)
 
 ## Why the review board is the interesting one
 
-Sort GitHub by [commits](/-/metrics/commits) and you get packaging and
-monorepos. Sort by [followers](/-/metrics/followers) and you get famous
-educators. Sort by reviews and you get the maintainers who keep large
+Sort GitHub by [commits](/-/most-commits-on-github) and you get packaging and
+monorepos. Sort by [followers](/-/most-followed-github-users) and you get
+famous educators. Sort by reviews and you get the maintainers who keep large
 ecosystems flowing, most of whom you have never heard of. As engineers grow
 senior, their output shifts from writing changes to vetting them, so a
-steepening review curve is often a promotion drawn as a chart. It is the
-metric most likely to re-rank the developers you think you know. The
+steepening review curve is often a promotion drawn as a chart. The
 [reviews explainer](/-/metrics/reviews) covers exactly what counts.
 
 ## Common questions
@@ -108,8 +167,7 @@ discussion do not. Reviews in private repositories fold into
 
 Projects like Homebrew and Home Assistant require an approving review on every
 pull request and receive enormous volumes of them. Their active maintainers
-therefore accumulate tens of thousands of reviews simply by keeping the
-project running.
+accumulate tens of thousands of reviews simply by keeping the project running.
 
 ## See where you land
 

--- a/src/content/posts/most-code-reviews-on-github.mdx
+++ b/src/content/posts/most-code-reviews-on-github.mdx
@@ -1,0 +1,122 @@
+---
+title: "The 10 developers with the most code reviews on GitHub"
+description: "Who reviews the most pull requests on GitHub? The 2026 top 10 is dominated by Homebrew, Home Assistant, and other package-manager maintainers doing open source's most invisible work. Full ranking with charts."
+publishedAt: "2026-07-20"
+updatedAt: "2026-07-20"
+order: 4
+people:
+  - { login: chenrui333, name: Rui Chen }
+  - { login: frenck, name: Franck Nijhof }
+  - { login: krehel, name: Justin Krehel }
+  - { login: vinayakkulkarni, name: Vinayak Kulkarni }
+  - { login: cpanato, name: Carlos Panato }
+  - { login: khipp, name: Klaus Hipp }
+  - { login: SMillerDev, name: Sean Molenaar }
+  - { login: MartinHjelmare, name: Martin Hjelmare }
+  - { login: NickCao, name: Nick Cao }
+  - { login: p-linnane, name: Patrick Linnane }
+---
+
+The developer who has submitted the most pull-request reviews on GitHub is
+**Rui Chen** (@chenrui333), a Homebrew maintainer, with more than 66,000,
+just ahead of **Franck Nijhof** (@frenck), who leads engineering on Home
+Assistant. This is the most quietly impressive of our leaderboards. A
+[review](/-/metrics/reviews) is the work that keeps a project moving and
+leaves nothing under your own name, and the people at the top of this board
+do it tens of thousands of times.
+
+| # | Developer | Reviews |
+| --- | --- | ---: |
+| 1 | [Rui Chen](/chenrui333) | 66.4k |
+| 2 | [Franck Nijhof](/frenck) | 61.9k |
+| 3 | [Justin Krehel](/krehel) | 45.9k |
+| 4 | [Vinayak Kulkarni](/vinayakkulkarni) | 36.2k |
+| 5 | [Carlos Panato](/cpanato) | 33.5k |
+| 6 | [Klaus Hipp](/khipp) | 32.9k |
+| 7 | [Sean Molenaar](/SMillerDev) | 31.8k |
+| 8 | [Martin Hjelmare](/MartinHjelmare) | 30.4k |
+| 9 | [Nick Cao](/NickCao) | 29.9k |
+| 10 | [Patrick Linnane](/p-linnane) | 27.2k |
+
+Reviewing is the classic case of essential, invisible engineering. Reading a
+diff, checking the edge cases, testing it, and writing feedback can take
+longer than the change itself, and none of it produces a commit under the
+reviewer's name. What it produces is this number.
+
+## Two ecosystems own this board
+
+Almost every name here is a maintainer of a huge, high-throughput open-source
+project with a required-review workflow: every pull request needs an approval,
+so the active maintainers accumulate reviews as a structural consequence of
+the process.
+
+<Person login="chenrui333" stats="66.4k reviews · Homebrew" />
+
+<Person login="krehel" stats="45.9k reviews · Homebrew" />
+
+<Person login="p-linnane" stats="27.2k reviews · Homebrew" />
+
+Homebrew, the macOS package manager, puts three maintainers in the top ten.
+Every formula update is a pull request that another maintainer reviews, and
+the volume is staggering.
+
+<Person login="frenck" stats="61.9k reviews · Home Assistant" />
+
+<Person login="MartinHjelmare" stats="30.4k reviews · Home Assistant" />
+
+Franck Nijhof leads Home Assistant engineering at Nabu Casa and coordinates
+its releases; Martin Hjelmare is a fellow core developer. Home Assistant is
+one of the busiest projects on GitHub, and reviewing its firehose of
+contributions is a full-time discipline.
+
+![Lifetime review history chart of Franck Nijhof](/embed/frenck)
+
+<Person login="cpanato" stats="33.5k reviews · Chainguard" />
+
+Carlos Panato at Chainguard rounds out the pattern from the cloud-native and
+supply-chain-security world, with Red Hat's Nick Cao close behind. Different
+ecosystem, same story: maintainers whose job is increasingly to vet other
+people's code rather than write their own.
+
+## Why the review board is the interesting one
+
+Sort GitHub by [commits](/-/metrics/commits) and you get packaging and
+monorepos. Sort by [followers](/-/metrics/followers) and you get famous
+educators. Sort by reviews and you get the maintainers who keep large
+ecosystems flowing, most of whom you have never heard of. As engineers grow
+senior, their output shifts from writing changes to vetting them, so a
+steepening review curve is often a promotion drawn as a chart. It is the
+metric most likely to re-rank the developers you think you know. The
+[reviews explainer](/-/metrics/reviews) covers exactly what counts.
+
+## Common questions
+
+### Who reviews the most pull requests on GitHub?
+
+By our count, Homebrew maintainer Rui Chen (@chenrui333) with over 66,000
+reviews, narrowly ahead of Home Assistant's Franck Nijhof (@frenck) at about
+62,000.
+
+### Are code reviews counted on a GitHub profile?
+
+Yes. Submitting a review on a pull request (an approval, a change request, or
+a review comment) counts as a contribution. Plain inline comments and issue
+discussion do not. Reviews in private repositories fold into
+[private contributions](/-/metrics/private-contributions).
+
+### Why do package-manager maintainers dominate the review board?
+
+Projects like Homebrew and Home Assistant require an approving review on every
+pull request and receive enormous volumes of them. Their active maintainers
+therefore accumulate tens of thousands of reviews simply by keeping the
+project running.
+
+## See where you land
+
+**[Look yourself up on commit-history](/)** and switch your chart to
+[reviews](/?metric=reviews) to see how much of your work is the invisible
+kind, and where it puts you on the [global leaderboard](/).
+
+*More rankings: the [most-followed developers](/-/most-followed-github-users),
+the [most commits](/-/most-commits-on-github), and the
+[most pull requests](/-/most-pull-requests-on-github).*

--- a/src/content/posts/most-commits-on-github.mdx
+++ b/src/content/posts/most-commits-on-github.mdx
@@ -1,0 +1,133 @@
+---
+title: "The 10 developers with the most commits on GitHub"
+description: "Who has the most commits on GitHub? The top 10 is not the famous framework authors, it's Linux-distribution maintainers and monorepo teams. The 2026 ranking, with charts and the reason why."
+publishedAt: "2026-07-20"
+updatedAt: "2026-07-20"
+order: 2
+people:
+  - { login: felixonmars, name: Felix Yan }
+  - { login: brianchandotcom, name: Brian Chan }
+  - { login: chrisguttandin, name: Christoph Guttandin }
+  - { login: mgorny, name: Michał Górny }
+  - { login: a17r, name: Andreas Sturmlechner }
+  - { login: thesamesam, name: Sam James }
+  - { login: mkartashev, name: Maxim Kartashev }
+  - { login: mcdonnnj, name: Nick }
+  - { login: Dicklesworthstone, name: Jeff Emanuel }
+  - { login: jsf9k, name: Shane Frasier }
+---
+
+The developer with the most public commits on GitHub is **Felix Yan**
+(@felixonmars), an Arch Linux maintainer, with more than 1.7 million. If
+that name surprises you, that is the whole point of this list. The commit
+leaderboard is not a ranking of the famous. It is a ranking of *volume*, and
+the biggest volumes on GitHub come from Linux-distribution packaging and
+giant company monorepos, not from the people whose names you know.
+
+| # | Developer | Commits |
+| --- | --- | ---: |
+| 1 | [Felix Yan](/felixonmars) | 1.78M |
+| 2 | [Brian Chan](/brianchandotcom) | 468k |
+| 3 | [Christoph Guttandin](/chrisguttandin) | 324k |
+| 4 | [Michał Górny](/mgorny) | 253k |
+| 5 | [Andreas Sturmlechner](/a17r) | 178k |
+| 6 | [Sam James](/thesamesam) | 173k |
+| 7 | [Maxim Kartashev](/mkartashev) | 171k |
+| 8 | [Nick](/mcdonnnj) | 165k |
+| 9 | [Jeff Emanuel](/Dicklesworthstone) | 146k |
+| 10 | [Shane Frasier](/jsf9k) | 130k |
+
+For contrast: Linus Torvalds, who created both Linux and Git, has about
+35,000 public commits. Every developer in the table above out-commits him by
+at least 3×. That gap has almost nothing to do with productivity and almost
+everything to do with how [GitHub counts commits](/-/metrics/commits).
+
+## Why the top is all Linux distributions
+
+Packaging a Linux distribution is a commit factory. Every version bump, every
+patch rebase, every dependency update is a commit on a default branch, and a
+distribution has tens of thousands of packages. Maintain a slice of that and
+your commit count climbs into six and seven figures without a single line of
+application code.
+
+<Person login="felixonmars" stats="1.78M commits · Arch Linux" />
+
+Felix Yan is an Arch Linux developer and RISC-V porter. A large share of his
+enormous count flows through Arch's package repositories, where keeping
+software current *is* the work, and the work is measured in commits.
+
+![Lifetime commit history chart of Felix Yan](/embed/felixonmars)
+
+The same pattern puts three Gentoo developers in the top six. Gentoo is a
+source-based distribution, so its packaging is especially commit-heavy.
+
+<Person login="mgorny" stats="253k commits · Gentoo" />
+
+<Person login="thesamesam" stats="173k commits · Gentoo" />
+
+Michał Górny and Sam James (with Andreas Sturmlechner close behind) are
+long-time Gentoo maintainers. Sam James is also a well-known contributor to
+GCC and the wider toolchain. Their profiles are what a decade of distribution
+maintenance looks like drawn as a curve: relentless, almost linear, and huge.
+
+## The monorepo effect
+
+The other route to a giant commit count is a single enormous codebase.
+
+<Person login="brianchandotcom" stats="468k commits · Liferay" />
+
+Brian Chan founded Liferay and was its chief software architect for seventeen
+years (he is now CEO). Nearly half a million commits reflect two decades
+inside one large Java monorepo, where a merge-commit workflow lands every
+change on the default branch. Maxim Kartashev at JetBrains sits at number
+seven for a similar reason: big corporate repositories generate commits at
+industrial scale.
+
+The rest of the table is a mix of distribution and infrastructure
+maintainers, including two engineers at the US government's
+[@cisagov](https://github.com/cisagov), plus a couple of independent
+developers whose day-to-day workflow commits directly and often. None of them
+is a household name. All of them commit more than almost anyone alive.
+
+## What the commit board actually measures
+
+Commit count rewards a workflow, not a person. Squash-merge teams compress a
+30-commit pull request into one; merge-commit and direct-push workflows keep
+every one. Distribution packaging and monorepos are the direct-push extreme,
+which is why they own the top of this board. It is a real signal, just not the
+one people assume: it measures how a developer's world turns changes into
+default-branch commits, not how good or important those changes are. The
+[commits metric explainer](/-/metrics/commits) has the full mechanics.
+
+## Common questions
+
+### Who has the most commits on GitHub?
+
+By our count, Felix Yan (@felixonmars), an Arch Linux maintainer, with over
+1.7 million public commits. The rest of the top ten is dominated by other
+Linux-distribution maintainers (Gentoo especially) and large-monorepo
+engineers.
+
+### Why doesn't Linus Torvalds have the most commits?
+
+The Linux kernel takes changes largely as emailed patches applied by
+subsystem maintainers, so a great deal of Linus's impact never lands as a
+commit authored by *him* on a GitHub default branch. His roughly 35,000
+public commits reflect that workflow, not his contribution to computing.
+
+### Do more commits mean a better developer?
+
+No. Commit totals are dominated by merge style and automation. A squash-merge
+team and a direct-push packager can do identical amounts of work and differ
+10× or more in commits. Read the count as a workflow fingerprint, not a
+scoreboard.
+
+## See where you land
+
+**[Look yourself up on commit-history](/)** to see your own lifetime commit
+curve and where it puts you on the [global leaderboard](/). Then compare
+yourself against a distribution maintainer and watch the slopes diverge.
+
+*More rankings: the [most-followed developers](/-/most-followed-github-users),
+the [most pull requests](/-/most-pull-requests-on-github), and the
+[most code reviews](/-/most-code-reviews-on-github).*

--- a/src/content/posts/most-commits-on-github.mdx
+++ b/src/content/posts/most-commits-on-github.mdx
@@ -24,18 +24,18 @@ name surprises you, that is the point of this list: the commit board ranks
 giant company monorepos, not from the people whose names you know. Linus
 Torvalds, who created both Linux and Git, has about 35,000.
 
-| # | Developer | Commits |
-| --- | --- | ---: |
-| 1 | [Felix Yan](/felixonmars) | 1.78M |
-| 2 | [Brian Chan](/brianchandotcom) | 468k |
-| 3 | [Christoph Guttandin](/chrisguttandin) | 324k |
-| 4 | [Michał Górny](/mgorny) | 253k |
-| 5 | [Andreas Sturmlechner](/a17r) | 178k |
-| 6 | [Sam James](/thesamesam) | 173k |
-| 7 | [Maxim Kartashev](/mkartashev) | 171k |
-| 8 | [Nick](/mcdonnnj) | 165k |
-| 9 | [Jeffrey Emanuel](/Dicklesworthstone) | 146k |
-| 10 | [Shane Frasier](/jsf9k) | 130k |
+<RankBoard unit="commits" rows={[
+	{ login: "felixonmars", name: "Felix Yan", value: "1.78M" },
+	{ login: "brianchandotcom", name: "Brian Chan", value: "468k" },
+	{ login: "chrisguttandin", name: "Christoph Guttandin", value: "324k" },
+	{ login: "mgorny", name: "Michał Górny", value: "253k" },
+	{ login: "a17r", name: "Andreas Sturmlechner", value: "178k" },
+	{ login: "thesamesam", name: "Sam James", value: "173k" },
+	{ login: "mkartashev", name: "Maxim Kartashev", value: "171k" },
+	{ login: "mcdonnnj", name: "Nick", value: "165k" },
+	{ login: "Dicklesworthstone", name: "Jeffrey Emanuel", value: "146k" },
+	{ login: "jsf9k", name: "Shane Frasier", value: "130k" },
+]} />
 
 ## 1. Felix Yan
 

--- a/src/content/posts/most-commits-on-github.mdx
+++ b/src/content/posts/most-commits-on-github.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The 10 developers with the most commits on GitHub"
-description: "Who has the most commits on GitHub? The top 10 is not the famous framework authors, it's Linux-distribution maintainers and monorepo teams. The 2026 ranking, with charts and the reason why."
+description: "Who has the most commits on GitHub? The top 10 is not the famous framework authors, it's Linux-distribution maintainers and big-monorepo engineers. The 2026 ranking, with charts."
 publishedAt: "2026-07-20"
 updatedAt: "2026-07-20"
 order: 2
@@ -13,16 +13,16 @@ people:
   - { login: thesamesam, name: Sam James }
   - { login: mkartashev, name: Maxim Kartashev }
   - { login: mcdonnnj, name: Nick }
-  - { login: Dicklesworthstone, name: Jeff Emanuel }
+  - { login: Dicklesworthstone, name: Jeffrey Emanuel }
   - { login: jsf9k, name: Shane Frasier }
 ---
 
 The developer with the most public commits on GitHub is **Felix Yan**
-(@felixonmars), an Arch Linux maintainer, with more than 1.7 million. If
-that name surprises you, that is the whole point of this list. The commit
-leaderboard is not a ranking of the famous. It is a ranking of *volume*, and
-the biggest volumes on GitHub come from Linux-distribution packaging and
-giant company monorepos, not from the people whose names you know.
+(@felixonmars), an Arch Linux maintainer, with more than 1.7 million. If that
+name surprises you, that is the point of this list: the commit board ranks
+*volume*, and the biggest volumes come from Linux-distribution packaging and
+giant company monorepos, not from the people whose names you know. Linus
+Torvalds, who created both Linux and Git, has about 35,000.
 
 | # | Developer | Commits |
 | --- | --- | ---: |
@@ -34,69 +34,120 @@ giant company monorepos, not from the people whose names you know.
 | 6 | [Sam James](/thesamesam) | 173k |
 | 7 | [Maxim Kartashev](/mkartashev) | 171k |
 | 8 | [Nick](/mcdonnnj) | 165k |
-| 9 | [Jeff Emanuel](/Dicklesworthstone) | 146k |
+| 9 | [Jeffrey Emanuel](/Dicklesworthstone) | 146k |
 | 10 | [Shane Frasier](/jsf9k) | 130k |
 
-For contrast: Linus Torvalds, who created both Linux and Git, has about
-35,000 public commits. Every developer in the table above out-commits him by
-at least 3×. That gap has almost nothing to do with productivity and almost
-everything to do with how [GitHub counts commits](/-/metrics/commits).
-
-## Why the top is all Linux distributions
-
-Packaging a Linux distribution is a commit factory. Every version bump, every
-patch rebase, every dependency update is a commit on a default branch, and a
-distribution has tens of thousands of packages. Maintain a slice of that and
-your commit count climbs into six and seven figures without a single line of
-application code.
+## 1. Felix Yan
 
 <Person login="felixonmars" stats="1.78M commits · Arch Linux" />
 
-Felix Yan is an Arch Linux developer and RISC-V porter. A large share of his
-enormous count flows through Arch's package repositories, where keeping
-software current *is* the work, and the work is measured in commits.
+An Arch Linux developer and RISC-V porter based in Wuhan. Packaging a
+distribution is a commit factory: every version bump and patch rebase is a
+commit, across thousands of packages. That workflow, not superhuman typing,
+is how you reach seven figures.
 
 ![Lifetime commit history chart of Felix Yan](/embed/felixonmars)
 
-The same pattern puts three Gentoo developers in the top six. Gentoo is a
-source-based distribution, so its packaging is especially commit-heavy.
-
-<Person login="mgorny" stats="253k commits · Gentoo" />
-
-<Person login="thesamesam" stats="173k commits · Gentoo" />
-
-Michał Górny and Sam James (with Andreas Sturmlechner close behind) are
-long-time Gentoo maintainers. Sam James is also a well-known contributor to
-GCC and the wider toolchain. Their profiles are what a decade of distribution
-maintenance looks like drawn as a curve: relentless, almost linear, and huge.
-
-## The monorepo effect
-
-The other route to a giant commit count is a single enormous codebase.
+## 2. Brian Chan
 
 <Person login="brianchandotcom" stats="468k commits · Liferay" />
 
-Brian Chan founded Liferay and was its chief software architect for seventeen
-years (he is now CEO). Nearly half a million commits reflect two decades
-inside one large Java monorepo, where a merge-commit workflow lands every
-change on the default branch. Maxim Kartashev at JetBrains sits at number
-seven for a similar reason: big corporate repositories generate commits at
-industrial scale.
+Founder and long-time chief software architect of Liferay, now its CEO.
+Nearly half a million commits reflect two decades inside one large Java
+monorepo where a merge-commit workflow lands every change on the default
+branch.
 
-The rest of the table is a mix of distribution and infrastructure
-maintainers, including two engineers at the US government's
-[@cisagov](https://github.com/cisagov), plus a couple of independent
-developers whose day-to-day workflow commits directly and often. None of them
-is a household name. All of them commit more than almost anyone alive.
+![Lifetime commit history chart of Brian Chan](/embed/brianchandotcom)
+
+## 3. Christoph Guttandin
+
+<Person login="chrisguttandin" stats="324k commits · Web Audio" />
+
+An independent developer in Berlin behind a family of Web Audio API libraries
+(`standardized-audio-context`, `worker-timers`) and a contributor to the W3C
+Audio Working Group. Proof you don't need a distribution behind you to commit
+constantly.
+
+![Lifetime commit history chart of Christoph Guttandin](/embed/chrisguttandin)
+
+## 4. Michał Górny
+
+<Person login="mgorny" stats="253k commits · Gentoo" />
+
+A Gentoo developer since 2010, maintaining Python packages, LLVM, and Xfce,
+and now working at Quansight Labs. Gentoo is source-based, which makes its
+packaging especially commit-heavy, and it puts three of its maintainers in
+this top ten.
+
+![Lifetime commit history chart of Michał Górny](/embed/mgorny)
+
+## 5. Andreas Sturmlechner
+
+<Person login="a17r" stats="178k commits · Gentoo" />
+
+Another Gentoo developer, focused on packaging KDE and Qt. His curve is what
+a decade of desktop-stack maintenance looks like: relentless and near-linear.
+
+![Lifetime commit history chart of Andreas Sturmlechner](/embed/a17r)
+
+## 6. Sam James
+
+<Person login="thesamesam" stats="173k commits · Gentoo" />
+
+A Gentoo maintainer who is also a well-known contributor to GCC and the wider
+toolchain. Between distribution packaging and compiler work, few people touch
+more default branches.
+
+![Lifetime commit history chart of Sam James](/embed/thesamesam)
+
+## 7. Maxim Kartashev
+
+<Person login="mkartashev" stats="171k commits · JetBrains" />
+
+An engineer at JetBrains. The other route to a giant commit count is a large
+corporate codebase, and JetBrains's runtime and tooling repositories generate
+commits at industrial scale.
+
+![Lifetime commit history chart of Maxim Kartashev](/embed/mkartashev)
+
+## 8. Nick
+
+<Person login="mcdonnnj" stats="165k commits · @cisagov" />
+
+A maintainer working under [@cisagov](https://github.com/cisagov), the US
+Cybersecurity and Infrastructure Security Agency's open-source org. Large
+public-sector security tooling, spread across many repositories, adds up fast.
+
+![Lifetime commit history chart of Nick](/embed/mcdonnnj)
+
+## 9. Jeffrey Emanuel
+
+<Person login="Dicklesworthstone" stats="146k commits · independent" />
+
+An independent builder in New York, a former equity analyst who now ships AI
+and agentic-coding tooling. One of the few here whose volume comes from
+personal projects rather than a distribution or monorepo.
+
+![Lifetime commit history chart of Jeffrey Emanuel](/embed/Dicklesworthstone)
+
+## 10. Shane Frasier
+
+<Person login="jsf9k" stats="130k commits · @cisagov" />
+
+A self-described public servant, the second [@cisagov](https://github.com/cisagov)
+engineer in the top ten. Government cybersecurity work, like distribution
+packaging, is repository-heavy and automation-adjacent, exactly the shape that
+tops this board.
+
+![Lifetime commit history chart of Shane Frasier](/embed/jsf9k)
 
 ## What the commit board actually measures
 
 Commit count rewards a workflow, not a person. Squash-merge teams compress a
-30-commit pull request into one; merge-commit and direct-push workflows keep
-every one. Distribution packaging and monorepos are the direct-push extreme,
-which is why they own the top of this board. It is a real signal, just not the
-one people assume: it measures how a developer's world turns changes into
-default-branch commits, not how good or important those changes are. The
+30-commit pull request into one; distribution packaging and direct-push
+monorepos keep every commit, which is why they own the top. It is a real
+signal, just not the one people assume: it tracks how your world turns changes
+into default-branch commits, not how good those changes are. The
 [commits metric explainer](/-/metrics/commits) has the full mechanics.
 
 ## Common questions
@@ -104,29 +155,27 @@ default-branch commits, not how good or important those changes are. The
 ### Who has the most commits on GitHub?
 
 By our count, Felix Yan (@felixonmars), an Arch Linux maintainer, with over
-1.7 million public commits. The rest of the top ten is dominated by other
+1.7 million public commits. The rest of the top ten is mostly other
 Linux-distribution maintainers (Gentoo especially) and large-monorepo
 engineers.
 
 ### Why doesn't Linus Torvalds have the most commits?
 
 The Linux kernel takes changes largely as emailed patches applied by
-subsystem maintainers, so a great deal of Linus's impact never lands as a
-commit authored by *him* on a GitHub default branch. His roughly 35,000
-public commits reflect that workflow, not his contribution to computing.
+maintainers, so much of Linus's impact never lands as a commit authored by
+*him* on a GitHub default branch. His roughly 35,000 public commits reflect
+that workflow, not his contribution to computing.
 
 ### Do more commits mean a better developer?
 
 No. Commit totals are dominated by merge style and automation. A squash-merge
-team and a direct-push packager can do identical amounts of work and differ
-10× or more in commits. Read the count as a workflow fingerprint, not a
-scoreboard.
+team and a direct-push packager can do identical work and differ 10× or more
+in commits. Read the count as a workflow fingerprint, not a scoreboard.
 
 ## See where you land
 
 **[Look yourself up on commit-history](/)** to see your own lifetime commit
-curve and where it puts you on the [global leaderboard](/). Then compare
-yourself against a distribution maintainer and watch the slopes diverge.
+curve and where it puts you on the [global leaderboard](/).
 
 *More rankings: the [most-followed developers](/-/most-followed-github-users),
 the [most pull requests](/-/most-pull-requests-on-github), and the

--- a/src/content/posts/most-commits-on-github.mdx
+++ b/src/content/posts/most-commits-on-github.mdx
@@ -46,7 +46,7 @@ distribution is a commit factory: every version bump and patch rebase is a
 commit, across thousands of packages. That workflow, not superhuman typing,
 is how you reach seven figures.
 
-![Lifetime commit history chart of Felix Yan](/embed/felixonmars)
+![Lifetime commit history chart of Felix Yan](/embed/felixonmars?metric=commits)
 
 ## 2. Brian Chan
 
@@ -57,7 +57,7 @@ Nearly half a million commits reflect two decades inside one large Java
 monorepo where a merge-commit workflow lands every change on the default
 branch.
 
-![Lifetime commit history chart of Brian Chan](/embed/brianchandotcom)
+![Lifetime commit history chart of Brian Chan](/embed/brianchandotcom?metric=commits)
 
 ## 3. Christoph Guttandin
 
@@ -68,7 +68,7 @@ An independent developer in Berlin behind a family of Web Audio API libraries
 Audio Working Group. Proof you don't need a distribution behind you to commit
 constantly.
 
-![Lifetime commit history chart of Christoph Guttandin](/embed/chrisguttandin)
+![Lifetime commit history chart of Christoph Guttandin](/embed/chrisguttandin?metric=commits)
 
 ## 4. Michał Górny
 
@@ -79,7 +79,7 @@ and now working at Quansight Labs. Gentoo is source-based, which makes its
 packaging especially commit-heavy, and it puts three of its maintainers in
 this top ten.
 
-![Lifetime commit history chart of Michał Górny](/embed/mgorny)
+![Lifetime commit history chart of Michał Górny](/embed/mgorny?metric=commits)
 
 ## 5. Andreas Sturmlechner
 
@@ -88,7 +88,7 @@ this top ten.
 Another Gentoo developer, focused on packaging KDE and Qt. His curve is what
 a decade of desktop-stack maintenance looks like: relentless and near-linear.
 
-![Lifetime commit history chart of Andreas Sturmlechner](/embed/a17r)
+![Lifetime commit history chart of Andreas Sturmlechner](/embed/a17r?metric=commits)
 
 ## 6. Sam James
 
@@ -98,7 +98,7 @@ A Gentoo maintainer who is also a well-known contributor to GCC and the wider
 toolchain. Between distribution packaging and compiler work, few people touch
 more default branches.
 
-![Lifetime commit history chart of Sam James](/embed/thesamesam)
+![Lifetime commit history chart of Sam James](/embed/thesamesam?metric=commits)
 
 ## 7. Maxim Kartashev
 
@@ -108,7 +108,7 @@ An engineer at JetBrains. The other route to a giant commit count is a large
 corporate codebase, and JetBrains's runtime and tooling repositories generate
 commits at industrial scale.
 
-![Lifetime commit history chart of Maxim Kartashev](/embed/mkartashev)
+![Lifetime commit history chart of Maxim Kartashev](/embed/mkartashev?metric=commits)
 
 ## 8. Nick
 
@@ -118,7 +118,7 @@ A maintainer working under [@cisagov](https://github.com/cisagov), the US
 Cybersecurity and Infrastructure Security Agency's open-source org. Large
 public-sector security tooling, spread across many repositories, adds up fast.
 
-![Lifetime commit history chart of Nick](/embed/mcdonnnj)
+![Lifetime commit history chart of Nick](/embed/mcdonnnj?metric=commits)
 
 ## 9. Jeffrey Emanuel
 
@@ -128,7 +128,7 @@ An independent builder in New York, a former equity analyst who now ships AI
 and agentic-coding tooling. One of the few here whose volume comes from
 personal projects rather than a distribution or monorepo.
 
-![Lifetime commit history chart of Jeffrey Emanuel](/embed/Dicklesworthstone)
+![Lifetime commit history chart of Jeffrey Emanuel](/embed/Dicklesworthstone?metric=commits)
 
 ## 10. Shane Frasier
 
@@ -139,7 +139,7 @@ engineer in the top ten. Government cybersecurity work, like distribution
 packaging, is repository-heavy and automation-adjacent, exactly the shape that
 tops this board.
 
-![Lifetime commit history chart of Shane Frasier](/embed/jsf9k)
+![Lifetime commit history chart of Shane Frasier](/embed/jsf9k?metric=commits)
 
 ## What the commit board actually measures
 
@@ -177,6 +177,9 @@ in commits. Read the count as a workflow fingerprint, not a scoreboard.
 **[Look yourself up on commit-history](/)** to see your own lifetime commit
 curve and where it puts you on the [global leaderboard](/).
 
-*More rankings: the [most-followed developers](/-/most-followed-github-users),
-the [most pull requests](/-/most-pull-requests-on-github), and the
-[most code reviews](/-/most-code-reviews-on-github).*
+*More GitHub rankings: [most-followed developers](/-/most-followed-github-users),
+[most pull requests](/-/most-pull-requests-on-github),
+[most code reviews](/-/most-code-reviews-on-github),
+[most issues](/-/most-issues-on-github),
+[most repositories](/-/most-repositories-on-github), and
+[most private contributions](/-/most-private-contributions-on-github).*

--- a/src/content/posts/most-followed-github-users.mdx
+++ b/src/content/posts/most-followed-github-users.mdx
@@ -60,7 +60,7 @@ requests into [the kernel](https://github.com/torvalds/linux). His follower
 count is GitHub's monument to the fact that the whole platform runs on his
 two inventions.
 
-![Lifetime commit history chart of Linus Torvalds](/embed/torvalds)
+![Lifetime commit history chart of Linus Torvalds](/embed/torvalds?metric=commits)
 
 ## 2. Andrej Karpathy
 
@@ -75,7 +75,7 @@ The following, though, comes from teaching: Stanford's CS231n, the
 [nanoGPT](https://github.com/karpathy/nanoGPT) that thousands of people
 have learned LLMs from.
 
-![Lifetime commit history chart of Andrej Karpathy](/embed/karpathy)
+![Lifetime commit history chart of Andrej Karpathy](/embed/karpathy?metric=commits)
 
 ## 3. Evan You
 
@@ -89,7 +89,7 @@ he founded [VoidZero](https://voidzero.dev) in 2024 to build a unified
 JavaScript toolchain. If your frontend builds fast, there is a decent
 chance you are inside his dependency graph.
 
-![Lifetime commit history chart of Evan You](/embed/yyx990803)
+![Lifetime commit history chart of Evan You](/embed/yyx990803?metric=commits)
 
 ## 4. Dan Abramov
 
@@ -103,7 +103,7 @@ to confused developers. After two years building at Bluesky he went
 independent in 2025. The writing continues, and so does the astonishing
 commit rate.
 
-![Lifetime commit history chart of Dan Abramov](/embed/gaearon)
+![Lifetime commit history chart of Dan Abramov](/embed/gaearon?metric=commits)
 
 ## 5. Sindre Sorhus
 
@@ -118,7 +118,7 @@ highest [repo count](/-/metrics/repositories) on this list by a factor of
 three. Your `node_modules` folder is statistically guaranteed to contain
 him.
 
-![Lifetime commit history chart of Sindre Sorhus](/embed/sindresorhus)
+![Lifetime commit history chart of Sindre Sorhus](/embed/sindresorhus?metric=commits)
 
 ## 6. Brad Traversy
 
@@ -131,7 +131,7 @@ and his repositories are course material rather than libraries. That is why
 Like Karpathy, Brad is what the [followers metric](/-/metrics/followers)
 looks like when teaching, not tooling, is the product.
 
-![Lifetime commit history chart of Brad Traversy](/embed/bradtraversy)
+![Lifetime commit history chart of Brad Traversy](/embed/bradtraversy?metric=commits)
 
 ## 7. Jake Wharton
 
@@ -144,7 +144,7 @@ Android at Skylight. His 7.3k [pull-request reviews](/-/metrics/reviews)
 are the highest on this list, the quiet senior kind of work that follower
 counts usually never see.
 
-![Lifetime commit history chart of Jake Wharton](/embed/jakewharton)
+![Lifetime commit history chart of Jake Wharton](/embed/jakewharton?metric=commits)
 
 ## 8. Phil Wang
 
@@ -158,7 +158,7 @@ reads "Working with Attention. It's all we need." An entire field of
 researchers follows him so they can read tomorrow's architectures as
 working code today.
 
-![Lifetime commit history chart of Phil Wang](/embed/lucidrains)
+![Lifetime commit history chart of Phil Wang](/embed/lucidrains?metric=commits)
 
 ## 9. Peter Steinberger
 
@@ -172,7 +172,7 @@ thousand commits make him the second-heaviest committer here. The follower
 spike is what happens when a lifetime builder suddenly becomes a broadcaster
 too.
 
-![Lifetime commit history chart of Peter Steinberger](/embed/steipete)
+![Lifetime commit history chart of Peter Steinberger](/embed/steipete?metric=commits)
 
 ## 10. TJ Holowaychuk
 
@@ -185,7 +185,7 @@ barely posts, rarely appears, and still sits in the global top ten a decade
 later, because followers are
 [peak visibility and they never go down](/-/metrics/followers).
 
-![Lifetime commit history chart of TJ Holowaychuk](/embed/tj)
+![Lifetime commit history chart of TJ Holowaychuk](/embed/tj?metric=commits)
 
 ## What the top ten says
 
@@ -227,6 +227,9 @@ commits put you on the global leaderboard, then flip it to
 [followers](/?metric=followers) to compare. The board only gets smarter as
 more people are added, so every lookup helps.
 
-*More rankings: the [most commits](/-/most-commits-on-github), the
-[most pull requests](/-/most-pull-requests-on-github), and the
-[most code reviews](/-/most-code-reviews-on-github) on GitHub.*
+*More GitHub rankings: [most commits](/-/most-commits-on-github),
+[most pull requests](/-/most-pull-requests-on-github),
+[most code reviews](/-/most-code-reviews-on-github),
+[most issues](/-/most-issues-on-github),
+[most repositories](/-/most-repositories-on-github), and
+[most private contributions](/-/most-private-contributions-on-github).*

--- a/src/content/posts/most-followed-github-users.mdx
+++ b/src/content/posts/most-followed-github-users.mdx
@@ -1,0 +1,171 @@
+---
+title: "The 10 most-followed developers on GitHub"
+description: "From Linus Torvalds to Andrej Karpathy: who tops the followers leaderboard in 2026, what they built, and what their commit histories reveal about how they got there."
+publishedAt: "2026-07-19"
+updatedAt: "2026-07-19"
+order: 1
+---
+
+Followers are GitHub's applause meter. They measure
+[reach, not contribution](/-/metrics/followers), so the ranking looks
+nothing like a commit leaderboard. Below are the ten most-followed
+developers on our [followers leaderboard](/?metric=followers), each with
+the lifetime commit chart that sits behind the fame. The two rarely agree,
+and that is the interesting part. Some of these people built the software
+you use every day, some taught a generation how to code, and a few did both.
+
+One honest caveat before the countdown. The board ranks everyone who has
+ever been looked up on commit-history.com, which makes it a mirror of who
+developers are curious about rather than a census of all of GitHub. If your
+favorite is missing, [look them up](/) and the board learns about them.
+Follower counts below come from our snapshot of July 19, 2026.
+
+## 1. Linus Torvalds
+
+<Person login="torvalds" followers="312k" commits="35.7k" />
+
+The unavoidable number one. Linus created Linux in 1991 and, almost as a
+side effect, Git in 2005, which means every follow, fork, and commit on
+this site flows through tooling he wrote. Officially a fellow at the Linux
+Foundation, he spends his days exactly where you would expect: merging pull
+requests into [the kernel](https://github.com/torvalds/linux). His follower
+count is GitHub's monument to the fact that the whole platform runs on his
+two inventions.
+
+![Lifetime commit history chart of Linus Torvalds](/embed/torvalds)
+
+## 2. Andrej Karpathy
+
+<Person login="karpathy" followers="210k" commits="2.9k" />
+
+The purest broadcaster profile on the list: two hundred thousand followers
+on fewer than three thousand public commits. Andrej was a founding member
+of OpenAI, ran Autopilot AI at Tesla, founded the AI-education startup
+Eureka Labs, and joined Anthropic in May 2026 to lead pretraining research.
+The following, though, comes from teaching: Stanford's CS231n, the
+*Neural Networks: Zero to Hero* videos, and tiny readable repositories like
+[nanoGPT](https://github.com/karpathy/nanoGPT) that thousands of people
+have learned LLMs from.
+
+![Lifetime commit history chart of Andrej Karpathy](/embed/karpathy)
+
+## 3. Evan You
+
+<Person login="yyx990803" followers="108k" commits="40k" />
+
+Creator of [Vue.js](https://github.com/vuejs) and
+[Vite](https://github.com/vitejs/vite), and proof that you can be both
+builder and broadcaster: forty thousand commits *and* six figures of
+followers. After a decade of independent open source funded by its users,
+he founded [VoidZero](https://voidzero.dev) in 2024 to build a unified
+JavaScript toolchain. If your frontend builds fast, there is a decent
+chance you are inside his dependency graph.
+
+![Lifetime commit history chart of Evan You](/embed/yyx990803)
+
+## 4. Dan Abramov
+
+<Person login="gaearon" followers="91k" commits="68.6k" />
+
+Co-author of Redux, longtime React core team member at Meta, and the
+highest committer on this entire list. Dan's superpower has always been
+explanation: [overreacted.io](https://overreacted.io) essays,
+[Just JavaScript](https://justjavascript.com), and years of patient replies
+to confused developers. After two years building at Bluesky he went
+independent in 2025. The writing continues, and so does the astonishing
+commit rate.
+
+![Lifetime commit history chart of Dan Abramov](/embed/gaearon)
+
+## 5. Sindre Sorhus
+
+<Person login="sindresorhus" followers="80k" commits="35k" />
+
+The most prolific open-source maintainer of the npm era: over a thousand
+packages (`chalk`, `got`, `execa`, `ora`…), the original
+[awesome list](https://github.com/sindresorhus/awesome), and a growing
+family of macOS apps. Sindre has been a full-time, sponsor-funded
+open-sourcerer since 2017, and his 1,134 created repositories are the
+highest [repo count](/-/metrics/repositories) on this list by a factor of
+three. Your `node_modules` folder is statistically guaranteed to contain
+him.
+
+![Lifetime commit history chart of Sindre Sorhus](/embed/sindresorhus)
+
+## 6. Brad Traversy
+
+<Person login="bradtraversy" followers="76k" commits="3.2k" />
+
+The educator's educator. [Traversy Media](https://traversymedia.com) crash
+courses have been the first hour of programming for millions of learners,
+and his repositories are course material rather than libraries. That is why
+76 thousand people follow an account with barely three thousand commits.
+Like Karpathy, Brad is what the [followers metric](/-/metrics/followers)
+looks like when teaching, not tooling, is the product.
+
+![Lifetime commit history chart of Brad Traversy](/embed/bradtraversy)
+
+## 7. Jake Wharton
+
+<Person login="JakeWharton" followers="68k" commits="26.6k" />
+
+If you have written Android code, you have imported Jake Wharton: Retrofit,
+OkHttp, and Picasso from his Square years, plus ActionBarSherlock and
+ButterKnife before that. After stints at Google and Cash App he now builds
+Android at Skylight. His 7.3k [pull-request reviews](/-/metrics/reviews)
+are the highest on this list, the quiet senior kind of work that follower
+counts usually never see.
+
+![Lifetime commit history chart of Jake Wharton](/embed/jakewharton)
+
+## 8. Phil Wang
+
+<Person login="lucidrains" followers="61k" commits="22.8k" />
+
+GitHub's research-paper printing press. When a notable AI paper drops, Phil
+Wang's PyTorch implementation often exists before the authors' own code
+does: [vit-pytorch](https://github.com/lucidrains/vit-pytorch),
+imagen-pytorch, x-transformers, four hundred repositories of them. His bio
+reads "Working with Attention. It's all we need." An entire field of
+researchers follows him so they can read tomorrow's architectures as
+working code today.
+
+![Lifetime commit history chart of Phil Wang](/embed/lucidrains)
+
+## 9. Peter Steinberger
+
+<Person login="steipete" followers="52k" commits="60.7k" />
+
+Founder of PSPDFKit, the PDF engine inside half your iOS apps. He retired,
+got bored, and in late 2025 shipped [OpenClaw](https://github.com/openclaw),
+the open-source AI agent that went memorably viral. OpenAI hired him in
+February 2026 and the project moved to an independent foundation. Sixty
+thousand commits make him the second-heaviest committer here. The follower
+spike is what happens when a lifetime builder suddenly becomes a broadcaster
+too.
+
+![Lifetime commit history chart of Peter Steinberger](/embed/steipete)
+
+## 10. TJ Holowaychuk
+
+<Person login="tj" followers="52k" commits="33.4k" />
+
+The ghost at the top of the dependency tree. TJ wrote Express, Koa, Mocha,
+Commander, and Stylus, a startling share of Node.js's foundational layer,
+mostly before 2014. Then he famously left for Go and later founded Apex. He
+barely posts, rarely appears, and still sits in the global top ten a decade
+later, because followers are
+[peak visibility and they never go down](/-/metrics/followers).
+
+![Lifetime commit history chart of TJ Holowaychuk](/embed/tj)
+
+## What the top ten says
+
+Split the list and you get three species: pure builders (Torvalds, Wharton,
+TJ), pure teachers (Karpathy, Traversy), and the rare both (Evan You, Dan
+Abramov, Sindre Sorhus, Steinberger, Wang). Their commit charts make the
+difference visible at a glance. Try
+[Torvalds vs Abramov vs Sorhus](/torvalds,gaearon,sindresorhus) on one
+chart, or flip the [leaderboard](/?metric=followers) to Commits and watch
+half this list vanish. Then [look someone up](/), because the board only
+gets smarter when you do.

--- a/src/content/posts/most-followed-github-users.mdx
+++ b/src/content/posts/most-followed-github-users.mdx
@@ -1,18 +1,46 @@
 ---
 title: "The 10 most-followed developers on GitHub"
-description: "From Linus Torvalds to Andrej Karpathy: who tops the followers leaderboard in 2026, what they built, and what their commit histories reveal about how they got there."
+description: "Who has the most GitHub followers? The 10 most-followed developers on GitHub in 2026, ranked: what each person built, where they work, and their lifetime commit charts."
 publishedAt: "2026-07-19"
-updatedAt: "2026-07-19"
+updatedAt: "2026-07-20"
 order: 1
+people:
+  - { login: torvalds, name: Linus Torvalds }
+  - { login: karpathy, name: Andrej Karpathy }
+  - { login: yyx990803, name: Evan You }
+  - { login: gaearon, name: Dan Abramov }
+  - { login: sindresorhus, name: Sindre Sorhus }
+  - { login: bradtraversy, name: Brad Traversy }
+  - { login: JakeWharton, name: Jake Wharton }
+  - { login: lucidrains, name: Phil Wang }
+  - { login: steipete, name: Peter Steinberger }
+  - { login: tj, name: TJ Holowaychuk }
 ---
+
+The most-followed developer on GitHub is **Linus Torvalds**, with more than
+312,000 followers. The rest of the top ten is a mix of language creators,
+framework authors, and educators. Here is the full ranking as of
+July 2026:
+
+| # | Developer | GitHub followers |
+| --- | --- | ---: |
+| 1 | [Linus Torvalds](/torvalds) | 312k |
+| 2 | [Andrej Karpathy](/karpathy) | 210k |
+| 3 | [Evan You](/yyx990803) | 108k |
+| 4 | [Dan Abramov](/gaearon) | 91k |
+| 5 | [Sindre Sorhus](/sindresorhus) | 80k |
+| 6 | [Brad Traversy](/bradtraversy) | 76k |
+| 7 | [Jake Wharton](/jakewharton) | 68k |
+| 8 | [Phil Wang](/lucidrains) | 61k |
+| 9 | [Peter Steinberger](/steipete) | 52k |
+| 10 | [TJ Holowaychuk](/tj) | 52k |
 
 Followers are GitHub's applause meter. They measure
 [reach, not contribution](/-/metrics/followers), so the ranking looks
-nothing like a commit leaderboard. Below are the ten most-followed
-developers on our [followers leaderboard](/?metric=followers), each with
-the lifetime commit chart that sits behind the fame. The two rarely agree,
-and that is the interesting part. Some of these people built the software
-you use every day, some taught a generation how to code, and a few did both.
+nothing like a commit leaderboard. Each entry below has the lifetime commit
+chart that sits behind the fame, and the two rarely agree. Some of these
+people built the software you use every day, some taught a generation how
+to code, and a few did both.
 
 One honest caveat before the countdown. The board ranks everyone who has
 ever been looked up on commit-history.com, which makes it a mirror of who
@@ -167,5 +195,34 @@ Abramov, Sindre Sorhus, Steinberger, Wang). Their commit charts make the
 difference visible at a glance. Try
 [Torvalds vs Abramov vs Sorhus](/torvalds,gaearon,sindresorhus) on one
 chart, or flip the [leaderboard](/?metric=followers) to Commits and watch
-half this list vanish. Then [look someone up](/), because the board only
-gets smarter when you do.
+half this list vanish.
+
+## Common questions
+
+### Who has the most followers on GitHub?
+
+Linus Torvalds, the creator of Linux and Git, with more than 312,000
+followers. Andrej Karpathy is second with about 210,000, and Evan You,
+creator of Vue.js, is third with roughly 108,000.
+
+### Are GitHub followers the same as stars?
+
+No. Followers attach to a person and track people who want to see that
+developer's activity. Stars attach to a repository and track interest in a
+project. A developer can have a hugely starred project and comparatively
+few followers, or the reverse.
+
+### Do more followers mean a better developer?
+
+Not directly. Followers measure
+[reach, not contribution](/-/metrics/followers). Several people on this
+list have enormous followings built on teaching or one famous project,
+while some of the heaviest committers on GitHub have a fraction of the
+followers. It is closer to an audience size than a skill score.
+
+## See where you land
+
+**[Look yourself up on commit-history](/)** to see where your own lifetime
+commits put you on the global leaderboard, then flip it to
+[followers](/?metric=followers) to compare. The board only gets smarter as
+more people are added, so every lookup helps.

--- a/src/content/posts/most-followed-github-users.mdx
+++ b/src/content/posts/most-followed-github-users.mdx
@@ -50,7 +50,7 @@ Follower counts below come from our snapshot of July 19, 2026.
 
 ## 1. Linus Torvalds
 
-<Person login="torvalds" followers="312k" commits="35.7k" />
+<Person login="torvalds" stats="312k followers · 35.7k commits" />
 
 The unavoidable number one. Linus created Linux in 1991 and, almost as a
 side effect, Git in 2005, which means every follow, fork, and commit on
@@ -64,7 +64,7 @@ two inventions.
 
 ## 2. Andrej Karpathy
 
-<Person login="karpathy" followers="210k" commits="2.9k" />
+<Person login="karpathy" stats="210k followers · 2.9k commits" />
 
 The purest broadcaster profile on the list: two hundred thousand followers
 on fewer than three thousand public commits. Andrej was a founding member
@@ -79,7 +79,7 @@ have learned LLMs from.
 
 ## 3. Evan You
 
-<Person login="yyx990803" followers="108k" commits="40k" />
+<Person login="yyx990803" stats="108k followers · 40k commits" />
 
 Creator of [Vue.js](https://github.com/vuejs) and
 [Vite](https://github.com/vitejs/vite), and proof that you can be both
@@ -93,7 +93,7 @@ chance you are inside his dependency graph.
 
 ## 4. Dan Abramov
 
-<Person login="gaearon" followers="91k" commits="68.6k" />
+<Person login="gaearon" stats="91k followers · 68.6k commits" />
 
 Co-author of Redux, longtime React core team member at Meta, and the
 highest committer on this entire list. Dan's superpower has always been
@@ -107,7 +107,7 @@ commit rate.
 
 ## 5. Sindre Sorhus
 
-<Person login="sindresorhus" followers="80k" commits="35k" />
+<Person login="sindresorhus" stats="80k followers · 35k commits" />
 
 The most prolific open-source maintainer of the npm era: over a thousand
 packages (`chalk`, `got`, `execa`, `ora`…), the original
@@ -122,7 +122,7 @@ him.
 
 ## 6. Brad Traversy
 
-<Person login="bradtraversy" followers="76k" commits="3.2k" />
+<Person login="bradtraversy" stats="76k followers · 3.2k commits" />
 
 The educator's educator. [Traversy Media](https://traversymedia.com) crash
 courses have been the first hour of programming for millions of learners,
@@ -135,7 +135,7 @@ looks like when teaching, not tooling, is the product.
 
 ## 7. Jake Wharton
 
-<Person login="JakeWharton" followers="68k" commits="26.6k" />
+<Person login="JakeWharton" stats="68k followers · 26.6k commits" />
 
 If you have written Android code, you have imported Jake Wharton: Retrofit,
 OkHttp, and Picasso from his Square years, plus ActionBarSherlock and
@@ -148,7 +148,7 @@ counts usually never see.
 
 ## 8. Phil Wang
 
-<Person login="lucidrains" followers="61k" commits="22.8k" />
+<Person login="lucidrains" stats="61k followers · 22.8k commits" />
 
 GitHub's research-paper printing press. When a notable AI paper drops, Phil
 Wang's PyTorch implementation often exists before the authors' own code
@@ -162,7 +162,7 @@ working code today.
 
 ## 9. Peter Steinberger
 
-<Person login="steipete" followers="52k" commits="60.7k" />
+<Person login="steipete" stats="52k followers · 60.7k commits" />
 
 Founder of PSPDFKit, the PDF engine inside half your iOS apps. He retired,
 got bored, and in late 2025 shipped [OpenClaw](https://github.com/openclaw),
@@ -176,7 +176,7 @@ too.
 
 ## 10. TJ Holowaychuk
 
-<Person login="tj" followers="52k" commits="33.4k" />
+<Person login="tj" stats="52k followers · 33.4k commits" />
 
 The ghost at the top of the dependency tree. TJ wrote Express, Koa, Mocha,
 Commander, and Stylus, a startling share of Node.js's foundational layer,
@@ -226,3 +226,7 @@ followers. It is closer to an audience size than a skill score.
 commits put you on the global leaderboard, then flip it to
 [followers](/?metric=followers) to compare. The board only gets smarter as
 more people are added, so every lookup helps.
+
+*More rankings: the [most commits](/-/most-commits-on-github), the
+[most pull requests](/-/most-pull-requests-on-github), and the
+[most code reviews](/-/most-code-reviews-on-github) on GitHub.*

--- a/src/content/posts/most-followed-github-users.mdx
+++ b/src/content/posts/most-followed-github-users.mdx
@@ -22,18 +22,18 @@ The most-followed developer on GitHub is **Linus Torvalds**, with more than
 framework authors, and educators. Here is the full ranking as of
 July 2026:
 
-| # | Developer | GitHub followers |
-| --- | --- | ---: |
-| 1 | [Linus Torvalds](/torvalds) | 312k |
-| 2 | [Andrej Karpathy](/karpathy) | 210k |
-| 3 | [Evan You](/yyx990803) | 108k |
-| 4 | [Dan Abramov](/gaearon) | 91k |
-| 5 | [Sindre Sorhus](/sindresorhus) | 80k |
-| 6 | [Brad Traversy](/bradtraversy) | 76k |
-| 7 | [Jake Wharton](/jakewharton) | 68k |
-| 8 | [Phil Wang](/lucidrains) | 61k |
-| 9 | [Peter Steinberger](/steipete) | 52k |
-| 10 | [TJ Holowaychuk](/tj) | 52k |
+<RankBoard unit="followers" rows={[
+	{ login: "torvalds", name: "Linus Torvalds", value: "312k" },
+	{ login: "karpathy", name: "Andrej Karpathy", value: "210k" },
+	{ login: "yyx990803", name: "Evan You", value: "108k" },
+	{ login: "gaearon", name: "Dan Abramov", value: "91k" },
+	{ login: "sindresorhus", name: "Sindre Sorhus", value: "80k" },
+	{ login: "bradtraversy", name: "Brad Traversy", value: "76k" },
+	{ login: "JakeWharton", name: "Jake Wharton", value: "68k" },
+	{ login: "lucidrains", name: "Phil Wang", value: "61k" },
+	{ login: "steipete", name: "Peter Steinberger", value: "52k" },
+	{ login: "tj", name: "TJ Holowaychuk", value: "52k" },
+]} />
 
 Followers are GitHub's applause meter. They measure
 [reach, not contribution](/-/metrics/followers), so the ranking looks

--- a/src/content/posts/most-issues-on-github.mdx
+++ b/src/content/posts/most-issues-on-github.mdx
@@ -23,18 +23,18 @@ issue is how you track a bug, plan a release, or record a decision, so this
 board is where maintainers live. It rewards the people *running* big
 projects more than the people contributing to them.
 
-| # | Developer | Issues |
-| --- | --- | ---: |
-| 1 | [Andy Wilkinson](/wilkinsona) | 13.9k |
-| 2 | [Yegor Bugayenko](/yegor256) | 10.9k |
-| 3 | [Andrew Nesbitt](/andrew) | 10.0k |
-| 4 | [Kim Morrison](/kim-em) | 9.8k |
-| 5 | [Hadley Wickham](/hadley) | 8.0k |
-| 6 | [Josh Goldberg](/JoshuaKGoldberg) | 7.8k |
-| 7 | [Benjamin Pasero](/bpasero) | 7.4k |
-| 8 | [Simon Willison](/simonw) | 7.4k |
-| 9 | [Sijie Guo](/sijie) | 6.7k |
-| 10 | [Chris Huber](/chubes4) | 6.5k |
+<RankBoard unit="issues" rows={[
+	{ login: "wilkinsona", name: "Andy Wilkinson", value: "13.9k" },
+	{ login: "yegor256", name: "Yegor Bugayenko", value: "10.9k" },
+	{ login: "andrew", name: "Andrew Nesbitt", value: "10.0k" },
+	{ login: "kim-em", name: "Kim Morrison", value: "9.8k" },
+	{ login: "hadley", name: "Hadley Wickham", value: "8.0k" },
+	{ login: "JoshuaKGoldberg", name: "Josh Goldberg", value: "7.8k" },
+	{ login: "bpasero", name: "Benjamin Pasero", value: "7.4k" },
+	{ login: "simonw", name: "Simon Willison", value: "7.4k" },
+	{ login: "sijie", name: "Sijie Guo", value: "6.7k" },
+	{ login: "chubes4", name: "Chris Huber", value: "6.5k" },
+]} />
 
 ## 1. Andy Wilkinson
 

--- a/src/content/posts/most-issues-on-github.mdx
+++ b/src/content/posts/most-issues-on-github.mdx
@@ -1,0 +1,182 @@
+---
+title: "The 10 developers who have opened the most issues on GitHub"
+description: "Who has opened the most issues on GitHub? The 2026 top 10 is a lineup of framework leads and open-source cartographers, from Spring Boot to Datasette. Full ranking, with charts."
+publishedAt: "2026-07-20"
+updatedAt: "2026-07-20"
+order: 5
+people:
+  - { login: wilkinsona, name: Andy Wilkinson }
+  - { login: yegor256, name: Yegor Bugayenko }
+  - { login: andrew, name: Andrew Nesbitt }
+  - { login: kim-em, name: Kim Morrison }
+  - { login: hadley, name: Hadley Wickham }
+  - { login: JoshuaKGoldberg, name: Josh Goldberg }
+  - { login: bpasero, name: Benjamin Pasero }
+  - { login: simonw, name: Simon Willison }
+  - { login: sijie, name: Sijie Guo }
+  - { login: chubes4, name: Chris Huber }
+---
+
+The developer who has opened the most issues on GitHub is **Andy Wilkinson**
+(@wilkinsona), a Spring Boot lead maintainer, with about 14,000. Opening an
+issue is how you track a bug, plan a release, or record a decision, so this
+board is where maintainers live. It rewards the people *running* big
+projects more than the people contributing to them.
+
+| # | Developer | Issues |
+| --- | --- | ---: |
+| 1 | [Andy Wilkinson](/wilkinsona) | 13.9k |
+| 2 | [Yegor Bugayenko](/yegor256) | 10.9k |
+| 3 | [Andrew Nesbitt](/andrew) | 10.0k |
+| 4 | [Kim Morrison](/kim-em) | 9.8k |
+| 5 | [Hadley Wickham](/hadley) | 8.0k |
+| 6 | [Josh Goldberg](/JoshuaKGoldberg) | 7.8k |
+| 7 | [Benjamin Pasero](/bpasero) | 7.4k |
+| 8 | [Simon Willison](/simonw) | 7.4k |
+| 9 | [Sijie Guo](/sijie) | 6.7k |
+| 10 | [Chris Huber](/chubes4) | 6.5k |
+
+## 1. Andy Wilkinson
+
+<Person login="wilkinsona" stats="13.9k issues · Spring Boot" />
+
+A lead maintainer of Spring Boot at Broadcom. Running one of the biggest
+frameworks in the Java world means the issue tracker is your desk: every
+bug, feature, and release task starts as an issue you open.
+
+![Lifetime issues chart of Andy Wilkinson](/embed/wilkinsona?metric=issues)
+
+## 2. Yegor Bugayenko
+
+<Person login="yegor256" stats="10.9k issues · author & Zerocracy" />
+
+Author of *Elegant Objects* and architect of Objectionary, who runs his
+projects (and his company, Zerocracy) on a famously issue-driven, pay-per-task
+process. If any workflow was built to generate issues, it is his.
+
+![Lifetime issues chart of Yegor Bugayenko](/embed/yegor256?metric=issues)
+
+## 3. Andrew Nesbitt
+
+<Person login="andrew" stats="10.0k issues · ecosyste.ms" />
+
+The open-source cartographer behind Libraries.io, ecosyste.ms, and Octobox.
+Mapping the dependency graph of all open source, and building tools to manage
+notifications across thousands of repositories, is issue-tracking as a
+vocation.
+
+![Lifetime issues chart of Andrew Nesbitt](/embed/andrew?metric=issues)
+
+## 4. Kim Morrison
+
+<Person login="kim-em" stats="9.8k issues · Lean & mathlib" />
+
+The mathematician and Lean/mathlib maintainer (at the Lean FRO) who also sits
+on the [pull-request board](/-/most-pull-requests-on-github). Formalizing
+mathematics is a heavily tracked, heavily reviewed process, and it shows up
+across every collaboration metric.
+
+![Lifetime issues chart of Kim Morrison](/embed/kim-em?metric=issues)
+
+## 5. Hadley Wickham
+
+<Person login="hadley" stats="8.0k issues · tidyverse" />
+
+Chief Scientist at Posit and the mind behind the tidyverse, the R packages
+(`ggplot2`, `dplyr`) that most data scientists learn first. Maintaining a
+huge family of packages means a huge, well-run issue tracker.
+
+![Lifetime issues chart of Hadley Wickham](/embed/hadley?metric=issues)
+
+## 6. Josh Goldberg
+
+<Person login="JoshuaKGoldberg" stats="7.8k issues · typescript-eslint" />
+
+A maintainer of typescript-eslint and a contributor across the ESLint and
+TypeScript tooling world, now at Sentry. Linting projects generate endless
+tracked work: rules, false positives, and version support.
+
+![Lifetime issues chart of Josh Goldberg](/embed/JoshuaKGoldberg?metric=issues)
+
+## 7. Benjamin Pasero
+
+<Person login="bpasero" stats="7.4k issues · VS Code" />
+
+A principal engineer on the Visual Studio Code core team at Microsoft. VS
+Code is one of the most-used and most-reported projects on GitHub, and its
+core maintainers open tracking issues at a matching pace.
+
+![Lifetime issues chart of Benjamin Pasero](/embed/bpasero?metric=issues)
+
+## 8. Simon Willison
+
+<Person login="simonw" stats="7.4k issues · Datasette" />
+
+Co-creator of Django and creator of Datasette, and a famous practitioner of
+"issue-driven development": he narrates his work in public issue threads.
+It is a deliberate style, and it puts him near the top of this board.
+
+![Lifetime issues chart of Simon Willison](/embed/simonw?metric=issues)
+
+## 9. Sijie Guo
+
+<Person login="sijie" stats="6.7k issues · Apache Pulsar" />
+
+Founder and CEO of StreamNative and a member of the Apache Software
+Foundation, central to Apache Pulsar. Shepherding an Apache-scale project is
+governance work, and governance runs on issues.
+
+![Lifetime issues chart of Sijie Guo](/embed/sijie?metric=issues)
+
+## 10. Chris Huber
+
+<Person login="chubes4" stats="6.5k issues · Automattic" />
+
+An engineer at Automattic and founder of Extra Chill. Rounding out a top ten
+that is, unusually, almost all recognizable maintainers: the issues board is
+the one where running projects, not automation, gets you to the top.
+
+![Lifetime issues chart of Chris Huber](/embed/chubes4?metric=issues)
+
+## What the issues board measures
+
+Of all our metrics, issues opened is the clearest fingerprint of
+*maintainership*. A high count means someone spends their days planning,
+triaging, and coordinating a project, not just contributing to one. That is
+why this board, unlike [commits](/-/most-commits-on-github) or
+[pull requests](/-/most-pull-requests-on-github), is full of names you may
+recognize: framework leads and open-source infrastructure builders. The
+[issues metric explainer](/-/metrics/issues) has the details.
+
+## Common questions
+
+### Who has opened the most issues on GitHub?
+
+By our count, Andy Wilkinson (@wilkinsona), a Spring Boot lead maintainer,
+with about 14,000, followed by Yegor Bugayenko and open-source cartographer
+Andrew Nesbitt.
+
+### Does opening lots of issues mean someone is complaining a lot?
+
+No. On GitHub an "issue" is a unit of tracked work: a bug report, a feature
+plan, a release task. High counts belong to the people organizing big
+projects, where the issue tracker is the primary planning tool.
+
+### Are issues you open counted on your GitHub profile?
+
+Yes. Opening an issue in a public repository counts as a contribution.
+Issues in private repositories fold into
+[private contributions](/-/most-private-contributions-on-github).
+
+## See where you land
+
+**[Look yourself up on commit-history](/)** and switch your chart to
+[issues](/?metric=issues) to see your own tracking curve and where it lands
+on the [global leaderboard](/).
+
+*More GitHub rankings: [most-followed developers](/-/most-followed-github-users),
+[most commits](/-/most-commits-on-github),
+[most pull requests](/-/most-pull-requests-on-github),
+[most code reviews](/-/most-code-reviews-on-github),
+[most repositories](/-/most-repositories-on-github), and
+[most private contributions](/-/most-private-contributions-on-github).*

--- a/src/content/posts/most-private-contributions-on-github.mdx
+++ b/src/content/posts/most-private-contributions-on-github.mdx
@@ -11,31 +11,31 @@ people:
   - { login: taylorotwell, name: Taylor Otwell }
   - { login: fabpot, name: Fabien Potencier }
   - { login: levelsio, name: Pieter Levels }
-  - { login: dfinley, name: dfinley }
   - { login: cheshire137, name: Sarah Vessels }
   - { login: designorant, name: Michał Ordon }
   - { login: zkochan, name: Zoltan Kochan }
+  - { login: riderx, name: Martin Donadieu }
 ---
 
 The developer with the most private contributions on GitHub is **Ryan
 Hartlage** (@ryanplusplus), an embedded-firmware engineer at GE Appliances,
 with over 366,000. Private contributions are the iceberg below the waterline:
-work in private repositories, which GitHub only reveals if you opt in. So
-this board is a specific mix, the people whose real output is mostly hidden
-*and* who chose to show the count anyway.
+work in private repositories, which GitHub only reveals if you opt in. So this
+board is a specific mix, the people whose real output is mostly hidden *and*
+who chose to show the count anyway.
 
-| # | Developer | Private contributions |
-| --- | --- | ---: |
-| 1 | [Ryan Hartlage](/ryanplusplus) | 367k |
-| 2 | [Prince Chaddha](/princechaddha) | 343k |
-| 3 | [Johannes Schindelin](/dscho) | 293k |
-| 4 | [Taylor Otwell](/taylorotwell) | 168k |
-| 5 | [Fabien Potencier](/fabpot) | 168k |
-| 6 | [Pieter Levels](/levelsio) | 162k |
-| 7 | [dfinley](/dfinley) | 145k |
-| 8 | [Sarah Vessels](/cheshire137) | 143k |
-| 9 | [Michał Ordon](/designorant) | 135k |
-| 10 | [Zoltan Kochan](/zkochan) | 130k |
+<RankBoard unit="private contributions" rows={[
+	{ login: "ryanplusplus", name: "Ryan Hartlage", value: "367k" },
+	{ login: "princechaddha", name: "Prince Chaddha", value: "343k" },
+	{ login: "dscho", name: "Johannes Schindelin", value: "293k" },
+	{ login: "taylorotwell", name: "Taylor Otwell", value: "168k" },
+	{ login: "fabpot", name: "Fabien Potencier", value: "168k" },
+	{ login: "levelsio", name: "Pieter Levels", value: "162k" },
+	{ login: "cheshire137", name: "Sarah Vessels", value: "143k" },
+	{ login: "designorant", name: "Michał Ordon", value: "135k" },
+	{ login: "zkochan", name: "Zoltan Kochan", value: "130k" },
+	{ login: "riderx", name: "Martin Donadieu", value: "127k" },
+]} />
 
 ## 1. Ryan Hartlage
 
@@ -53,7 +53,7 @@ work that tops this board.
 <Person login="princechaddha" stats="343k private contributions · ProjectDiscovery" />
 
 A core member of ProjectDiscovery, makers of the Nuclei vulnerability scanner.
-Security tooling companies do much of their development privately before it
+Security-tooling companies do much of their development privately before it
 ships, and the private-contribution count captures that.
 
 ![Lifetime private-contribution chart of Prince Chaddha](/embed/princechaddha?metric=private)
@@ -99,18 +99,7 @@ almost nothing public.
 
 ![Lifetime private-contribution chart of Pieter Levels](/embed/levelsio?metric=private)
 
-## 7. dfinley
-
-<Person login="dfinley" stats="145k private contributions · unidentified" />
-
-An account with almost no public footprint: no name, no bio, a handful of
-small repositories. It is the perfect illustration of the metric. You can sit
-near the top of the private-contributions board while being effectively
-invisible on GitHub, because the work is, by definition, private.
-
-![Lifetime private-contribution chart of dfinley](/embed/dfinley?metric=private)
-
-## 8. Sarah Vessels
+## 7. Sarah Vessels
 
 <Person login="cheshire137" stats="143k private contributions · GitHub" />
 
@@ -120,7 +109,7 @@ of the job.
 
 ![Lifetime private-contribution chart of Sarah Vessels](/embed/cheshire137?metric=private)
 
-## 9. Michał Ordon
+## 8. Michał Ordon
 
 <Person login="designorant" stats="135k private contributions · independent" />
 
@@ -130,15 +119,25 @@ independent racks up a six-figure hidden count.
 
 ![Lifetime private-contribution chart of Michał Ordon](/embed/designorant?metric=private)
 
-## 10. Zoltan Kochan
+## 9. Zoltan Kochan
 
 <Person login="zkochan" stats="130k private contributions · pnpm" />
 
 The maintainer of pnpm, the fast package manager, now at Bit. A rare case
-where a very public open-source figure also carries an enormous private
-count, from the commercial work alongside the open project.
+where a very public open-source figure also carries an enormous private count,
+from the commercial work alongside the open project.
 
 ![Lifetime private-contribution chart of Zoltan Kochan](/embed/zkochan?metric=private)
+
+## 10. Martin Donadieu
+
+<Person login="riderx" stats="127k private contributions · Capgo" />
+
+The founder of Capgo, an open-source live-update platform for Capacitor apps,
+built solo and bootstrapped. Another indie maker whose product work happens
+mostly in private, alongside the open-source core.
+
+![Lifetime private-contribution chart of Martin Donadieu](/embed/riderx?metric=private)
 
 ## What the private-contributions board measures
 
@@ -147,8 +146,7 @@ single opaque count of contributions in private repositories, and only if the
 user turns on "include private contributions." So the board has a built-in
 selection effect: it is not everyone with lots of private work, only those who
 also chose to reveal the number. The names reflect that: framework creators
-who build commercially, company engineers, indie hackers, and the occasional
-account that is otherwise a ghost. The
+who build commercially, company engineers, and indie hackers. The
 [private-contributions explainer](/-/metrics/private-contributions) covers how
 the count works and why it can vanish.
 
@@ -177,9 +175,8 @@ contributions live.
 ## See where you land
 
 **[Look yourself up on commit-history](/)** and switch your chart to
-[private](/?metric=private) to see your own hidden curve, if you have
-private contributions enabled, and where it lands on the
-[global leaderboard](/).
+[private](/?metric=private) to see your own hidden curve, if you have private
+contributions enabled, and where it lands on the [global leaderboard](/).
 
 *More GitHub rankings: [most-followed developers](/-/most-followed-github-users),
 [most commits](/-/most-commits-on-github),

--- a/src/content/posts/most-private-contributions-on-github.mdx
+++ b/src/content/posts/most-private-contributions-on-github.mdx
@@ -1,0 +1,189 @@
+---
+title: "The 10 developers with the most private contributions on GitHub"
+description: "Who has the most private contributions on GitHub? The 2026 top 10 is the platform's biggest icebergs, from Laravel and Symfony's creators to indie hackers. Full ranking, with charts."
+publishedAt: "2026-07-20"
+updatedAt: "2026-07-20"
+order: 7
+people:
+  - { login: ryanplusplus, name: Ryan Hartlage }
+  - { login: princechaddha, name: Prince Chaddha }
+  - { login: dscho, name: Johannes Schindelin }
+  - { login: taylorotwell, name: Taylor Otwell }
+  - { login: fabpot, name: Fabien Potencier }
+  - { login: levelsio, name: Pieter Levels }
+  - { login: dfinley, name: dfinley }
+  - { login: cheshire137, name: Sarah Vessels }
+  - { login: designorant, name: Michał Ordon }
+  - { login: zkochan, name: Zoltan Kochan }
+---
+
+The developer with the most private contributions on GitHub is **Ryan
+Hartlage** (@ryanplusplus), an embedded-firmware engineer at GE Appliances,
+with over 366,000. Private contributions are the iceberg below the waterline:
+work in private repositories, which GitHub only reveals if you opt in. So
+this board is a specific mix, the people whose real output is mostly hidden
+*and* who chose to show the count anyway.
+
+| # | Developer | Private contributions |
+| --- | --- | ---: |
+| 1 | [Ryan Hartlage](/ryanplusplus) | 367k |
+| 2 | [Prince Chaddha](/princechaddha) | 343k |
+| 3 | [Johannes Schindelin](/dscho) | 293k |
+| 4 | [Taylor Otwell](/taylorotwell) | 168k |
+| 5 | [Fabien Potencier](/fabpot) | 168k |
+| 6 | [Pieter Levels](/levelsio) | 162k |
+| 7 | [dfinley](/dfinley) | 145k |
+| 8 | [Sarah Vessels](/cheshire137) | 143k |
+| 9 | [Michał Ordon](/designorant) | 135k |
+| 10 | [Zoltan Kochan](/zkochan) | 130k |
+
+## 1. Ryan Hartlage
+
+<Person login="ryanplusplus" stats="367k private contributions · GE Appliances" />
+
+An embedded-firmware engineer at GE Appliances, and the author of the open
+"tiny" state-machine library for microcontrollers. Day-job appliance firmware
+lives in private repositories, which is exactly the kind of high-volume hidden
+work that tops this board.
+
+![Lifetime private-contribution chart of Ryan Hartlage](/embed/ryanplusplus?metric=private)
+
+## 2. Prince Chaddha
+
+<Person login="princechaddha" stats="343k private contributions · ProjectDiscovery" />
+
+A core member of ProjectDiscovery, makers of the Nuclei vulnerability scanner.
+Security tooling companies do much of their development privately before it
+ships, and the private-contribution count captures that.
+
+![Lifetime private-contribution chart of Prince Chaddha](/embed/princechaddha?metric=private)
+
+## 3. Johannes Schindelin
+
+<Person login="dscho" stats="293k private contributions · Git for Windows" />
+
+The maintainer of Git for Windows, at Microsoft. One of the most consequential
+open-source maintainers alive, whose day-to-day also runs through a great deal
+of private work.
+
+![Lifetime private-contribution chart of Johannes Schindelin](/embed/dscho?metric=private)
+
+## 4. Taylor Otwell
+
+<Person login="taylorotwell" stats="168k private contributions · Laravel" />
+
+The creator of Laravel, the framework behind a huge share of the PHP web.
+Laravel's commercial products (Forge, Vapor, Cloud) are built privately, so
+much of his prodigious output never appears as a public commit.
+
+![Lifetime private-contribution chart of Taylor Otwell](/embed/taylorotwell?metric=private)
+
+## 5. Fabien Potencier
+
+<Person login="fabpot" stats="168k private contributions · Symfony" />
+
+The creator of Symfony and CTO of Upsun. The same story as Laravel from the
+other side of the PHP world: a framework author whose business is built in
+private repositories.
+
+![Lifetime private-contribution chart of Fabien Potencier](/embed/fabpot?metric=private)
+
+## 6. Pieter Levels
+
+<Person login="levelsio" stats="162k private contributions · indie hacker" />
+
+The famous solo founder (Nomad List, Photo AI, and more), who ships a stream
+of profitable products almost entirely in private. With barely two dozen
+public commits, he is the purest iceberg on this list: enormous hidden output,
+almost nothing public.
+
+![Lifetime private-contribution chart of Pieter Levels](/embed/levelsio?metric=private)
+
+## 7. dfinley
+
+<Person login="dfinley" stats="145k private contributions · unidentified" />
+
+An account with almost no public footprint: no name, no bio, a handful of
+small repositories. It is the perfect illustration of the metric. You can sit
+near the top of the private-contributions board while being effectively
+invisible on GitHub, because the work is, by definition, private.
+
+![Lifetime private-contribution chart of dfinley](/embed/dfinley?metric=private)
+
+## 8. Sarah Vessels
+
+<Person login="cheshire137" stats="143k private contributions · GitHub" />
+
+A developer at GitHub itself. Working on GitHub means working in GitHub's own
+private repositories, so a huge private-contribution count is simply the shape
+of the job.
+
+![Lifetime private-contribution chart of Sarah Vessels](/embed/cheshire137?metric=private)
+
+## 9. Michał Ordon
+
+<Person login="designorant" stats="135k private contributions · independent" />
+
+An independent engineering consultant in London (and React Native ecosystem
+alum). Client and consulting work is private by nature, which is how an
+independent racks up a six-figure hidden count.
+
+![Lifetime private-contribution chart of Michał Ordon](/embed/designorant?metric=private)
+
+## 10. Zoltan Kochan
+
+<Person login="zkochan" stats="130k private contributions · pnpm" />
+
+The maintainer of pnpm, the fast package manager, now at Bit. A rare case
+where a very public open-source figure also carries an enormous private
+count, from the commercial work alongside the open project.
+
+![Lifetime private-contribution chart of Zoltan Kochan](/embed/zkochan?metric=private)
+
+## What the private-contributions board measures
+
+This is the only metric that measures work you *cannot* see. GitHub reports a
+single opaque count of contributions in private repositories, and only if the
+user turns on "include private contributions." So the board has a built-in
+selection effect: it is not everyone with lots of private work, only those who
+also chose to reveal the number. The names reflect that: framework creators
+who build commercially, company engineers, indie hackers, and the occasional
+account that is otherwise a ghost. The
+[private-contributions explainer](/-/metrics/private-contributions) covers how
+the count works and why it can vanish.
+
+## Common questions
+
+### Who has the most private contributions on GitHub?
+
+By our count, Ryan Hartlage (@ryanplusplus), an embedded engineer at GE
+Appliances, with over 366,000, followed by ProjectDiscovery's Prince Chaddha
+and Git for Windows maintainer Johannes Schindelin.
+
+### What counts as a private contribution?
+
+An opaque, all-types count of your activity (commits, PRs, issues, reviews) in
+private repositories. GitHub shows it only if you enable "include private
+contributions on my profile"; otherwise it stays hidden and reads as zero
+here.
+
+### Why do framework creators have so many private contributions?
+
+Many open-source frameworks are funded by private commercial products built by
+the same people. Laravel, Symfony, and pnpm all have private business code
+alongside the public project, and that private work is where a lot of the
+contributions live.
+
+## See where you land
+
+**[Look yourself up on commit-history](/)** and switch your chart to
+[private](/?metric=private) to see your own hidden curve, if you have
+private contributions enabled, and where it lands on the
+[global leaderboard](/).
+
+*More GitHub rankings: [most-followed developers](/-/most-followed-github-users),
+[most commits](/-/most-commits-on-github),
+[most pull requests](/-/most-pull-requests-on-github),
+[most code reviews](/-/most-code-reviews-on-github),
+[most issues](/-/most-issues-on-github), and
+[most repositories](/-/most-repositories-on-github).*

--- a/src/content/posts/most-pull-requests-on-github.mdx
+++ b/src/content/posts/most-pull-requests-on-github.mdx
@@ -1,56 +1,43 @@
 ---
-title: "The 10 accounts with the most pull requests on GitHub"
-description: "Who has opened the most pull requests on GitHub? The 2026 top 10, from a Liferay CI bot to the busiest human maintainers, each with their chart and what they work on."
+title: "The 10 developers who have opened the most pull requests on GitHub"
+description: "Who has opened the most pull requests on GitHub? The 2026 top 10 is dominated by package maintainers and PR-gated workflows, from Homebrew to Home Assistant. Full ranking, with charts."
 publishedAt: "2026-07-20"
 updatedAt: "2026-07-20"
 order: 3
 people:
-  - { login: liferay-continuous-integration, name: Liferay Continuous Integration }
   - { login: chenrui333, name: Rui Chen }
   - { login: bfoley13, name: Brandon Foley }
-  - { login: AlCutter, name: Al Cutter }
   - { login: fabaff, name: Fabian Affolter }
   - { login: bdraco, name: J. Nick Koston }
   - { login: p-linnane, name: Patrick Linnane }
   - { login: kim-em, name: Kim Morrison }
   - { login: vkameswaran, name: Vaishant Kameswaran }
   - { login: shuyangzhou, name: Shuyang Zhou }
+  - { login: suzuki-shunsuke, name: Shunsuke Suzuki }
+  - { login: chenjiahan, name: Jiahan Chen }
 ---
 
-The account that has opened the most pull requests on GitHub is not a person
-at all: it is **Liferay's continuous-integration bot**
-(@liferay-continuous-integration), with more than 74,000. The most prolific
-*human* is **Rui Chen** (@chenrui333), a Homebrew maintainer, with about
-54,000. That one-two captures the whole board: a [pull
-request](/-/metrics/pull-requests) is counted the moment it is opened, so the
-top is owned by automation and by package maintainers who open one for every
-update.
+The developer who has opened the most pull requests on GitHub is **Rui Chen**
+(@chenrui333), a Homebrew maintainer, with about 54,000. A [pull
+request](/-/metrics/pull-requests) is counted the moment it is opened, in any
+public repository, so this board rewards volume above all. It belongs almost
+entirely to package maintainers and engineers on PR-gated workflows, where
+every change, however small, goes through a pull request.
 
-| # | Account | Pull requests |
-| --- | --- | ---: |
-| 1 | [Liferay CI](/liferay-continuous-integration) *(bot)* | 74.7k |
-| 2 | [Rui Chen](/chenrui333) | 54.0k |
-| 3 | [Brandon Foley](/bfoley13) | 52.6k |
-| 4 | [Al Cutter](/AlCutter) | 27.3k |
-| 5 | [Fabian Affolter](/fabaff) | 24.1k |
-| 6 | [J. Nick Koston](/bdraco) | 21.7k |
-| 7 | [Patrick Linnane](/p-linnane) | 18.6k |
-| 8 | [Kim Morrison](/kim-em) | 18.4k |
-| 9 | [Vaishant Kameswaran](/vkameswaran) | 17.4k |
-| 10 | [Shuyang Zhou](/shuyangzhou) | 15.0k |
+<RankBoard unit="pull requests" rows={[
+	{ login: "chenrui333", name: "Rui Chen", value: "54.0k" },
+	{ login: "bfoley13", name: "Brandon Foley", value: "52.6k" },
+	{ login: "fabaff", name: "Fabian Affolter", value: "24.1k" },
+	{ login: "bdraco", name: "J. Nick Koston", value: "21.7k" },
+	{ login: "p-linnane", name: "Patrick Linnane", value: "18.6k" },
+	{ login: "kim-em", name: "Kim Morrison", value: "18.4k" },
+	{ login: "vkameswaran", name: "Vaishant Kameswaran", value: "17.4k" },
+	{ login: "shuyangzhou", name: "Shuyang Zhou", value: "15.0k" },
+	{ login: "suzuki-shunsuke", name: "Shunsuke Suzuki", value: "14.3k" },
+	{ login: "chenjiahan", name: "Jiahan Chen", value: "13.4k" },
+]} />
 
-## 1. Liferay Continuous Integration
-
-<Person login="liferay-continuous-integration" stats="74.7k pull requests · automation" />
-
-Not a developer: this is a bot that opens pull requests programmatically as
-part of Liferay's build pipeline. GitHub counts it as a user, so it tops the
-board, which is the first thing to know before reading anything into a raw PR
-number. Automation is the single biggest force at the extreme top.
-
-![Lifetime pull-request chart of the Liferay CI account](/embed/liferay-continuous-integration?metric=prs)
-
-## 2. Rui Chen
+## 1. Rui Chen
 
 <Person login="chenrui333" stats="54.0k pull requests · Homebrew" />
 
@@ -60,7 +47,7 @@ rack up numbers no application developer ever could.
 
 ![Lifetime pull-request chart of Rui Chen](/embed/chenrui333?metric=prs)
 
-## 3. Brandon Foley
+## 2. Brandon Foley
 
 <Person login="bfoley13" stats="52.6k pull requests · Microsoft" />
 
@@ -71,17 +58,7 @@ merges land elsewhere.
 
 ![Lifetime pull-request chart of Brandon Foley](/embed/bfoley13?metric=prs)
 
-## 4. Al Cutter
-
-<Person login="AlCutter" stats="27.3k pull requests · Google" />
-
-A Google engineer working on Certificate Transparency and verifiable logs
-(Trillian, Tessera). Transparency-log infrastructure means constant,
-reviewed, automated change, which is exactly the shape that fills a PR board.
-
-![Lifetime pull-request chart of Al Cutter](/embed/AlCutter?metric=prs)
-
-## 5. Fabian Affolter
+## 3. Fabian Affolter
 
 <Person login="fabaff" stats="24.1k pull requests · Fedora & NixOS" />
 
@@ -91,7 +68,7 @@ takes updates as pull requests by the thousand.
 
 ![Lifetime pull-request chart of Fabian Affolter](/embed/fabaff?metric=prs)
 
-## 6. J. Nick Koston
+## 4. J. Nick Koston
 
 <Person login="bdraco" stats="21.7k pull requests · Home Assistant" />
 
@@ -101,7 +78,7 @@ its most active people sit near the top of every board we have.
 
 ![Lifetime pull-request chart of J. Nick Koston](/embed/bdraco?metric=prs)
 
-## 7. Patrick Linnane
+## 5. Patrick Linnane
 
 <Person login="p-linnane" stats="18.6k pull requests · Homebrew" />
 
@@ -111,43 +88,65 @@ structural reason as the first.
 
 ![Lifetime pull-request chart of Patrick Linnane](/embed/p-linnane?metric=prs)
 
-## 8. Kim Morrison
+## 6. Kim Morrison
 
 <Person login="kim-em" stats="18.4k pull requests · Lean & mathlib" />
 
 A mathematician and maintainer of the Lean theorem prover and its mathlib
 library, now at the Lean FRO. Formalizing mathematics is a stacked-diff
-discipline: enormous amounts of small, reviewed pull requests.
+discipline: enormous numbers of small, reviewed pull requests.
 
 ![Lifetime pull-request chart of Kim Morrison](/embed/kim-em?metric=prs)
 
-## 9. Vaishant Kameswaran
+## 7. Vaishant Kameswaran
 
 <Person login="vkameswaran" stats="17.4k pull requests · Greptile" />
 
 Founder of Greptile. Like Brandon Foley, his ratio (thousands of pull
 requests against very few commits) is the fingerprint of a team where every
-change, however small, goes through a pull request.
+change goes through a pull request.
 
 ![Lifetime pull-request chart of Vaishant Kameswaran](/embed/vkameswaran?metric=prs)
 
-## 10. Shuyang Zhou
+## 8. Shuyang Zhou
 
 <Person login="shuyangzhou" stats="15.0k pull requests · Liferay" />
 
-A Liferay engineer, closing the top ten where it opened: inside a large
-codebase whose process routes everything through pull requests (and whose CI
-bot sits at number one).
+A Liferay engineer, working inside a large codebase whose process routes
+every change through a pull request. Corporate monorepos are a reliable way
+onto this board.
 
 ![Lifetime pull-request chart of Shuyang Zhou](/embed/shuyangzhou?metric=prs)
+
+## 9. Shunsuke Suzuki
+
+<Person login="suzuki-shunsuke" stats="14.3k pull requests · aqua" />
+
+A platform engineer and prolific tooling author: the creator of aqua, a
+declarative CLI version manager, plus a suite of GitHub Actions tools
+(pinact, ghalint, github-comment). Automating other people's CI means opening
+a great many pull requests of your own.
+
+![Lifetime pull-request chart of Shunsuke Suzuki](/embed/suzuki-shunsuke?metric=prs)
+
+## 10. Jiahan Chen
+
+<Person login="chenjiahan" stats="13.4k pull requests · Rstack" />
+
+The creator of Rsbuild and lead of the Rust-based Rstack web toolchain at
+ByteDance, and the original author of the Vant mobile UI library. Running a
+fast-moving toolchain family generates a constant stream of pull requests.
+
+![Lifetime pull-request chart of Jiahan Chen](/embed/chenjiahan?metric=prs)
 
 ## What the pull-request board measures
 
 PR count is the best single read on **collaboration across repositories**,
 because a pull request is a proposal made to a codebase, often someone else's.
-But at the extreme top it is dominated by two things that are not "great
-engineering": automated tooling, and the pull-request treadmill of package
-maintenance. Read it as a measure of volume, and see the
+But at the extreme top it is dominated by package maintenance and PR-gated
+corporate workflows more than by raw coding. The commits-to-PRs ratio is the
+tell: someone with 400 commits and 52,000 pull requests lives a very different
+GitHub life than someone with the reverse. See the
 [PR metric explainer](/-/metrics/pull-requests) for how it relates to commits
 and reviews.
 
@@ -155,21 +154,21 @@ and reviews.
 
 ### Who has opened the most pull requests on GitHub?
 
-By our count, the top account is Liferay's continuous-integration bot
-(@liferay-continuous-integration) with over 74,000. The most prolific human is
-Homebrew maintainer Rui Chen (@chenrui333), with about 54,000.
+By our count, Homebrew maintainer Rui Chen (@chenrui333), with about 54,000,
+just ahead of Microsoft's Brandon Foley. (Automated bot accounts can post even
+higher numbers, but they are hidden from our leaderboard when we spot them.)
 
-### Why do bots rank so high for pull requests?
+### Why do package maintainers dominate?
 
-GitHub counts a pull request when it is opened, and continuous-integration and
-dependency-update services open them automatically. A single automation
-account can open more in a month than a person does in years.
+Package managers like Homebrew, Fedora, and NixOS take every update as a pull
+request. Keeping thousands of packages current therefore means opening
+thousands of pull requests, which no ordinary application developer matches.
 
 ### What is a high number of pull requests?
 
 For an individual, a few thousand lifetime pull requests already marks a very
-active open-source contributor. The five-figure counts on this board almost
-always come from package maintenance or automation, not ordinary development.
+active open-source contributor. The five-figure counts on this board come from
+package maintenance or PR-gated workflows, not everyday development.
 
 ## See where you land
 

--- a/src/content/posts/most-pull-requests-on-github.mdx
+++ b/src/content/posts/most-pull-requests-on-github.mdx
@@ -1,0 +1,123 @@
+---
+title: "The 10 accounts with the most pull requests on GitHub"
+description: "Who has opened the most pull requests on GitHub? The 2026 top 10, from a Liferay CI bot to the busiest human contributors, and why the pull-request board rewards automation and package maintenance."
+publishedAt: "2026-07-20"
+updatedAt: "2026-07-20"
+order: 3
+people:
+  - { login: liferay-continuous-integration, name: Liferay Continuous Integration }
+  - { login: chenrui333, name: Rui Chen }
+  - { login: bfoley13, name: Brandon Foley }
+  - { login: AlCutter, name: Al Cutter }
+  - { login: fabaff, name: Fabian Affolter }
+  - { login: bdraco, name: J. Nick Koston }
+  - { login: p-linnane, name: Patrick Linnane }
+  - { login: kim-em, name: Kim Morrison }
+  - { login: vkameswaran, name: Vaishant Kameswaran }
+  - { login: shuyangzhou, name: Shuyang Zhou }
+---
+
+The account that has opened the most pull requests on GitHub is not a person
+at all. It is **Liferay's continuous-integration bot**
+(@liferay-continuous-integration), with more than 74,000. The most prolific
+*human* is **Rui Chen** (@chenrui333), a Homebrew maintainer, with about
+54,000. That one-two says almost everything about what the pull-request board
+measures: automation first, package maintenance second.
+
+| # | Account | Pull requests |
+| --- | --- | ---: |
+| 1 | [Liferay CI](/liferay-continuous-integration) *(bot)* | 74.7k |
+| 2 | [Rui Chen](/chenrui333) | 54.0k |
+| 3 | [Brandon Foley](/bfoley13) | 52.6k |
+| 4 | [Al Cutter](/AlCutter) | 27.3k |
+| 5 | [Fabian Affolter](/fabaff) | 24.1k |
+| 6 | [J. Nick Koston](/bdraco) | 21.7k |
+| 7 | [Patrick Linnane](/p-linnane) | 18.6k |
+| 8 | [Kim Morrison](/kim-em) | 18.4k |
+| 9 | [Vaishant Kameswaran](/vkameswaran) | 17.4k |
+| 10 | [Shuyang Zhou](/shuyangzhou) | 15.0k |
+
+A [pull request](/-/metrics/pull-requests) is counted the moment it is
+*opened*, in any public repository, whether or not it ever merges. Open one
+automatically, tens of thousands of times, and you top this board.
+
+## Why automation owns the top
+
+The number one account is a CI service that opens pull requests
+programmatically as part of Liferay's build pipeline. It is on the developer
+leaderboard because GitHub treats it as a user, but it is a machine. Bots and
+automation are the single biggest reason the extreme top of the PR board
+looks the way it does, and it is worth knowing that before reading too much
+into any raw count.
+
+## The human champions: package maintenance
+
+Strip out the bot and the humans who remain are mostly package and dependency
+maintainers, because keeping a package ecosystem current means opening a
+pull request for every single update.
+
+<Person login="chenrui333" stats="54.0k pull requests · Homebrew" />
+
+Rui Chen is a Homebrew maintainer (and an infrastructure engineer at
+Justworks). Homebrew's model turns every formula bump into a pull request, so
+its active maintainers rack up numbers no application developer ever could.
+
+<Person login="fabaff" stats="24.1k pull requests · Fedora & NixOS" />
+
+Fabian Affolter works across Fedora and NixOS, two more package universes
+where updates flow as pull requests by the thousand.
+
+<Person login="bdraco" stats="21.7k pull requests · Home Assistant" />
+
+J. Nick Koston is a core Home Assistant developer. A project that large, with
+a required-review workflow and constant dependency churn, produces pull
+requests endlessly, and its most active people sit near the top of every
+contribution board we have.
+
+![Lifetime pull-request history chart of J. Nick Koston](/embed/bdraco)
+
+The rest of the human top ten fits the same shape: Patrick Linnane leads
+Homebrew, Shuyang Zhou is another Liferay engineer, and Kim Morrison is a
+prolific contributor in the Lean theorem-prover ecosystem. High PR counts
+mark people who propose changes constantly, usually across many repositories.
+
+## What the pull-request board measures
+
+Of our metrics, PR count is the best single read on **collaboration across
+repositories**, because a pull request is a proposal made to a codebase,
+often someone else's. But at the extreme top it is dominated by two things
+that are not "great engineering": automated tooling, and the pull-request
+treadmill of package maintenance. Read it as a measure of *volume of
+proposals*, and check the [PR metric explainer](/-/metrics/pull-requests) for
+how it relates to commits and reviews.
+
+## Common questions
+
+### Who has opened the most pull requests on GitHub?
+
+By our count, the top account is Liferay's continuous-integration bot
+(@liferay-continuous-integration) with over 74,000 pull requests. The most
+prolific human is Homebrew maintainer Rui Chen (@chenrui333), with about
+54,000.
+
+### Why do bots rank so high for pull requests?
+
+GitHub counts a pull request when it is opened, and continuous-integration
+and dependency-update services open them automatically. A single automation
+account can open more pull requests in a month than a person does in years.
+
+### What is a high number of pull requests?
+
+For an individual, a few thousand lifetime pull requests already marks a very
+active open-source contributor. The five-figure counts on this board almost
+always come from package maintenance or automation, not ordinary development.
+
+## See where you land
+
+**[Look yourself up on commit-history](/)** and flip your chart to
+[pull requests](/?metric=prs) to see your own collaboration curve and where
+it lands on the [global leaderboard](/).
+
+*More rankings: the [most-followed developers](/-/most-followed-github-users),
+the [most commits](/-/most-commits-on-github), and the
+[most code reviews](/-/most-code-reviews-on-github).*

--- a/src/content/posts/most-pull-requests-on-github.mdx
+++ b/src/content/posts/most-pull-requests-on-github.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The 10 accounts with the most pull requests on GitHub"
-description: "Who has opened the most pull requests on GitHub? The 2026 top 10, from a Liferay CI bot to the busiest human contributors, and why the pull-request board rewards automation and package maintenance."
+description: "Who has opened the most pull requests on GitHub? The 2026 top 10, from a Liferay CI bot to the busiest human maintainers, each with their chart and what they work on."
 publishedAt: "2026-07-20"
 updatedAt: "2026-07-20"
 order: 3
@@ -18,11 +18,13 @@ people:
 ---
 
 The account that has opened the most pull requests on GitHub is not a person
-at all. It is **Liferay's continuous-integration bot**
+at all: it is **Liferay's continuous-integration bot**
 (@liferay-continuous-integration), with more than 74,000. The most prolific
 *human* is **Rui Chen** (@chenrui333), a Homebrew maintainer, with about
-54,000. That one-two says almost everything about what the pull-request board
-measures: automation first, package maintenance second.
+54,000. That one-two captures the whole board: a [pull
+request](/-/metrics/pull-requests) is counted the moment it is opened, so the
+top is owned by automation and by package maintainers who open one for every
+update.
 
 | # | Account | Pull requests |
 | --- | --- | ---: |
@@ -37,74 +39,131 @@ measures: automation first, package maintenance second.
 | 9 | [Vaishant Kameswaran](/vkameswaran) | 17.4k |
 | 10 | [Shuyang Zhou](/shuyangzhou) | 15.0k |
 
-A [pull request](/-/metrics/pull-requests) is counted the moment it is
-*opened*, in any public repository, whether or not it ever merges. Open one
-automatically, tens of thousands of times, and you top this board.
+## 1. Liferay Continuous Integration
 
-## Why automation owns the top
+<Person login="liferay-continuous-integration" stats="74.7k pull requests · automation" />
 
-The number one account is a CI service that opens pull requests
-programmatically as part of Liferay's build pipeline. It is on the developer
-leaderboard because GitHub treats it as a user, but it is a machine. Bots and
-automation are the single biggest reason the extreme top of the PR board
-looks the way it does, and it is worth knowing that before reading too much
-into any raw count.
+Not a developer: this is a bot that opens pull requests programmatically as
+part of Liferay's build pipeline. GitHub counts it as a user, so it tops the
+board, which is the first thing to know before reading anything into a raw PR
+number. Automation is the single biggest force at the extreme top.
 
-## The human champions: package maintenance
+![Lifetime pull-request chart of the Liferay CI account](/embed/liferay-continuous-integration)
 
-Strip out the bot and the humans who remain are mostly package and dependency
-maintainers, because keeping a package ecosystem current means opening a
-pull request for every single update.
+## 2. Rui Chen
 
 <Person login="chenrui333" stats="54.0k pull requests · Homebrew" />
 
-Rui Chen is a Homebrew maintainer (and an infrastructure engineer at
-Justworks). Homebrew's model turns every formula bump into a pull request, so
-its active maintainers rack up numbers no application developer ever could.
+A Homebrew maintainer and an infrastructure engineer at Justworks. Homebrew's
+model turns every formula bump into a pull request, so its active maintainers
+rack up numbers no application developer ever could.
+
+![Lifetime pull-request chart of Rui Chen](/embed/chenrui333)
+
+## 3. Brandon Foley
+
+<Person login="bfoley13" stats="52.6k pull requests · Microsoft" />
+
+A senior software engineer at Microsoft working on Azure Kubernetes Service.
+With barely 400 commits against 52,000 pull requests, his profile is a pure
+example of a PR-gated workflow: propose everything as a pull request, let the
+merges land elsewhere.
+
+![Lifetime pull-request chart of Brandon Foley](/embed/bfoley13)
+
+## 4. Al Cutter
+
+<Person login="AlCutter" stats="27.3k pull requests · Google" />
+
+A Google engineer working on Certificate Transparency and verifiable logs
+(Trillian, Tessera). Transparency-log infrastructure means constant,
+reviewed, automated change, which is exactly the shape that fills a PR board.
+
+![Lifetime pull-request chart of Al Cutter](/embed/AlCutter)
+
+## 5. Fabian Affolter
 
 <Person login="fabaff" stats="24.1k pull requests · Fedora & NixOS" />
 
-Fabian Affolter works across Fedora and NixOS, two more package universes
-where updates flow as pull requests by the thousand.
+Works across Fedora, the Fedora Security Lab, and NixOS, with sidelines in
+Home Assistant and Alpine. Three package universes at once, each of which
+takes updates as pull requests by the thousand.
+
+![Lifetime pull-request chart of Fabian Affolter](/embed/fabaff)
+
+## 6. J. Nick Koston
 
 <Person login="bdraco" stats="21.7k pull requests · Home Assistant" />
 
-J. Nick Koston is a core Home Assistant developer. A project that large, with
-a required-review workflow and constant dependency churn, produces pull
-requests endlessly, and its most active people sit near the top of every
-contribution board we have.
+A core Home Assistant developer. A project that large, with a required-review
+workflow and constant dependency churn, produces pull requests endlessly, and
+its most active people sit near the top of every board we have.
 
-![Lifetime pull-request history chart of J. Nick Koston](/embed/bdraco)
+![Lifetime pull-request chart of J. Nick Koston](/embed/bdraco)
 
-The rest of the human top ten fits the same shape: Patrick Linnane leads
-Homebrew, Shuyang Zhou is another Liferay engineer, and Kim Morrison is a
-prolific contributor in the Lean theorem-prover ecosystem. High PR counts
-mark people who propose changes constantly, usually across many repositories.
+## 7. Patrick Linnane
+
+<Person login="p-linnane" stats="18.6k pull requests · Homebrew" />
+
+A lead maintainer at Homebrew who runs its security program, and a RubyGems
+contributor too. The second Homebrew name in this top ten, for the same
+structural reason as the first.
+
+![Lifetime pull-request chart of Patrick Linnane](/embed/p-linnane)
+
+## 8. Kim Morrison
+
+<Person login="kim-em" stats="18.4k pull requests · Lean & mathlib" />
+
+A mathematician and maintainer of the Lean theorem prover and its mathlib
+library, now at the Lean FRO. Formalizing mathematics is a stacked-diff
+discipline: enormous amounts of small, reviewed pull requests.
+
+![Lifetime pull-request chart of Kim Morrison](/embed/kim-em)
+
+## 9. Vaishant Kameswaran
+
+<Person login="vkameswaran" stats="17.4k pull requests · Greptile" />
+
+Founder of Greptile. Like Brandon Foley, his ratio (thousands of pull
+requests against very few commits) is the fingerprint of a team where every
+change, however small, goes through a pull request.
+
+![Lifetime pull-request chart of Vaishant Kameswaran](/embed/vkameswaran)
+
+## 10. Shuyang Zhou
+
+<Person login="shuyangzhou" stats="15.0k pull requests · Liferay" />
+
+A Liferay engineer, closing the top ten where it opened: inside a large
+codebase whose process routes everything through pull requests (and whose CI
+bot sits at number one).
+
+![Lifetime pull-request chart of Shuyang Zhou](/embed/shuyangzhou)
 
 ## What the pull-request board measures
 
-Of our metrics, PR count is the best single read on **collaboration across
-repositories**, because a pull request is a proposal made to a codebase,
-often someone else's. But at the extreme top it is dominated by two things
-that are not "great engineering": automated tooling, and the pull-request
-treadmill of package maintenance. Read it as a measure of *volume of
-proposals*, and check the [PR metric explainer](/-/metrics/pull-requests) for
-how it relates to commits and reviews.
+PR count is the best single read on **collaboration across repositories**,
+because a pull request is a proposal made to a codebase, often someone else's.
+But at the extreme top it is dominated by two things that are not "great
+engineering": automated tooling, and the pull-request treadmill of package
+maintenance. Read it as a measure of volume, and see the
+[PR metric explainer](/-/metrics/pull-requests) for how it relates to commits
+and reviews.
 
 ## Common questions
 
 ### Who has opened the most pull requests on GitHub?
 
 By our count, the top account is Liferay's continuous-integration bot
-(@liferay-continuous-integration) with over 74,000 pull requests. The most
-prolific human is Homebrew maintainer Rui Chen (@chenrui333), with about
-54,000.
+(@liferay-continuous-integration) with over 74,000. The most prolific human is
+Homebrew maintainer Rui Chen (@chenrui333), with about 54,000.
 
 ### Why do bots rank so high for pull requests?
 
-GitHub counts a pull request when it is opened, and continuous-integration
-and dependency-update services open them automatically. A single automation
-account can open more pull requests in a month than a person does in years.
+GitHub counts a pull request when it is opened, and continuous-integration and
+dependency-update services open them automatically. A single automation
+account can open more in a month than a person does in years.
 
 ### What is a high number of pull requests?
 
@@ -115,8 +174,8 @@ always come from package maintenance or automation, not ordinary development.
 ## See where you land
 
 **[Look yourself up on commit-history](/)** and flip your chart to
-[pull requests](/?metric=prs) to see your own collaboration curve and where
-it lands on the [global leaderboard](/).
+[pull requests](/?metric=prs) to see your own collaboration curve and where it
+lands on the [global leaderboard](/).
 
 *More rankings: the [most-followed developers](/-/most-followed-github-users),
 the [most commits](/-/most-commits-on-github), and the

--- a/src/content/posts/most-pull-requests-on-github.mdx
+++ b/src/content/posts/most-pull-requests-on-github.mdx
@@ -48,7 +48,7 @@ part of Liferay's build pipeline. GitHub counts it as a user, so it tops the
 board, which is the first thing to know before reading anything into a raw PR
 number. Automation is the single biggest force at the extreme top.
 
-![Lifetime pull-request chart of the Liferay CI account](/embed/liferay-continuous-integration)
+![Lifetime pull-request chart of the Liferay CI account](/embed/liferay-continuous-integration?metric=prs)
 
 ## 2. Rui Chen
 
@@ -58,7 +58,7 @@ A Homebrew maintainer and an infrastructure engineer at Justworks. Homebrew's
 model turns every formula bump into a pull request, so its active maintainers
 rack up numbers no application developer ever could.
 
-![Lifetime pull-request chart of Rui Chen](/embed/chenrui333)
+![Lifetime pull-request chart of Rui Chen](/embed/chenrui333?metric=prs)
 
 ## 3. Brandon Foley
 
@@ -69,7 +69,7 @@ With barely 400 commits against 52,000 pull requests, his profile is a pure
 example of a PR-gated workflow: propose everything as a pull request, let the
 merges land elsewhere.
 
-![Lifetime pull-request chart of Brandon Foley](/embed/bfoley13)
+![Lifetime pull-request chart of Brandon Foley](/embed/bfoley13?metric=prs)
 
 ## 4. Al Cutter
 
@@ -79,7 +79,7 @@ A Google engineer working on Certificate Transparency and verifiable logs
 (Trillian, Tessera). Transparency-log infrastructure means constant,
 reviewed, automated change, which is exactly the shape that fills a PR board.
 
-![Lifetime pull-request chart of Al Cutter](/embed/AlCutter)
+![Lifetime pull-request chart of Al Cutter](/embed/AlCutter?metric=prs)
 
 ## 5. Fabian Affolter
 
@@ -89,7 +89,7 @@ Works across Fedora, the Fedora Security Lab, and NixOS, with sidelines in
 Home Assistant and Alpine. Three package universes at once, each of which
 takes updates as pull requests by the thousand.
 
-![Lifetime pull-request chart of Fabian Affolter](/embed/fabaff)
+![Lifetime pull-request chart of Fabian Affolter](/embed/fabaff?metric=prs)
 
 ## 6. J. Nick Koston
 
@@ -99,7 +99,7 @@ A core Home Assistant developer. A project that large, with a required-review
 workflow and constant dependency churn, produces pull requests endlessly, and
 its most active people sit near the top of every board we have.
 
-![Lifetime pull-request chart of J. Nick Koston](/embed/bdraco)
+![Lifetime pull-request chart of J. Nick Koston](/embed/bdraco?metric=prs)
 
 ## 7. Patrick Linnane
 
@@ -109,7 +109,7 @@ A lead maintainer at Homebrew who runs its security program, and a RubyGems
 contributor too. The second Homebrew name in this top ten, for the same
 structural reason as the first.
 
-![Lifetime pull-request chart of Patrick Linnane](/embed/p-linnane)
+![Lifetime pull-request chart of Patrick Linnane](/embed/p-linnane?metric=prs)
 
 ## 8. Kim Morrison
 
@@ -119,7 +119,7 @@ A mathematician and maintainer of the Lean theorem prover and its mathlib
 library, now at the Lean FRO. Formalizing mathematics is a stacked-diff
 discipline: enormous amounts of small, reviewed pull requests.
 
-![Lifetime pull-request chart of Kim Morrison](/embed/kim-em)
+![Lifetime pull-request chart of Kim Morrison](/embed/kim-em?metric=prs)
 
 ## 9. Vaishant Kameswaran
 
@@ -129,7 +129,7 @@ Founder of Greptile. Like Brandon Foley, his ratio (thousands of pull
 requests against very few commits) is the fingerprint of a team where every
 change, however small, goes through a pull request.
 
-![Lifetime pull-request chart of Vaishant Kameswaran](/embed/vkameswaran)
+![Lifetime pull-request chart of Vaishant Kameswaran](/embed/vkameswaran?metric=prs)
 
 ## 10. Shuyang Zhou
 
@@ -139,7 +139,7 @@ A Liferay engineer, closing the top ten where it opened: inside a large
 codebase whose process routes everything through pull requests (and whose CI
 bot sits at number one).
 
-![Lifetime pull-request chart of Shuyang Zhou](/embed/shuyangzhou)
+![Lifetime pull-request chart of Shuyang Zhou](/embed/shuyangzhou?metric=prs)
 
 ## What the pull-request board measures
 
@@ -177,6 +177,9 @@ always come from package maintenance or automation, not ordinary development.
 [pull requests](/?metric=prs) to see your own collaboration curve and where it
 lands on the [global leaderboard](/).
 
-*More rankings: the [most-followed developers](/-/most-followed-github-users),
-the [most commits](/-/most-commits-on-github), and the
-[most code reviews](/-/most-code-reviews-on-github).*
+*More GitHub rankings: [most-followed developers](/-/most-followed-github-users),
+[most commits](/-/most-commits-on-github),
+[most code reviews](/-/most-code-reviews-on-github),
+[most issues](/-/most-issues-on-github),
+[most repositories](/-/most-repositories-on-github), and
+[most private contributions](/-/most-private-contributions-on-github).*

--- a/src/content/posts/most-repositories-on-github.mdx
+++ b/src/content/posts/most-repositories-on-github.mdx
@@ -1,0 +1,185 @@
+---
+title: "The 10 developers with the most repositories on GitHub"
+description: "Who has created the most repositories on GitHub? The 2026 top 10, where prolific project-starters meet outright automation, from Google engineers to the npm one-man army. With charts."
+publishedAt: "2026-07-20"
+updatedAt: "2026-07-20"
+order: 6
+people:
+  - { login: mbrukman, name: Misha Brukman }
+  - { login: jamestiotio, name: James Raphael Tiovalen }
+  - { login: mattn, name: mattn }
+  - { login: felixonmars, name: Felix Yan }
+  - { login: cicorias, name: Shawn Cicoria }
+  - { login: sindresorhus, name: Sindre Sorhus }
+  - { login: willnguyen1312, name: Nam Nguyen }
+  - { login: jonnycrunch, name: Jonathan Holt }
+  - { login: davelab6, name: Dave Crossland }
+  - { login: degouville, name: Mathieu de Gouville }
+---
+
+The developer who has created the most public repositories on GitHub is
+**Misha Brukman** (@mbrukman), a Google engineer and JanusGraph co-founder,
+with more than 8,000. This metric counts repositories you *create* (forks do
+not count), so the top of the board blends genuinely prolific
+project-starters with people generating repositories at a scale no human
+types by hand.
+
+| # | Developer | Repositories |
+| --- | --- | ---: |
+| 1 | [Misha Brukman](/mbrukman) | 8,077 |
+| 2 | [James Raphael Tiovalen](/jamestiotio) | 4,402 |
+| 3 | [mattn](/mattn) | 2,198 |
+| 4 | [Felix Yan](/felixonmars) | 1,722 |
+| 5 | [Shawn Cicoria](/cicorias) | 1,350 |
+| 6 | [Sindre Sorhus](/sindresorhus) | 1,134 |
+| 7 | [Nam Nguyen](/willnguyen1312) | 1,079 |
+| 8 | [Jonathan Holt](/jonnycrunch) | 1,040 |
+| 9 | [Dave Crossland](/davelab6) | 1,029 |
+| 10 | [Mathieu de Gouville](/degouville) | 1,026 |
+
+## 1. Misha Brukman
+
+<Person login="mbrukman" stats="8,077 repositories · Google" />
+
+A Google engineer, an early LLVM contributor, and a co-founder of the
+JanusGraph distributed graph database. Eight thousand created repositories is
+far beyond what anyone maintains by hand, so a count this high almost
+certainly includes large numbers of small, generated, or archived
+repositories alongside the notable work.
+
+![Lifetime repositories chart of Misha Brukman](/embed/mbrukman?metric=repos)
+
+## 2. James Raphael Tiovalen
+
+<Person login="jamestiotio" stats="4,402 repositories · Meta" />
+
+An engineer at Meta. Like the number one, the sheer count points to bulk
+repository creation rather than four thousand maintained projects, a reminder
+that this particular board rewards *creating* far more than *sustaining*.
+
+![Lifetime repositories chart of James Raphael Tiovalen](/embed/jamestiotio?metric=repos)
+
+## 3. mattn
+
+<Person login="mattn" stats="2,198 repositories · Go & Vim" />
+
+A legendary prolific author in the Go and Vim worlds, a Google Developer
+Expert for Go, based in Japan. Here the count is real craft: mattn genuinely
+ships an enormous number of small, useful tools and plugins.
+
+![Lifetime repositories chart of mattn](/embed/mattn?metric=repos)
+
+## 4. Felix Yan
+
+<Person login="felixonmars" stats="1,722 repositories · Arch Linux" />
+
+The Arch Linux maintainer who also tops the
+[commits board](/-/most-commits-on-github). Distribution packaging spreads
+across a repository per package, so a prolific packager naturally creates a
+lot of them.
+
+![Lifetime repositories chart of Felix Yan](/embed/felixonmars?metric=repos)
+
+## 5. Shawn Cicoria
+
+<Person login="cicorias" stats="1,350 repositories · Microsoft" />
+
+An engineer in Microsoft's Commercial Software Engineering group. Customer
+and prototype work tends to spin up a repository per engagement, which adds
+up quickly over a long career.
+
+![Lifetime repositories chart of Shawn Cicoria](/embed/cicorias?metric=repos)
+
+## 6. Sindre Sorhus
+
+<Person login="sindresorhus" stats="1,134 repositories · npm" />
+
+The full-time open-sourcerer behind more than a thousand npm packages, each
+in its own repository. The purest example of "one small, sharp package per
+repo," sustained for over a decade.
+
+![Lifetime repositories chart of Sindre Sorhus](/embed/sindresorhus?metric=repos)
+
+## 7. Nam Nguyen
+
+<Person login="willnguyen1312" stats="1,079 repositories · Shopify" />
+
+A frontend engineer at Shopify and author of the headless `zoom-image`
+library. Another developer whose repository count reflects a habit of
+starting small, focused projects.
+
+![Lifetime repositories chart of Nam Nguyen](/embed/willnguyen1312?metric=repos)
+
+## 8. Jonathan Holt
+
+<Person login="jonnycrunch" stats="1,040 repositories · decentralized identity" />
+
+A clinical geneticist turned health-IT founder, working on decentralized
+identity: he authored IPID, a DID method built on IPFS, and contributes to
+the W3C Credentials Community Group. A researcher's sprawl of experiments.
+
+![Lifetime repositories chart of Jonathan Holt](/embed/jonnycrunch?metric=repos)
+
+## 9. Dave Crossland
+
+<Person login="davelab6" stats="1,029 repositories · Google Fonts" />
+
+The Google Fonts program manager who has spent his career freeing fonts.
+Google Fonts tracks each font family in its own repository, so curating that
+library means creating and shepherding a thousand of them.
+
+![Lifetime repositories chart of Dave Crossland](/embed/davelab6?metric=repos)
+
+## 10. Mathieu de Gouville
+
+<Person login="degouville" stats="1,026 repositories · TideTech AI" />
+
+A senior technical product manager at TideTech AI who builds Raycast
+extensions and MCP servers. Rounding out a board where the through-line is a
+compulsion to start new things.
+
+![Lifetime repositories chart of Mathieu de Gouville](/embed/degouville?metric=repos)
+
+## What the repository board measures
+
+Repository count rewards *starting*, not finishing or maintaining. Because
+forks do not count, every number here is a repository the person created, but
+creating and sustaining are very different things. At the top you find two
+kinds of people: genuine prolific tinkerers who ship hundreds of real small
+projects, and accounts that generate repositories in bulk. Read a high count
+as a taste for new beginnings, not a measure of impact. The
+[repositories explainer](/-/metrics/repositories) has more.
+
+## Common questions
+
+### Who has created the most repositories on GitHub?
+
+By our count, Misha Brukman (@mbrukman), a Google engineer, with over 8,000
+public repositories created. Forks are not counted, so these are all
+repositories the person started.
+
+### Do forks count toward the repository total?
+
+No. GitHub's repository-contribution count (what we rank) counts repositories
+you create, not ones you fork. That is why the numbers are lower than the raw
+repo count shown on some profiles.
+
+### Does a high repository count mean someone is a great developer?
+
+Not on its own. It measures how many projects someone starts, which at the
+extreme is dominated by bulk or generated repositories. A thoughtful
+maintainer with ten deep projects can matter far more than an account with a
+thousand shallow ones.
+
+## See where you land
+
+**[Look yourself up on commit-history](/)** and switch your chart to
+[repositories](/?metric=repos) to see your own creation curve and where it
+lands on the [global leaderboard](/).
+
+*More GitHub rankings: [most-followed developers](/-/most-followed-github-users),
+[most commits](/-/most-commits-on-github),
+[most pull requests](/-/most-pull-requests-on-github),
+[most code reviews](/-/most-code-reviews-on-github),
+[most issues](/-/most-issues-on-github), and
+[most private contributions](/-/most-private-contributions-on-github).*

--- a/src/content/posts/most-repositories-on-github.mdx
+++ b/src/content/posts/most-repositories-on-github.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The 10 developers with the most repositories on GitHub"
-description: "Who has created the most repositories on GitHub? The 2026 top 10, where prolific project-starters meet outright automation, from Google engineers to the npm one-man army. With charts."
+description: "Who has created the most repositories on GitHub? The 2026 top 10, where prolific project-starters meet bulk creation, from Google engineers to the npm one-man army. With charts."
 publishedAt: "2026-07-20"
 updatedAt: "2026-07-20"
 order: 6
@@ -8,34 +8,34 @@ people:
   - { login: mbrukman, name: Misha Brukman }
   - { login: jamestiotio, name: James Raphael Tiovalen }
   - { login: mattn, name: mattn }
+  - { login: ishandutta2007, name: Ishan Dutta }
   - { login: felixonmars, name: Felix Yan }
   - { login: cicorias, name: Shawn Cicoria }
+  - { login: JJ, name: Juan Julián Merelo Guervós }
   - { login: sindresorhus, name: Sindre Sorhus }
   - { login: willnguyen1312, name: Nam Nguyen }
   - { login: jonnycrunch, name: Jonathan Holt }
-  - { login: davelab6, name: Dave Crossland }
-  - { login: degouville, name: Mathieu de Gouville }
 ---
 
 The developer who has created the most public repositories on GitHub is
 **Misha Brukman** (@mbrukman), a Google engineer and JanusGraph co-founder,
-with more than 8,000. This metric counts repositories you *create* (forks do
-not count), so the top of the board blends genuinely prolific
-project-starters with people generating repositories at a scale no human
-types by hand.
+with more than 8,000. This metric counts repositories you *create*, so the top
+of the board blends genuinely prolific project-starters with accounts that
+accumulate repositories in bulk. Read a high number as a taste for starting
+things, not a measure of impact.
 
-| # | Developer | Repositories |
-| --- | --- | ---: |
-| 1 | [Misha Brukman](/mbrukman) | 8,077 |
-| 2 | [James Raphael Tiovalen](/jamestiotio) | 4,402 |
-| 3 | [mattn](/mattn) | 2,198 |
-| 4 | [Felix Yan](/felixonmars) | 1,722 |
-| 5 | [Shawn Cicoria](/cicorias) | 1,350 |
-| 6 | [Sindre Sorhus](/sindresorhus) | 1,134 |
-| 7 | [Nam Nguyen](/willnguyen1312) | 1,079 |
-| 8 | [Jonathan Holt](/jonnycrunch) | 1,040 |
-| 9 | [Dave Crossland](/davelab6) | 1,029 |
-| 10 | [Mathieu de Gouville](/degouville) | 1,026 |
+<RankBoard unit="repositories" rows={[
+	{ login: "mbrukman", name: "Misha Brukman", value: "8,077" },
+	{ login: "jamestiotio", name: "James Raphael Tiovalen", value: "4,402" },
+	{ login: "mattn", name: "mattn", value: "2,198" },
+	{ login: "ishandutta2007", name: "Ishan Dutta", value: "1,775" },
+	{ login: "felixonmars", name: "Felix Yan", value: "1,722" },
+	{ login: "cicorias", name: "Shawn Cicoria", value: "1,350" },
+	{ login: "JJ", name: "Juan Julián Merelo Guervós", value: "1,249" },
+	{ login: "sindresorhus", name: "Sindre Sorhus", value: "1,134" },
+	{ login: "willnguyen1312", name: "Nam Nguyen", value: "1,079" },
+	{ login: "jonnycrunch", name: "Jonathan Holt", value: "1,040" },
+]} />
 
 ## 1. Misha Brukman
 
@@ -43,9 +43,9 @@ types by hand.
 
 A Google engineer, an early LLVM contributor, and a co-founder of the
 JanusGraph distributed graph database. Eight thousand created repositories is
-far beyond what anyone maintains by hand, so a count this high almost
-certainly includes large numbers of small, generated, or archived
-repositories alongside the notable work.
+far beyond what anyone maintains by hand, so a count this high certainly
+includes large numbers of small, generated, or archived repositories
+alongside the notable work.
 
 ![Lifetime repositories chart of Misha Brukman](/embed/mbrukman?metric=repos)
 
@@ -53,9 +53,9 @@ repositories alongside the notable work.
 
 <Person login="jamestiotio" stats="4,402 repositories · Meta" />
 
-An engineer at Meta. Like the number one, the sheer count points to bulk
+An engineer at Meta. As with the number one, the sheer count points to bulk
 repository creation rather than four thousand maintained projects, a reminder
-that this particular board rewards *creating* far more than *sustaining*.
+that this board rewards *creating* far more than *sustaining*.
 
 ![Lifetime repositories chart of James Raphael Tiovalen](/embed/jamestiotio?metric=repos)
 
@@ -69,7 +69,18 @@ ships an enormous number of small, useful tools and plugins.
 
 ![Lifetime repositories chart of mattn](/embed/mattn?metric=repos)
 
-## 4. Felix Yan
+## 4. Ishan Dutta
+
+<Person login="ishandutta2007" stats="1,775 repositories · AI entrepreneur" />
+
+An AI-focused entrepreneur. His profile is the clearest illustration of this
+board's caveat: the repository count is made up overwhelmingly of forks and
+curated list repositories rather than original projects. It is exactly why a
+big repo number, on its own, says little about what someone has built.
+
+![Lifetime repositories chart of Ishan Dutta](/embed/ishandutta2007?metric=repos)
+
+## 5. Felix Yan
 
 <Person login="felixonmars" stats="1,722 repositories · Arch Linux" />
 
@@ -80,74 +91,64 @@ lot of them.
 
 ![Lifetime repositories chart of Felix Yan](/embed/felixonmars?metric=repos)
 
-## 5. Shawn Cicoria
+## 6. Shawn Cicoria
 
 <Person login="cicorias" stats="1,350 repositories · Microsoft" />
 
-An engineer in Microsoft's Commercial Software Engineering group. Customer
-and prototype work tends to spin up a repository per engagement, which adds
-up quickly over a long career.
+An engineer in Microsoft's Commercial Software Engineering group. Customer and
+prototype work tends to spin up a repository per engagement, which adds up
+quickly over a long career.
 
 ![Lifetime repositories chart of Shawn Cicoria](/embed/cicorias?metric=repos)
 
-## 6. Sindre Sorhus
+## 7. Juan Julián Merelo Guervós
+
+<Person login="JJ" stats="1,249 repositories · Raku & UGR" />
+
+A full professor at the University of Granada, a longtime Perl and Raku
+community figure, and author of *Raku Recipes*. Decades of teaching, research,
+and writing (developing, as his bio notes, since 1983) leave a long trail of
+repositories.
+
+![Lifetime repositories chart of Juan Julián Merelo Guervós](/embed/JJ?metric=repos)
+
+## 8. Sindre Sorhus
 
 <Person login="sindresorhus" stats="1,134 repositories · npm" />
 
-The full-time open-sourcerer behind more than a thousand npm packages, each
-in its own repository. The purest example of "one small, sharp package per
-repo," sustained for over a decade.
+The full-time open-sourcerer behind more than a thousand npm packages, each in
+its own repository. The purest example of "one small, sharp package per repo,"
+sustained for over a decade.
 
 ![Lifetime repositories chart of Sindre Sorhus](/embed/sindresorhus?metric=repos)
 
-## 7. Nam Nguyen
+## 9. Nam Nguyen
 
 <Person login="willnguyen1312" stats="1,079 repositories · Shopify" />
 
 A frontend engineer at Shopify and author of the headless `zoom-image`
-library. Another developer whose repository count reflects a habit of
-starting small, focused projects.
+library. Another developer whose repository count reflects a habit of starting
+small, focused projects.
 
 ![Lifetime repositories chart of Nam Nguyen](/embed/willnguyen1312?metric=repos)
 
-## 8. Jonathan Holt
+## 10. Jonathan Holt
 
 <Person login="jonnycrunch" stats="1,040 repositories · decentralized identity" />
 
 A clinical geneticist turned health-IT founder, working on decentralized
-identity: he authored IPID, a DID method built on IPFS, and contributes to
-the W3C Credentials Community Group. A researcher's sprawl of experiments.
+identity: he authored IPID, a DID method built on IPFS, and contributes to the
+W3C Credentials Community Group. A researcher's sprawl of experiments.
 
 ![Lifetime repositories chart of Jonathan Holt](/embed/jonnycrunch?metric=repos)
 
-## 9. Dave Crossland
-
-<Person login="davelab6" stats="1,029 repositories · Google Fonts" />
-
-The Google Fonts program manager who has spent his career freeing fonts.
-Google Fonts tracks each font family in its own repository, so curating that
-library means creating and shepherding a thousand of them.
-
-![Lifetime repositories chart of Dave Crossland](/embed/davelab6?metric=repos)
-
-## 10. Mathieu de Gouville
-
-<Person login="degouville" stats="1,026 repositories · TideTech AI" />
-
-A senior technical product manager at TideTech AI who builds Raycast
-extensions and MCP servers. Rounding out a board where the through-line is a
-compulsion to start new things.
-
-![Lifetime repositories chart of Mathieu de Gouville](/embed/degouville?metric=repos)
-
 ## What the repository board measures
 
-Repository count rewards *starting*, not finishing or maintaining. Because
-forks do not count, every number here is a repository the person created, but
-creating and sustaining are very different things. At the top you find two
-kinds of people: genuine prolific tinkerers who ship hundreds of real small
-projects, and accounts that generate repositories in bulk. Read a high count
-as a taste for new beginnings, not a measure of impact. The
+Repository count rewards *starting*, not finishing or maintaining. At the top
+you find two kinds of people: genuine prolific tinkerers who ship hundreds of
+real small projects, and accounts that pile up generated or forked
+repositories. A thoughtful maintainer with ten deep projects can matter far
+more than an account with a thousand shallow ones. The
 [repositories explainer](/-/metrics/repositories) has more.
 
 ## Common questions
@@ -155,21 +156,19 @@ as a taste for new beginnings, not a measure of impact. The
 ### Who has created the most repositories on GitHub?
 
 By our count, Misha Brukman (@mbrukman), a Google engineer, with over 8,000
-public repositories created. Forks are not counted, so these are all
-repositories the person started.
-
-### Do forks count toward the repository total?
-
-No. GitHub's repository-contribution count (what we rank) counts repositories
-you create, not ones you fork. That is why the numbers are lower than the raw
-repo count shown on some profiles.
+public repositories.
 
 ### Does a high repository count mean someone is a great developer?
 
 Not on its own. It measures how many projects someone starts, which at the
-extreme is dominated by bulk or generated repositories. A thoughtful
-maintainer with ten deep projects can matter far more than an account with a
-thousand shallow ones.
+extreme is dominated by bulk, generated, or forked repositories. Depth of a
+few projects usually says more than the raw number.
+
+### What is a normal number of repositories?
+
+Most active developers have tens of repositories; a few hundred marks a
+prolific open-source author. The four-figure counts on this board are unusual
+and almost always involve automation or forks.
 
 ## See where you land
 

--- a/src/lib/chart-svg.ts
+++ b/src/lib/chart-svg.ts
@@ -6,7 +6,7 @@ import {
 	CROWN_TRANSFORM,
 	CROWN_VIEWBOX,
 } from "#/lib/crown";
-import type { CommitHistory } from "#/lib/github";
+import type { CommitHistory, CommitPoint } from "#/lib/github";
 import { xkcdFontDataUrl } from "#/lib/xkcd-font";
 
 /**
@@ -41,17 +41,17 @@ const THEMES: Record<Theme, ThemeColors> = {
 	dark: { bg: "#0d1117", fg: "#c9d1d9", muted: "#8b949e", grid: "#30363d" },
 };
 
-// The data type a chart shows. "all" is the aggregate (public commits + private contributions —
-// what the embed sums today); "commits" is live too, the rest are on the roadmap. Each gets its
-// embed wording here — the single switch point for new types. Per-type ranking on the embed is
-// tracked separately (see the "rank on the embed" issue).
+// The data type a chart shows. "all" is the aggregate (public commits + private contributions),
+// the embed default; every other type plots its own lifetime series (see monthlyValue). Wording
+// per type lives in TYPE_WORDS below; the embed route maps `?metric=` to one of these.
 export type GraphType =
 	| "all"
 	| "commits"
 	| "pullRequests"
 	| "issues"
 	| "reviews"
-	| "repositories";
+	| "repositories"
+	| "private";
 
 // The embed is standalone (no profile header like the on-page chart), so `title(login)` always
 // leads with the username; `unit` labels the running total.
@@ -68,7 +68,32 @@ const TYPE_WORDS: Record<
 	issues: { title: (l) => `${l}'s issues`, unit: "issues" },
 	reviews: { title: (l) => `${l}'s reviews`, unit: "reviews" },
 	repositories: { title: (l) => `${l}'s repositories`, unit: "repositories" },
+	private: {
+		title: (l) => `${l}'s private contributions`,
+		unit: "private contributions",
+	},
 };
+
+/** The monthly value a given graph type plots (cumulated into the running curve below). */
+function monthlyValue(p: CommitPoint, type: GraphType): number {
+	switch (type) {
+		case "commits":
+			return p.commits;
+		case "pullRequests":
+			return p.pullRequests;
+		case "issues":
+			return p.issues;
+		case "reviews":
+			return p.reviews;
+		case "repositories":
+			return p.repos;
+		case "private":
+			return p.restricted;
+		default:
+			// "all": public commits + private contributions, the site's default series.
+			return p.commits + p.restricted;
+	}
+}
 
 function compact(n: number) {
 	return new Intl.NumberFormat("en-US", { notation: "compact" }).format(n);
@@ -140,15 +165,19 @@ export function renderChartSvg(
 		return renderMessageSvg(`${user.login} has no public commits`, theme);
 	}
 
-	// Default to "both": public commits + private contributions, summed per month —
-	// the same series the main chart shows. For users who don't expose private
-	// activity, `restrictedCumulative` is 0, so this is identical to public.
-	const value = (p: (typeof points)[number]) =>
-		p.cumulative + p.restrictedCumulative;
-	const grandTotal = total + totalRestricted;
+	// Running cumulative of the selected metric, one value per point. Built from the monthly
+	// fields so any type (commits, PRs, issues, reviews, repos, private) plots its own curve;
+	// the header total is the endpoint of that curve, so number and line always agree.
+	let running = 0;
+	const values = points.map((p) => {
+		running += monthlyValue(p, type);
+		return running;
+	});
+	const grandTotal =
+		type === "all" ? total + totalRestricted : (values[values.length - 1] ?? 0);
 
 	const n = points.length;
-	const max = Math.max(...points.map(value), 1);
+	const max = Math.max(...values, 1);
 	const x = (i: number) =>
 		PAD.left + (n === 1 ? innerW / 2 : (i / (n - 1)) * innerW);
 	const y = (v: number) => PAD.top + innerH - (v / max) * innerH;
@@ -156,8 +185,8 @@ export function renderChartSvg(
 
 	const line = points
 		.map(
-			(p, i) =>
-				`${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(value(p)).toFixed(1)}`,
+			(_p, i) =>
+				`${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(values[i]).toFixed(1)}`,
 		)
 		.join(" ");
 	const area = `${line} L${x(n - 1).toFixed(1)},${baseline} L${x(0).toFixed(1)},${baseline} Z`;
@@ -184,9 +213,9 @@ export function renderChartSvg(
 		)
 		.join("");
 	const dots = points
-		.map((p, i) =>
+		.map((_p, i) =>
 			i % dotEvery === 0 || i === n - 1
-				? `<circle cx="${x(i).toFixed(1)}" cy="${y(value(p)).toFixed(1)}" r="2.5" fill="${ACCENT}"/>`
+				? `<circle cx="${x(i).toFixed(1)}" cy="${y(values[i]).toFixed(1)}" r="2.5" fill="${ACCENT}"/>`
 				: "",
 		)
 		.join("");

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -5,6 +5,9 @@
  * - src/content/organizations/<slug>.mdx → /-/organizations/<slug> (organization context —
  *   deliberately its own collection, NOT mixed into the individuals' hub: the definitions differ,
  *   e.g. org-scoped vs global contributions)
+ * - src/content/posts/<slug>.mdx → /-/<slug> (standalone long-form pieces, e.g. leaderboard
+ *   rankings — flat under /-/ so each gets a clean article slug with no section prefix;
+ *   time-sensitive ones carry a visible updatedAt)
  *
  * Two globs per collection with different costs:
  * - an eager, frontmatter-only glob (tiny — just the exported metadata objects), used
@@ -99,5 +102,37 @@ export function loadOrgArticle(
 	slug: string,
 ): Promise<{ default: MDXContent }> | undefined {
 	const load = orgComponents[`../content/organizations/${slug}.mdx`];
+	return load?.();
+}
+
+// ── Standalone posts collection (/-/<slug>) ──────────────────────────────────
+
+const postFrontmatters = import.meta.glob<ArticleFrontmatter>(
+	"../content/posts/*.mdx",
+	{ eager: true, import: "frontmatter" },
+);
+
+const postComponents = import.meta.glob<{ default: MDXContent }>(
+	"../content/posts/*.mdx",
+);
+
+/** All standalone posts in curated reading order. */
+export const posts: ArticleMeta[] = Object.entries(postFrontmatters)
+	.map(([path, fm]) => ({ slug: slugOf(path), ...fm }))
+	.sort(
+		(a, b) =>
+			(a.order ?? Number.MAX_SAFE_INTEGER) -
+				(b.order ?? Number.MAX_SAFE_INTEGER) || a.title.localeCompare(b.title),
+	);
+
+export function getPostMeta(slug: string): ArticleMeta | undefined {
+	return posts.find((a) => a.slug === slug);
+}
+
+/** Lazily import a post's compiled MDX module (shape fits React.lazy). */
+export function loadPost(
+	slug: string,
+): Promise<{ default: MDXContent }> | undefined {
+	const load = postComponents[`../content/posts/${slug}.mdx`];
 	return load?.();
 }

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -29,6 +29,12 @@ export interface ArticleFrontmatter {
 	updatedAt: string;
 	/** Position in the /-/metrics hub list (unset sorts last, then by title). */
 	order?: number;
+	/**
+	 * Ranked-list posts only: the entities in ranking order. Emitted as ItemList structured
+	 * data so search engines and agents can read the ranking without parsing prose. Mirror the
+	 * `<Person>` blocks in the body (same order); each `login` links to that profile on-site.
+	 */
+	people?: { login: string; name: string }[];
 }
 
 type MDXContent = ComponentType<{ components?: MDXComponents }>;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as MetricsSlugRouteImport } from './routes/metrics.$slug'
 import { Route as EmbedUserRouteImport } from './routes/embed.$user'
 import { Route as CompanySlugRouteImport } from './routes/company.$slug'
 import { Route as Char91Char93SponsoringRouteImport } from './routes/[-].sponsoring'
+import { Route as Char91Char93SlugRouteImport } from './routes/[-].$slug'
 import { Route as Char91Char93MetricsIndexRouteImport } from './routes/[-].metrics.index'
 import { Route as OgKindLoginRouteImport } from './routes/og.$kind.$login'
 import { Route as Char91Char93OrganizationsSlugRouteImport } from './routes/[-].organizations.$slug'
@@ -74,6 +75,11 @@ const Char91Char93SponsoringRoute = Char91Char93SponsoringRouteImport.update({
   path: '/-/sponsoring',
   getParentRoute: () => rootRouteImport,
 } as any)
+const Char91Char93SlugRoute = Char91Char93SlugRouteImport.update({
+  id: '/-/$slug',
+  path: '/-/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const Char91Char93MetricsIndexRoute =
   Char91Char93MetricsIndexRouteImport.update({
     id: '/-/metrics/',
@@ -102,6 +108,7 @@ export interface FileRoutesByFullPath {
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sponsoring': typeof SponsoringRoute
+  '/-/$slug': typeof Char91Char93SlugRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
@@ -118,6 +125,7 @@ export interface FileRoutesByTo {
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sponsoring': typeof SponsoringRoute
+  '/-/$slug': typeof Char91Char93SlugRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
@@ -135,6 +143,7 @@ export interface FileRoutesById {
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sponsoring': typeof SponsoringRoute
+  '/-/$slug': typeof Char91Char93SlugRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
@@ -153,6 +162,7 @@ export interface FileRouteTypes {
     | '/$user'
     | '/robots.txt'
     | '/sponsoring'
+    | '/-/$slug'
     | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
@@ -169,6 +179,7 @@ export interface FileRouteTypes {
     | '/$user'
     | '/robots.txt'
     | '/sponsoring'
+    | '/-/$slug'
     | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
@@ -185,6 +196,7 @@ export interface FileRouteTypes {
     | '/$user'
     | '/robots.txt'
     | '/sponsoring'
+    | '/-/$slug'
     | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
@@ -202,6 +214,7 @@ export interface RootRouteChildren {
   UserRoute: typeof UserRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
   SponsoringRoute: typeof SponsoringRoute
+  Char91Char93SlugRoute: typeof Char91Char93SlugRoute
   Char91Char93SponsoringRoute: typeof Char91Char93SponsoringRoute
   CompanySlugRoute: typeof CompanySlugRoute
   EmbedUserRoute: typeof EmbedUserRoute
@@ -286,6 +299,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91Char93SponsoringRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/-/$slug': {
+      id: '/-/$slug'
+      path: '/-/$slug'
+      fullPath: '/-/$slug'
+      preLoaderRoute: typeof Char91Char93SlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/-/metrics/': {
       id: '/-/metrics/'
       path: '/-/metrics'
@@ -322,6 +342,7 @@ const rootRouteChildren: RootRouteChildren = {
   UserRoute: UserRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,
   SponsoringRoute: SponsoringRoute,
+  Char91Char93SlugRoute: Char91Char93SlugRoute,
   Char91Char93SponsoringRoute: Char91Char93SponsoringRoute,
   CompanySlugRoute: CompanySlugRoute,
   EmbedUserRoute: EmbedUserRoute,

--- a/src/routes/[-].$slug.tsx
+++ b/src/routes/[-].$slug.tsx
@@ -1,0 +1,152 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { type ComponentType, lazy, Suspense } from "react";
+import { mdxComponents } from "#/components/MdxComponents";
+import { getPostMeta, loadPost } from "#/lib/content";
+
+/**
+ * Standalone long-form posts (src/content/posts/*.mdx) served flat at /-/<slug>, e.g.
+ * /-/most-followed-github-users. Sits alongside the /-/metrics and /-/organizations section
+ * routes; static segments (metrics, sponsoring, organizations) win over this dynamic $slug, so
+ * only genuinely unclaimed slugs reach here. The /-/ namespace is mandatory: a bare single
+ * segment is a GitHub login ($user route). Ranking posts are time-sensitive — the body cites a
+ * dated snapshot and updatedAt is the freshness signal, so keep both in sync when refreshing a
+ * list. Per-post OG cards come from scripts/generate-og.ts.
+ */
+
+const SITE = "https://commit-history.com";
+
+// One stable lazy component per slug — created on demand, cached at module level so
+// re-renders don't recreate (and thereby remount) the article body.
+type BodyComponent = ComponentType<{ components?: typeof mdxComponents }>;
+const bodies = new Map<string, BodyComponent>();
+function articleBody(slug: string): BodyComponent {
+	let body = bodies.get(slug);
+	if (!body) {
+		body = lazy(() => {
+			const load = loadPost(slug);
+			if (!load) throw notFound();
+			return load;
+		});
+		bodies.set(slug, body);
+	}
+	return body;
+}
+
+function formatDate(iso: string) {
+	return new Date(iso).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
+export const Route = createFileRoute("/-/$slug")({
+	loader: ({ params }) => {
+		const meta = getPostMeta(params.slug);
+		if (!meta) throw notFound();
+		return meta;
+	},
+	head: ({ params }) => {
+		const meta = getPostMeta(params.slug);
+		if (!meta) return {};
+		const url = `${SITE}/-/${meta.slug}`;
+		const ogImage = `${SITE}/og/posts/${meta.slug}.png`;
+		return {
+			meta: [
+				{ title: `${meta.title} · Commit History` },
+				{ name: "description", content: meta.description },
+				// Open Graph — article type; image/url/alt override the site-wide card.
+				{ property: "og:type", content: "article" },
+				{ property: "og:title", content: meta.title },
+				{ property: "og:description", content: meta.description },
+				{ property: "og:url", content: url },
+				{ property: "og:image", content: ogImage },
+				{ property: "og:image:alt", content: meta.title },
+				{ property: "article:published_time", content: meta.publishedAt },
+				{ property: "article:modified_time", content: meta.updatedAt },
+				{ name: "twitter:title", content: meta.title },
+				{ name: "twitter:description", content: meta.description },
+				{ name: "twitter:image", content: ogImage },
+				{ name: "twitter:image:alt", content: meta.title },
+			],
+			links: [{ rel: "canonical", href: url }],
+			scripts: [
+				{
+					type: "application/ld+json",
+					children: JSON.stringify([
+						{
+							"@context": "https://schema.org",
+							"@type": "Article",
+							headline: meta.title,
+							description: meta.description,
+							datePublished: meta.publishedAt,
+							dateModified: meta.updatedAt,
+							image: ogImage,
+							mainEntityOfPage: url,
+							author: {
+								"@type": "Person",
+								name: "Philip Poloczek",
+								url: "https://github.com/peetzweg",
+							},
+							publisher: {
+								"@type": "Organization",
+								name: "Commit History",
+								url: SITE,
+								logo: {
+									"@type": "ImageObject",
+									url: `${SITE}/crown-180.png`,
+								},
+							},
+						},
+						{
+							"@context": "https://schema.org",
+							"@type": "BreadcrumbList",
+							itemListElement: [
+								{
+									"@type": "ListItem",
+									position: 1,
+									name: "Commit History",
+									item: SITE,
+								},
+								{ "@type": "ListItem", position: 2, name: meta.title },
+							],
+						},
+					]),
+				},
+			],
+		};
+	},
+	component: ArticlePage,
+});
+
+function ArticlePage() {
+	const meta = Route.useLoaderData();
+	const Body = articleBody(meta.slug);
+	return (
+		<main className="mx-auto max-w-3xl px-6 py-12">
+			<nav aria-label="Breadcrumb">
+				<Link
+					to="/"
+					className="text-sm text-muted-foreground hover:text-foreground"
+				>
+					← leaderboard
+				</Link>
+			</nav>
+			<article className="mt-6">
+				<header>
+					<h1 className="text-3xl font-bold leading-tight">{meta.title}</h1>
+					<p className="mt-3 text-muted-foreground">{meta.description}</p>
+					<p className="mt-2 text-xs text-muted-foreground">
+						Updated{" "}
+						<time dateTime={meta.updatedAt}>{formatDate(meta.updatedAt)}</time>
+					</p>
+				</header>
+				<div className="prose prose-neutral mt-8 max-w-none">
+					<Suspense fallback={null}>
+						<Body components={mdxComponents} />
+					</Suspense>
+				</div>
+			</article>
+		</main>
+	);
+}

--- a/src/routes/[-].$slug.tsx
+++ b/src/routes/[-].$slug.tsx
@@ -111,6 +111,25 @@ export const Route = createFileRoute("/-/$slug")({
 								{ "@type": "ListItem", position: 2, name: meta.title },
 							],
 						},
+						// Ranked-list posts advertise their ranking explicitly so search engines can
+						// show it as a list and agents can extract it without reading the prose.
+						...(meta.people?.length
+							? [
+									{
+										"@context": "https://schema.org",
+										"@type": "ItemList",
+										name: meta.title,
+										numberOfItems: meta.people.length,
+										itemListOrder: "https://schema.org/ItemListOrderDescending",
+										itemListElement: meta.people.map((p, i) => ({
+											"@type": "ListItem",
+											position: i + 1,
+											name: p.name,
+											url: `${SITE}/${p.login.toLowerCase()}`,
+										})),
+									},
+								]
+							: []),
 					]),
 				},
 			],

--- a/src/routes/embed.$user.tsx
+++ b/src/routes/embed.$user.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { getCommitHistory } from "#/lib/cache";
-import { renderChartSvg, renderMessageSvg } from "#/lib/chart-svg";
+import {
+	type GraphType,
+	renderChartSvg,
+	renderMessageSvg,
+} from "#/lib/chart-svg";
 import { GitHubError } from "#/lib/github";
 
 /**
@@ -8,15 +12,28 @@ import { GitHubError } from "#/lib/github";
  *
  * A pure server route — `server.handlers.GET` returns raw image/svg+xml (no React component).
  * The SVG inlines its font + filter so it renders standalone in GitHub's <img> sandbox.
+ *
+ * `?metric=` picks which lifetime series to plot (default: all contributions). Uses the same
+ * metric names as the leaderboard URLs so an embed matches the board it came from.
  */
+const METRIC_TO_GRAPH: Record<string, GraphType> = {
+	commits: "commits",
+	public: "commits",
+	prs: "pullRequests",
+	issues: "issues",
+	reviews: "reviews",
+	repos: "repositories",
+	private: "private",
+};
+
 export const Route = createFileRoute("/embed/$user")({
 	server: {
 		handlers: {
 			GET: async ({ request, params }) => {
+				const url = new URL(request.url);
 				const theme =
-					new URL(request.url).searchParams.get("theme") === "dark"
-						? "dark"
-						: "light";
+					url.searchParams.get("theme") === "dark" ? "dark" : "light";
+				const graph = METRIC_TO_GRAPH[url.searchParams.get("metric") ?? ""];
 				const token = process.env.GITHUB_TOKEN ?? "";
 
 				try {
@@ -25,7 +42,7 @@ export const Route = createFileRoute("/embed/$user")({
 					const history = await getCommitHistory(params.user, token, {
 						record: false,
 					});
-					return new Response(renderChartSvg(history, theme), {
+					return new Response(renderChartSvg(history, theme, graph), {
 						headers: {
 							"content-type": "image/svg+xml; charset=utf-8",
 							// Badge image, not a page — keep it (and its ?theme= variants) out of the

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -629,6 +629,20 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 				</h2>
 				<p className="mt-1.5 text-xs text-muted-foreground">
 					{subtitle} <ExplainerLink metric={mode} />
+					{/* The followers board has an editorial companion — surface it right where
+					    the ranking it describes is on screen. */}
+					{mode === "followers" && (
+						<>
+							{" "}
+							<Link
+								to="/-/$slug"
+								params={{ slug: "most-followed-github-users" }}
+								className="whitespace-nowrap underline decoration-dotted underline-offset-2 hover:text-foreground"
+							>
+								Meet the top 10 →
+							</Link>
+						</>
+					)}
 				</p>
 			</div>
 			<ol>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -51,6 +51,9 @@ const RANKING_POST_SLUG: Partial<Record<LeaderMode, string>> = {
 	prs: "most-pull-requests-on-github",
 	reviews: "most-code-reviews-on-github",
 	followers: "most-followed-github-users",
+	issues: "most-issues-on-github",
+	repos: "most-repositories-on-github",
+	private: "most-private-contributions-on-github",
 };
 
 export const Route = createFileRoute("/")({

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -43,6 +43,16 @@ interface HomeSearch {
 // LEADERBOARD_PAGE_STOPS infinite-scroll pattern when it outgrows this.
 const ORG_PAGE_SIZE = 100;
 
+// Metrics that have an editorial "top 10" post (src/content/posts). Surfaced as a link right in
+// the board heading so the ranking on screen points at the article about it. Metrics without a
+// post (issues, repos, private, total) simply don't get a link.
+const RANKING_POST_SLUG: Partial<Record<LeaderMode, string>> = {
+	public: "most-commits-on-github",
+	prs: "most-pull-requests-on-github",
+	reviews: "most-code-reviews-on-github",
+	followers: "most-followed-github-users",
+};
+
 export const Route = createFileRoute("/")({
 	// `?metric=` selects the leaderboard type so a view can be shared; invalid/absent → commits.
 	// `?kind=org` flips the board to organizations (same clean-URL convention: default is absent).
@@ -629,14 +639,14 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 				</h2>
 				<p className="mt-1.5 text-xs text-muted-foreground">
 					{subtitle} <ExplainerLink metric={mode} />
-					{/* The followers board has an editorial companion — surface it right where
-					    the ranking it describes is on screen. */}
-					{mode === "followers" && (
+					{/* Boards with an editorial companion post link to it right where the ranking
+					    they describe is on screen. */}
+					{RANKING_POST_SLUG[mode] && (
 						<>
 							{" "}
 							<Link
 								to="/-/$slug"
-								params={{ slug: "most-followed-github-users" }}
+								params={{ slug: RANKING_POST_SLUG[mode] as string }}
 								className="whitespace-nowrap underline decoration-dotted underline-offset-2 hover:text-foreground"
 							>
 								Meet the top 10 →

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ function contentSlugs(collection: string): string[] {
 }
 const metricSlugs = contentSlugs("metrics");
 const orgSlugs = contentSlugs("organizations");
+const postSlugs = contentSlugs("posts");
 
 const config = defineConfig({
 	resolve: { tsconfigPaths: true },
@@ -90,6 +91,13 @@ const config = defineConfig({
 					path: `/-/organizations/${slug}`,
 					prerender: { enabled: true, crawlLinks: false },
 					sitemap: { changefreq: "monthly" as const, priority: 0.7 },
+				})),
+				// Standalone posts, flat under /-/ (leaderboard rankings etc). Refreshed in place,
+				// so weekly signals crawlers to revisit as the underlying boards move.
+				...postSlugs.map((slug) => ({
+					path: `/-/${slug}`,
+					prerender: { enabled: true, crawlLinks: false },
+					sitemap: { changefreq: "weekly" as const, priority: 0.8 },
 				})),
 			],
 		}),


### PR DESCRIPTION
A new standalone-post collection (`src/content/posts/` → flat `/-/<slug>`) with seven "top 10" ranking articles, one per leaderboard metric, all built from live snapshots:

- [most-followed developers](https://commit-history.com/-/most-followed-github-users)
- [most commits](https://commit-history.com/-/most-commits-on-github)
- [most pull requests](https://commit-history.com/-/most-pull-requests-on-github)
- [most code reviews](https://commit-history.com/-/most-code-reviews-on-github)
- [most issues](https://commit-history.com/-/most-issues-on-github)
- [most repositories](https://commit-history.com/-/most-repositories-on-github)
- [most private contributions](https://commit-history.com/-/most-private-contributions-on-github)

**Why:** indexable, shareable long-form content targeting real search queries, using data and charts only this site has. Each board tells a different story (fame vs. distro-packaging volume vs. automation vs. invisible maintenance vs. the private 'iceberg').

**How:** collection wired like metrics/organizations (globs, prerender, sitemap, build-time OG cards). Each post: direct-answer lead, summary table, per-person profile header + blurb + chart, `ItemList` structured data, Q&A, CTA; fully prerendered static HTML. Bios verified via research (not guessed); bots/anonymous/automation-inflated entries labelled honestly rather than dressed up.

Also completes the embed's half-finished `GraphType`: `/embed/<user>?metric=<m>` now plots that lifetime series (commits/prs/issues/reviews/repos/private) instead of always commits, so each post's charts show the metric it ranks on. Default (no param) is unchanged, so existing README embeds keep working.

**Moderation guard:** `pnpm check:posts` fails if any featured account is suspended or missing (these posts are static snapshots). Currently 70/70 active.

Verified: full build prerenders all seven, sitemap lists them, OG cards render, ItemList/tables/headers present, biome/tsc/tests pass, and embed metric totals checked against the DB.