### PR TITLE
Serve /sitemap.xml via a route (fix $user shadowing it)

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SponsoringRouteImport } from './routes/sponsoring'
+import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as UserRouteImport } from './routes/$user'
 import { Route as IndexRouteImport } from './routes/index'
@@ -28,6 +29,11 @@ import { Route as Char91Char93MetricsSlugRouteImport } from './routes/[-].metric
 const SponsoringRoute = SponsoringRouteImport.update({
   id: '/sponsoring',
   path: '/sponsoring',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
+  id: '/sitemap.xml',
+  path: '/sitemap.xml',
   getParentRoute: () => rootRouteImport,
 } as any)
 const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
@@ -107,6 +113,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/sponsoring': typeof SponsoringRoute
   '/-/$slug': typeof Char91Char93SlugRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
@@ -124,6 +131,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/sponsoring': typeof SponsoringRoute
   '/-/$slug': typeof Char91Char93SlugRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
@@ -142,6 +150,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$user': typeof UserRoute
   '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
   '/sponsoring': typeof SponsoringRoute
   '/-/$slug': typeof Char91Char93SlugRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
@@ -161,6 +170,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/robots.txt'
+    | '/sitemap.xml'
     | '/sponsoring'
     | '/-/$slug'
     | '/-/sponsoring'
@@ -178,6 +188,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/robots.txt'
+    | '/sitemap.xml'
     | '/sponsoring'
     | '/-/$slug'
     | '/-/sponsoring'
@@ -195,6 +206,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$user'
     | '/robots.txt'
+    | '/sitemap.xml'
     | '/sponsoring'
     | '/-/$slug'
     | '/-/sponsoring'
@@ -213,6 +225,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   UserRoute: typeof UserRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   SponsoringRoute: typeof SponsoringRoute
   Char91Char93SlugRoute: typeof Char91Char93SlugRoute
   Char91Char93SponsoringRoute: typeof Char91Char93SponsoringRoute
@@ -234,6 +247,13 @@ declare module '@tanstack/react-router' {
       path: '/sponsoring'
       fullPath: '/sponsoring'
       preLoaderRoute: typeof SponsoringRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sitemap.xml': {
+      id: '/sitemap.xml'
+      path: '/sitemap.xml'
+      fullPath: '/sitemap.xml'
+      preLoaderRoute: typeof SitemapDotxmlRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/robots.txt': {
@@ -341,6 +361,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   UserRoute: UserRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,
+  SitemapDotxmlRoute: SitemapDotxmlRoute,
   SponsoringRoute: SponsoringRoute,
   Char91Char93SlugRoute: Char91Char93SlugRoute,
   Char91Char93SponsoringRoute: Char91Char93SponsoringRoute,

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -1,6 +1,7 @@
 import {
 	createFileRoute,
 	Link,
+	notFound,
 	useNavigate,
 	useRouter,
 } from "@tanstack/react-router";
@@ -55,7 +56,13 @@ export const Route = createFileRoute("/$user")({
 		isMetricParam(search.metric) ? { metric: search.metric } : {},
 	// GitHub logins are one namespace across users and orgs, so this route serves both:
 	// /paritytech renders the org view, /peetzweg the user view (see getLookup).
-	loader: ({ params }) => getLookup({ data: parseLogins(params.user) }),
+	loader: ({ params }) => {
+		// A dot is never valid in a GitHub login, so a single segment containing one is a static
+		// file (sitemap.xml, foo.php probes, …), not a user. Refuse it here so this catch-all can
+		// never render a bogus "<file>'s commit history" page and shadow a real asset/route.
+		if (params.user.includes(".")) throw notFound();
+		return getLookup({ data: parseLogins(params.user) });
+	},
 	head: ({
 		params,
 		loaderData,

--- a/src/routes/sitemap[.]xml.tsx
+++ b/src/routes/sitemap[.]xml.tsx
@@ -1,0 +1,84 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { articles, orgArticles, posts } from "#/lib/content";
+
+/**
+ * XML sitemap, served as an explicit route rather than a generated static file.
+ *
+ * The build-time sitemap plugin writes /sitemap.xml into the client output, but a single-segment
+ * file isn't in nitro's static-asset manifest, so the `$user` catch-all shadows it and the URL
+ * renders a bogus "sitemap.xml's commit history" page. An explicit route outranks `$user` (same
+ * as robots[.]txt.tsx), so this always wins. It's generated from the content collections, so new
+ * editorial pages appear automatically.
+ *
+ * Editorial pages only — never the DB-backed `$user`/org lookup routes.
+ */
+const SITE = "https://commit-history.com";
+
+interface SitemapEntry {
+	path: string;
+	changefreq: string;
+	priority: string;
+	lastmod?: string;
+}
+
+function renderSitemap(): string {
+	// Server route, so a real clock is available (unlike build-time); the homepage is DB-driven
+	// and effectively always fresh, so it gets today's date.
+	const today = new Date().toISOString().slice(0, 10);
+	const entries: SitemapEntry[] = [
+		{ path: "/", changefreq: "weekly", priority: "1.0", lastmod: today },
+		{ path: "/-/metrics", changefreq: "monthly", priority: "0.8" },
+		{ path: "/-/sponsoring", changefreq: "monthly", priority: "0.5" },
+		...articles.map((a) => ({
+			path: `/-/metrics/${a.slug}`,
+			changefreq: "monthly",
+			priority: "0.7",
+			lastmod: a.updatedAt,
+		})),
+		...orgArticles.map((a) => ({
+			path: `/-/organizations/${a.slug}`,
+			changefreq: "monthly",
+			priority: "0.7",
+			lastmod: a.updatedAt,
+		})),
+		...posts.map((a) => ({
+			path: `/-/${a.slug}`,
+			changefreq: "weekly",
+			priority: "0.8",
+			lastmod: a.updatedAt,
+		})),
+	];
+	const urls = entries
+		.map((e) =>
+			[
+				"  <url>",
+				`    <loc>${SITE}${e.path}</loc>`,
+				e.lastmod ? `    <lastmod>${e.lastmod}</lastmod>` : "",
+				`    <changefreq>${e.changefreq}</changefreq>`,
+				`    <priority>${e.priority}</priority>`,
+				"  </url>",
+			]
+				.filter(Boolean)
+				.join("\n"),
+		)
+		.join("\n");
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+export const Route = createFileRoute("/sitemap.xml")({
+	server: {
+		handlers: {
+			GET: () =>
+				new Response(renderSitemap(), {
+					headers: {
+						"content-type": "application/xml; charset=utf-8",
+						"cache-control": "public, max-age=3600",
+					},
+				}),
+		},
+	},
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,18 +46,16 @@ const config = defineConfig({
 			}),
 		},
 		tanstackStart({
-			// Generated into the client output as /sitemap.xml (replaces the old static file;
-			// robots.txt already points there). Only pages listed below are included — the
-			// dynamic per-user sitemap (#70) will join as a sitemap index later.
-			sitemap: { host: "https://commit-history.com" },
-			// Only the explicit list below — never crawl into DB-backed routes.
+			// Prerender config only. The sitemap is NOT generated here: a single-segment file
+			// like /sitemap.xml written into the client output isn't in nitro's static-asset
+			// manifest, so the `$user` catch-all shadows it at runtime. It's served instead by
+			// an explicit route (src/routes/sitemap[.]xml.tsx), the same trick robots.txt uses.
 			prerender: { autoStaticPathsDiscovery: false },
 			pages: [
-				// Homepage is DB-driven — sitemap entry only, never prerendered.
+				// Homepage is DB-driven — never prerendered (and listed in the sitemap route).
 				{
 					path: "/",
 					prerender: { enabled: false },
-					sitemap: { changefreq: "weekly", priority: 1.0 },
 				},
 				// `enabled: true` must be explicit — it's what switches prerendering on for
 				// the whole build (a page relying on the schema default doesn't). And
@@ -73,31 +71,25 @@ const config = defineConfig({
 				{
 					path: "/-/metrics",
 					prerender: { enabled: true, crawlLinks: false },
-					sitemap: { changefreq: "monthly", priority: 0.8 },
 				},
 				// The sponsor pitch page — static content, so prerendered like the explainers.
 				{
 					path: "/-/sponsoring",
 					prerender: { enabled: true, crawlLinks: false },
-					sitemap: { changefreq: "monthly", priority: 0.5 },
 				},
 				...metricSlugs.map((slug) => ({
 					path: `/-/metrics/${slug}`,
 					prerender: { enabled: true, crawlLinks: false },
-					sitemap: { changefreq: "monthly" as const, priority: 0.7 },
 				})),
 				// Organization-context explainers.
 				...orgSlugs.map((slug) => ({
 					path: `/-/organizations/${slug}`,
 					prerender: { enabled: true, crawlLinks: false },
-					sitemap: { changefreq: "monthly" as const, priority: 0.7 },
 				})),
-				// Standalone posts, flat under /-/ (leaderboard rankings etc). Refreshed in place,
-				// so weekly signals crawlers to revisit as the underlying boards move.
+				// Standalone posts, flat under /-/ (leaderboard rankings etc).
 				...postSlugs.map((slug) => ({
 					path: `/-/${slug}`,
 					prerender: { enabled: true, crawlLinks: false },
-					sitemap: { changefreq: "weekly" as const, priority: 0.8 },
 				})),
 			],
 		}),


### PR DESCRIPTION
`https://commit-history.com/sitemap.xml` was returning a page titled "sitemap.xml's commit history" instead of the sitemap, so Search Console can't read it.

**Why:** the build-time sitemap plugin writes `/sitemap.xml` into the client output, but a single-segment file isn't in nitro's static-asset manifest, so the `$user` catch-all shadows it and renders it as a username lookup. (robots.txt is unaffected only because it already has its own route.) Confirmed on prod and in a local prod build.

**How:** `src/routes/sitemap[.]xml.tsx` — an explicit route that outranks `$user` (same pattern as `robots[.]txt.tsx`) and generates the sitemap from the content collections, so new editorial pages show up automatically. Dropped the now-redundant tanstackStart sitemap plugin config. Separately, `$user` now returns `notFound()` for any segment containing a `.` — never valid in a GitHub login — so dotted paths (the sitemap, vuln-scanner probes like `/wp-login.php`) 404 instead of rendering a fake profile and shadowing static assets.

Verified on a local production build: `/sitemap.xml` → `application/xml` with 20 URLs; `/wp-login.php` → 404; `/torvalds`, `/-/<post>`, and `/robots.txt` unchanged. tsc/biome/tests pass.