### PR TITLE
Split over-limit contribution batches instead of failing the build

### DIFF
--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { isValidLogin, monthlyWindows, yearlyWindows } from "#/lib/github";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	fetchMonthlyCommits,
+	isValidLogin,
+	type MonthWindow,
+	monthlyWindows,
+	yearlyWindows,
+} from "#/lib/github";
 
 const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
@@ -84,5 +90,90 @@ describe("yearlyWindows", () => {
 		expect(yearly.at(-1)?.to.slice(0, 7)).toBe(
 			monthly.at(-1)?.label.slice(0, 7),
 		);
+	});
+});
+
+describe("fetchMonthlyCommits adaptive batching", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	// A GraphQL "resource limits exceeded" body (HTTP 200 with errors), as GitHub returns when
+	// a batch bundles too many expensive contributionsCollection windows.
+	const resourceLimit = {
+		ok: true,
+		status: 200,
+		headers: { get: () => null },
+		json: async () => ({
+			errors: [{ message: "Resource limits for this query exceeded." }],
+		}),
+	};
+	const dataFor = (aliasCount: number) => {
+		const user: Record<string, unknown> = {};
+		for (let i = 0; i < aliasCount; i++) {
+			user[`w${i}`] = {
+				totalCommitContributions: 1,
+				restrictedContributionsCount: 0,
+				totalIssueContributions: 0,
+				totalPullRequestContributions: 0,
+				totalPullRequestReviewContributions: 0,
+				totalRepositoryContributions: 0,
+			};
+		}
+		return {
+			ok: true,
+			status: 200,
+			headers: { get: () => null },
+			json: async () => ({ data: { user } }),
+		};
+	};
+	const aliasCount = (init: RequestInit) => {
+		const { query } = JSON.parse(init.body as string) as { query: string };
+		return (query.match(/contributionsCollection/g) ?? []).length;
+	};
+	const windows = (n: number): MonthWindow[] =>
+		monthlyWindows(new Date("2019-01-01T00:00:00Z"), new Date()).slice(0, n);
+
+	it("splits an over-limit batch and reassembles all windows in order", async () => {
+		let maxAliasSeen = 0;
+		// Any query wider than 3 windows trips the limit; 3-or-fewer succeed — so the initial
+		// 6-window batch must be split before it can complete.
+		vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+			const n = aliasCount(init);
+			maxAliasSeen = Math.max(maxAliasSeen, n);
+			return n > 3 ? resourceLimit : dataFor(n);
+		});
+
+		const ws = windows(6);
+		const counts = await fetchMonthlyCommits("someactiveuser", "tok", ws);
+
+		expect(maxAliasSeen).toBe(6); // the wide batch was attempted (and rejected) first
+		expect(counts).toHaveLength(6); // every window survives the split
+		expect(counts.every((c) => c.commits === 1)).toBe(true);
+	});
+
+	it("degrades a single window that always exceeds the limit to a zero month", async () => {
+		// Even a one-window query is rejected — the last-resort zero path must engage.
+		vi.stubGlobal("fetch", async () => resourceLimit);
+
+		const counts = await fetchMonthlyCommits("someuser", "tok", windows(2));
+
+		expect(counts).toHaveLength(2);
+		expect(counts).toEqual([
+			{
+				commits: 0,
+				restricted: 0,
+				issues: 0,
+				pullRequests: 0,
+				reviews: 0,
+				repos: 0,
+			},
+			{
+				commits: 0,
+				restricted: 0,
+				issues: 0,
+				pullRequests: 0,
+				reviews: 0,
+				repos: 0,
+			},
+		]);
 	});
 });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -57,6 +57,23 @@ const MAX_BACKOFF_MS = 4000;
 // the shared token for every visitor. Fail fast and let the cache serve what it has.
 const RETRYABLE_STATUS = new Set([500, 502, 503, 504]);
 
+/**
+ * GitHub aborts an over-expensive query with a GraphQL "resource limits for this query exceeded"
+ * error — a *dynamic* per-query cost/timeout limit (~10s of execution), tripped when a batch
+ * bundles too many EXPENSIVE aliased `contributionsCollection` windows for a hyper-active account
+ * (e.g. a recent month with hundreds of commits/private contributions). It is deterministic for a
+ * given query shape+data, so retrying the identical query is futile — the caller must split the
+ * batch into smaller windows instead (see `fetchMonthlyCommits`). We map it to 502 like other
+ * heavy-query failures, but detect it by message so both the retry loop (fail fast, don't burn
+ * ~10s per doomed attempt) and the batch fetchers (split rather than give up) can special-case it.
+ */
+function isResourceLimit(e: unknown): e is GitHubError {
+	return (
+		e instanceof GitHubError &&
+		/resource limits? for this query exceeded/i.test(e.message)
+	);
+}
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /**
@@ -336,6 +353,9 @@ async function graphql<T>(token: string, query: string): Promise<T> {
 		lastError = result.error;
 		if (
 			!RETRYABLE_STATUS.has(result.error.status) ||
+			// Resource-limit aborts are deterministic — retrying the same query only burns ~10s
+			// per attempt. Throw immediately so the caller can split the batch and try smaller.
+			isResourceLimit(result.error) ||
 			attempt === MAX_ATTEMPTS
 		) {
 			throw result.error;
@@ -663,6 +683,15 @@ export async function fetchOrgMemberContributions(
  * with bounded concurrency (see CONCURRENCY). Returns counts aligned 1:1 with `windows`. The cache
  * uses this to refresh only the trailing months instead of refetching a whole lifetime.
  */
+const ZERO_MONTH: MonthlyCount = {
+	commits: 0,
+	restricted: 0,
+	issues: 0,
+	pullRequests: 0,
+	reviews: 0,
+	repos: 0,
+};
+
 export async function fetchMonthlyCommits(
 	rawLogin: string,
 	token: string,
@@ -671,19 +700,15 @@ export async function fetchMonthlyCommits(
 	const login = assertLogin(rawLogin);
 	if (windows.length === 0) return [];
 
-	const batches: MonthWindow[][] = [];
-	for (let i = 0; i < windows.length; i += BATCH) {
-		batches.push(windows.slice(i, i + BATCH));
-	}
-
-	const results = await mapWithConcurrency(batches, CONCURRENCY, (batch) => {
+	// One GraphQL request for a batch of windows, returning counts aligned 1:1 with `batch`.
+	async function fetchBatch(batch: MonthWindow[]): Promise<MonthlyCount[]> {
 		const aliases = batch
 			.map(
 				(w, i) =>
 					`w${i}: contributionsCollection(from: "${w.from}", to: "${w.to}") { totalCommitContributions restrictedContributionsCount totalIssueContributions totalPullRequestContributions totalPullRequestReviewContributions totalRepositoryContributions }`,
 			)
 			.join("\n");
-		return graphql<{
+		const res = await graphql<{
 			user: Record<
 				string,
 				{
@@ -696,10 +721,7 @@ export async function fetchMonthlyCommits(
 				}
 			>;
 		}>(token, `query { user(login: "${login}") { ${aliases} } }`);
-	});
-
-	return results.flatMap((res, b) =>
-		batches[b].map((_, i) => {
+		return batch.map((_, i) => {
 			const w = res.user[`w${i}`];
 			return {
 				commits: w?.totalCommitContributions ?? 0,
@@ -709,8 +731,36 @@ export async function fetchMonthlyCommits(
 				reviews: w?.totalPullRequestReviewContributions ?? 0,
 				repos: w?.totalRepositoryContributions ?? 0,
 			};
-		}),
-	);
+		});
+	}
+
+	// A batch of hyper-active months can exceed GitHub's per-query resource limit (see
+	// isResourceLimit) or hit a transient server hiccup. Both are isolated the same way
+	// `fetchOrgMemberContributions` isolates a poisoned window: split the batch and retry the
+	// halves *sequentially* (so we never burst past the outer CONCURRENCY cap into a secondary
+	// rate limit). A single window that still fails after graphql()'s retries degrades to a
+	// zero month rather than sinking the whole build — the same last-resort the org path takes,
+	// and it self-heals on the frontier re-fetch.
+	async function fetchAdaptive(batch: MonthWindow[]): Promise<MonthlyCount[]> {
+		try {
+			return await fetchBatch(batch);
+		} catch (err) {
+			if (!isResourceLimit(err) && !isServerHiccup(err)) throw err;
+			if (batch.length === 1) return [ZERO_MONTH];
+			const mid = Math.ceil(batch.length / 2);
+			const left = await fetchAdaptive(batch.slice(0, mid));
+			const right = await fetchAdaptive(batch.slice(mid));
+			return [...left, ...right];
+		}
+	}
+
+	const batches: MonthWindow[][] = [];
+	for (let i = 0; i < windows.length; i += BATCH) {
+		batches.push(windows.slice(i, i + BATCH));
+	}
+
+	const results = await mapWithConcurrency(batches, CONCURRENCY, fetchAdaptive);
+	return results.flat();
 }
 
 /** Accumulate per-month counts into separate cumulative series (public + private). */


### PR DESCRIPTION
Fixes profiles that never load, e.g. `Sigmanificient`. The history builder now splits a contribution batch that trips GitHub's per-query resource limit instead of letting the whole build fail.

**Why:** hyper-active recent months (500+ commits/month) make a 6-month `contributionsCollection` query exceed GitHub's ~10s per-query resource limit. `fetchMonthlyCommits` had no split-on-failure fallback, so the chunk threw and — because builds only stamp `builtAt` once every month lands — the profile stayed stuck "building" forever.

**How:** recognize the "resource limits exceeded" error and fail fast on it (retrying the identical query is futile), then split a failing batch and retry the halves *sequentially*, mirroring the existing `fetchOrgMemberContributions` window-isolation. One judgment call: a single window that still fails degrades to a zero month as a last resort (same as the org path) rather than sinking the build; in practice single-month queries always succeed.

No migration. Resumable builds mean stuck prod rows finish on their own after deploy — no DB action. Verified against real GitHub (build completes, 84 months) and added unit tests for the split and zero-fallback paths.