### PR TITLE
Self-serve sponsor-slot rental via Stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,27 @@ GITHUB_TOKEN=
 # Get it from the Neon console → your project → "Connection string".
 # Leave empty to run without a DB (cache falls back to in-memory).
 DATABASE_URL=
+
+# --- Sponsor slots (Stripe) ---------------------------------------------------------------------
+# Self-serve rental of the two leaderboard sponsor slots. Leave ALL of these empty to run without
+# Stripe: the /-/sponsoring page falls back to its mailto CTA and nothing breaks. Set them up in
+# the Stripe dashboard (test mode first). See issue #131 for the full owner checklist.
+
+# Secret API key (test: sk_test_…, live: sk_live_…). Server-only, never shipped to the client.
+STRIPE_SECRET_KEY=
+# Signing secret for the webhook endpoint (whsec_…) — from the dashboard webhook, or `stripe listen`.
+STRIPE_WEBHOOK_SECRET=
+
+# Developer-board slot: recurring Price id, Payment Link id (webhook deactivates it on sale), and
+# Payment Link URL (the page sends buyers here — not derivable from the id).
+SPONSOR_DEV_PRICE_ID=
+SPONSOR_DEV_PAYMENT_LINK_ID=
+SPONSOR_DEV_PAYMENT_LINK_URL=
+# Force the dev slot to show "Booked" while the legacy Rebates deal holds it (not a Stripe sub).
+# Set to 1 to override; unset/empty lets Stripe subscription state decide.
+SPONSOR_DEV_SLOT_FORCE_BOOKED=
+
+# Organization-board slot: same three values.
+SPONSOR_ORG_PRICE_ID=
+SPONSOR_ORG_PAYMENT_LINK_ID=
+SPONSOR_ORG_PAYMENT_LINK_URL=

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "remark-gfm": "^4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
     "satori": "^0.26.0",
+    "stripe": "^22.3.2",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.3.2",
     "tw-animate-css": "^1.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,10 @@ importers:
         version: 0.10.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)
       '@tanstack/react-query':
         specifier: latest
-        version: 5.101.2(react@19.2.7)
+        version: 5.101.3(react@19.2.7)
       '@tanstack/react-query-devtools':
         specifier: latest
-        version: 5.101.2(@tanstack/react-query@5.101.2(react@19.2.7))(react@19.2.7)
+        version: 5.101.3(@tanstack/react-query@5.101.3(react@19.2.7))(react@19.2.7)
       '@tanstack/react-router':
         specifier: latest
         version: 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -37,10 +37,10 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.15)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-router-ssr-query':
         specifier: latest
-        version: 1.167.1(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.167.1(@tanstack/query-core@5.101.3)(@tanstack/react-query@5.101.3(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: latest
-        version: 1.168.28(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.168.32(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.168.19
         version: 1.168.19(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -83,6 +83,9 @@ importers:
       satori:
         specifier: ^0.26.0
         version: 0.26.0
+      stripe:
+        specifier: ^22.3.2
+        version: 22.3.2(@types/node@22.20.0)
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.6.0
@@ -1499,11 +1502,11 @@ packages:
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/query-core@5.101.2':
-    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+  '@tanstack/query-core@5.101.3':
+    resolution: {integrity: sha512-pWLyu7AjFFVM5G+frjcL81kKEW9R8GCCPKnL3uaWbMwd2f3ZINFCuy+PtKkdz/+pKw/f/XMsFsYq/H+uJHM4GQ==}
 
-  '@tanstack/query-devtools@5.101.2':
-    resolution: {integrity: sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==}
+  '@tanstack/query-devtools@5.101.3':
+    resolution: {integrity: sha512-twEAOB5uBmpFAdlIuy3KIUujwmoZIhCXZpu1PFMTress2XvK/CyzsvV70WrhtTcocszKpbvwMR0Bxq4dqkvH0g==}
 
   '@tanstack/react-devtools@0.10.8':
     resolution: {integrity: sha512-YJV6YttQf9lhhPbPBLULgy1eScEvJUMsCS26mjg9hfBKgAJQA5sF9zvzorDzW9Ob6o/asoXikO81JnRUVuFX0Q==}
@@ -1514,14 +1517,14 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-query-devtools@5.101.2':
-    resolution: {integrity: sha512-eU7HctdA9gDjqoERoEdzLbw9DiqnBDfh5+Hu0u26gjqoHJezOpQAuiesDL2VvkU+2cPV76zgv0tMZsOrI4LjnQ==}
+  '@tanstack/react-query-devtools@5.101.3':
+    resolution: {integrity: sha512-Xr4gCymObeVmtImtsPDVzOlvy3Itr2ti3IrtdbcyhsmpsM54v2A7VR9hTB40C6wzCf3yM4Q2LqkFbNm1u8wd3A==}
     peerDependencies:
-      '@tanstack/react-query': ^5.101.2
+      '@tanstack/react-query': ^5.101.3
       react: ^18 || ^19
 
-  '@tanstack/react-query@5.101.2':
-    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+  '@tanstack/react-query@5.101.3':
+    resolution: {integrity: sha512-ZjgcRwmQUSCythDPj6pE2NKFi9bpQegxIBxgt3hPytXI1ElFHNaa3A7aWW8vFaLCIRjPv467rbREYHbxcdgQbg==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -1561,8 +1564,8 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start-rsc@0.1.27':
-    resolution: {integrity: sha512-4Gt8+XHRhcYJjfw1rTlkW5ZxRWcp6AmvPoBf1p7ysOSVlnfVitQBqgAAFNGy+d745vWfoz1/JWqyFBP8IVVYYg==}
+  '@tanstack/react-start-rsc@0.1.31':
+    resolution: {integrity: sha512-WxjkXYflq550vTNJpdPyMaPC+Vyh88L5wOL+SiDTjPMGne9ad7FZmoJxqfCFEv1e7HVKMH/mMoE8619TsTNVzQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rspack/core': '>=2.0.0-0'
@@ -1585,8 +1588,8 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start@1.168.28':
-    resolution: {integrity: sha512-UyJ/OYBw7x8MQclyXKlbg72qzSTK6Do4AugHcx0LoagHNg6tQgvF0l2HZqll2CrxKAlv2Ar8+0gEkHnFYxxI5Q==}
+  '@tanstack/react-start@1.168.32':
+    resolution: {integrity: sha512-y1WXHo+jPfHxiuuN1m+br06IcriiBQnEWryBdbKdEOS5vw2PmnOj+Cgf1/YcGOqtSougScWFeE2rL1FXWvsLLg==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -1635,8 +1638,8 @@ packages:
     resolution: {integrity: sha512-kFvM4caRds9Q3EXg64bZubJ6rbDxyV0YDSBSGvOGzmKspQPdz5Xrh0uj5T1Ov8avUUg+c761u04VQAaEzSBXRw==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/router-generator@1.167.19':
-    resolution: {integrity: sha512-db3AQGLinf8ZQ8AKMyxLVWwHIFZxtx+zLktvPXv/nFH/B793/Z7lKLl4dUWM3JpAluynDSVVKaTWQVTAgTYmVA==}
+  '@tanstack/router-generator@1.167.21':
+    resolution: {integrity: sha512-m3oXZyienj8owialdyoZ0txHQrnEx/Ra+D9kWtar5fC2cWZr5Pvxl86VY2mX5RRLC5QLKLeRGT1x4HV95wHVDQ==}
     engines: {node: '>=20.19'}
 
   '@tanstack/router-plugin@1.168.19':
@@ -1660,8 +1663,8 @@ packages:
       webpack:
         optional: true
 
-  '@tanstack/router-plugin@1.168.20':
-    resolution: {integrity: sha512-G5S63xDr2AxADtWP+0tQtJsduijT/Mk85hDh3Od4ct8UV0PHr2f/H1CGl72lYWLgcWRMn6bKJoQhz27QFIgLRQ==}
+  '@tanstack/router-plugin@1.168.23':
+    resolution: {integrity: sha512-0+PIcvnaAimFwjoEIeV3h7LKjzC8zNnp7pH2UamdKwQ9QlY99WU9V0Xl0zbM0i9hrUa/mKgWPDAzELmPUu5fMA==}
     engines: {node: '>=20.19'}
     peerDependencies:
       '@rsbuild/core': '>=1.0.2 || ^2.0.0'
@@ -1700,8 +1703,8 @@ packages:
     resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
     engines: {node: '>=22.12.0'}
 
-  '@tanstack/start-plugin-core@1.171.20':
-    resolution: {integrity: sha512-s2n82ykGXGkDSoJwGZP85vC9Dv5vAN6fya5TCSm/cvUn+r/g30iDR1x+Ptizas3fIvcracSOOvRnma4RJ8Orww==}
+  '@tanstack/start-plugin-core@1.171.24':
+    resolution: {integrity: sha512-l/tm+T0ntXHeIzr9kJDTJ2IDNZC0yFazjkvbEVeZsDOrJ8F+HiZmY+tXYqI5/nDYkwxY0DVQr+kGsTRVb6y2Jw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -3041,6 +3044,15 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  stripe@22.3.2:
+    resolution: {integrity: sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -4418,9 +4430,9 @@ snapshots:
 
   '@tanstack/history@1.162.0': {}
 
-  '@tanstack/query-core@5.101.2': {}
+  '@tanstack/query-core@5.101.3': {}
 
-  '@tanstack/query-devtools@5.101.2': {}
+  '@tanstack/query-devtools@5.101.3': {}
 
   '@tanstack/react-devtools@0.10.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(solid-js@1.9.13)':
     dependencies:
@@ -4435,15 +4447,15 @@ snapshots:
       - solid-js
       - utf-8-validate
 
-  '@tanstack/react-query-devtools@5.101.2(@tanstack/react-query@5.101.2(react@19.2.7))(react@19.2.7)':
+  '@tanstack/react-query-devtools@5.101.3(@tanstack/react-query@5.101.3(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tanstack/query-devtools': 5.101.2
-      '@tanstack/react-query': 5.101.2(react@19.2.7)
+      '@tanstack/query-devtools': 5.101.3
+      '@tanstack/react-query': 5.101.3(react@19.2.7)
       react: 19.2.7
 
-  '@tanstack/react-query@5.101.2(react@19.2.7)':
+  '@tanstack/react-query@5.101.3(react@19.2.7)':
     dependencies:
-      '@tanstack/query-core': 5.101.2
+      '@tanstack/query-core': 5.101.3
       react: 19.2.7
 
   '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.15)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
@@ -4457,12 +4469,12 @@ snapshots:
     transitivePeerDependencies:
       - csstype
 
-  '@tanstack/react-router-ssr-query@1.167.1(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tanstack/react-router-ssr-query@1.167.1(@tanstack/query-core@5.101.3)(@tanstack/react-query@5.101.3(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tanstack/query-core': 5.101.2
-      '@tanstack/react-query': 5.101.2(react@19.2.7)
+      '@tanstack/query-core': 5.101.3
+      '@tanstack/react-query': 5.101.3(react@19.2.7)
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/router-ssr-query-core': 1.169.1(@tanstack/query-core@5.101.2)(@tanstack/router-core@1.171.15)
+      '@tanstack/router-ssr-query-core': 1.169.1(@tanstack/query-core@5.101.3)(@tanstack/router-core@1.171.15)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -4485,14 +4497,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.27(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.31(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-core': 1.171.15
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17(crossws@0.4.8(srvx@0.11.17))
       '@tanstack/start-storage-context': 1.167.17
       pathe: 2.0.3
@@ -4522,15 +4534,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.28(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.32(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start-client': 1.168.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.27(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.31(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.22(crossws@0.4.8(srvx@0.11.17))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
-      '@tanstack/start-plugin-core': 1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17(crossws@0.4.8(srvx@0.11.17))
       pathe: 2.0.3
       react: 19.2.7
@@ -4601,7 +4613,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-generator@1.167.19':
+  '@tanstack/router-generator@1.167.21':
     dependencies:
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
@@ -4638,13 +4650,13 @@ snapshots:
       - supports-color
       - unloader
 
-  '@tanstack/router-plugin@1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
-      '@tanstack/router-generator': 1.167.19
+      '@tanstack/router-generator': 1.167.21
       '@tanstack/router-utils': 1.162.2
       chokidar: 5.0.0
       unplugin: 3.2.0(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -4662,9 +4674,9 @@ snapshots:
       - supports-color
       - unloader
 
-  '@tanstack/router-ssr-query-core@1.169.1(@tanstack/query-core@5.101.2)(@tanstack/router-core@1.171.15)':
+  '@tanstack/router-ssr-query-core@1.169.1(@tanstack/query-core@5.101.3)(@tanstack/router-core@1.171.15)':
     dependencies:
-      '@tanstack/query-core': 5.101.2
+      '@tanstack/query-core': 5.101.3
       '@tanstack/router-core': 1.171.15
 
   '@tanstack/router-utils@1.162.2':
@@ -4689,14 +4701,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.8(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
-      '@tanstack/router-generator': 1.167.19
-      '@tanstack/router-plugin': 1.168.20(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@tanstack/router-generator': 1.167.21
+      '@tanstack/router-plugin': 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.17(crossws@0.4.8(srvx@0.11.17))
       exsolve: 1.1.0
@@ -6370,6 +6382,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  stripe@22.3.2(@types/node@22.20.0):
+    optionalDependencies:
+      '@types/node': 22.20.0
 
   style-to-js@1.1.21:
     dependencies:

--- a/src/components/OrgView.tsx
+++ b/src/components/OrgView.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { BadgeCheck } from "lucide-react";
 import { motion } from "motion/react";
+import { SponsorRow } from "#/components/SponsorRow";
 import type { BuildProgress } from "#/lib/github";
 import type { OrgMemberEntry, OrgResult } from "#/lib/org";
 import type { OrgSummary } from "#/lib/org-cache";
@@ -315,49 +316,57 @@ function MemberBoard({
 				</p>
 			</div>
 			<ol>
-				{members.map((m, i) => (
-					<li key={m.login} className="border-border border-b">
-						<Link
-							to="/$user"
-							params={{ user: m.login }}
-							preload={false}
-							className="group flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
-						>
-							<span className="flex w-6 items-center justify-center text-sm tabular-nums text-muted-foreground">
-								{i === 0 ? (
-									<img
-										src="/crown.svg"
-										alt="1st place"
-										className="h-4 w-auto"
-									/>
-								) : (
-									i + 1
-								)}
-							</span>
-							<img
-								src={m.avatarUrl ?? ""}
-								alt=""
-								className="h-8 w-8 rounded-full border border-border"
-							/>
-							<span className="min-w-0 flex-1 truncate font-medium">
-								{m.login}
-								{m.name && (
-									<span className="ml-2 hidden font-normal text-muted-foreground opacity-0 transition-opacity duration-200 sm:inline desktop:group-hover:opacity-100 desktop:group-focus-within:opacity-100">
-										{m.name}
+				{members.flatMap((m, i) => {
+					const items = [
+						<li key={m.login} className="border-border border-b">
+							<Link
+								to="/$user"
+								params={{ user: m.login }}
+								preload={false}
+								className="group flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
+							>
+								<span className="flex w-6 items-center justify-center text-sm tabular-nums text-muted-foreground">
+									{i === 0 ? (
+										<img
+											src="/crown.svg"
+											alt="1st place"
+											className="h-4 w-auto"
+										/>
+									) : (
+										i + 1
+									)}
+								</span>
+								<img
+									src={m.avatarUrl ?? ""}
+									alt=""
+									className="h-8 w-8 rounded-full border border-border"
+								/>
+								<span className="min-w-0 flex-1 truncate font-medium">
+									{m.login}
+									{m.name && (
+										<span className="ml-2 hidden font-normal text-muted-foreground opacity-0 transition-opacity duration-200 sm:inline desktop:group-hover:opacity-100 desktop:group-focus-within:opacity-100">
+											{m.name}
+										</span>
+									)}
+								</span>
+								<span className="text-right">
+									<span className="block font-semibold tabular-nums">
+										{m.commits.toLocaleString()}
 									</span>
-								)}
-							</span>
-							<span className="text-right">
-								<span className="block font-semibold tabular-nums">
-									{m.commits.toLocaleString()}
+									<span className="block text-xs text-muted-foreground tabular-nums">
+										commits
+									</span>
 								</span>
-								<span className="block text-xs text-muted-foreground tabular-nums">
-									commits
-								</span>
-							</span>
-						</Link>
-					</li>
-				))}
+							</Link>
+						</li>,
+					];
+					// The organization sponsor slot rides along on every org's member board too, not
+					// just the home org board — same slot, more of the impressions it's sold on. After
+					// rank 5, once there's more below.
+					if (i === 4 && members.length > 5)
+						items.push(<SponsorRow key="sponsor" slot="org" />);
+					return items;
+				})}
 			</ol>
 		</section>
 	);

--- a/src/components/SponsorRow.tsx
+++ b/src/components/SponsorRow.tsx
@@ -1,0 +1,140 @@
+import { Link } from "@tanstack/react-router";
+import { motion } from "motion/react";
+import { useEffect, useState } from "react";
+import {
+	SPONSORS,
+	type SponsorCreative,
+	type SponsorSlotId,
+} from "#/content/sponsors";
+import { cn } from "#/lib/utils";
+
+/**
+ * The sponsor slot row shown after rank 5 on a leaderboard.
+ *
+ * Driven purely by the static creative in `src/content/sponsors.ts`: a booked slot renders the
+ * sponsor's creative, an empty slot advertises itself and links to the /-/sponsoring pitch page.
+ * Reused across the developer board, the organization board, and each organization's internal
+ * member board, so the same paid slot is seen everywhere its board appears.
+ *
+ * Live "is it sold" status (the "Rent this slot" buttons) is a separate, Stripe-driven concern on
+ * the /-/sponsoring page (`src/lib/sponsor.ts`) — swapping the creative here stays a manual,
+ * reviewable commit made once a sponsor mails their logo.
+ *
+ * Takes an optional `ref` because on the home boards it's a direct child of AnimatePresence
+ * (mode="popLayout"), which attaches a ref to each child to measure it.
+ */
+export function SponsorRow({
+	slot,
+	ref,
+}: {
+	slot: SponsorSlotId;
+	ref?: React.Ref<HTMLLIElement>;
+}) {
+	const creative = SPONSORS[slot];
+	return creative ? (
+		<BookedRow creative={creative} ref={ref} />
+	) : (
+		<EmptyRow ref={ref} />
+	);
+}
+
+function BookedRow({
+	creative,
+	ref,
+}: {
+	creative: SponsorCreative;
+	ref?: React.Ref<HTMLLIElement>;
+}) {
+	// Default to the control arm (index 0) on the server + first paint so hydration matches, then
+	// flip to a random arm on the client. Math.random() during render would desync SSR/hydration.
+	const [arm, setArm] = useState(0);
+	const variants = creative.abVariants;
+	useEffect(() => {
+		if (variants && variants.length > 1) {
+			setArm(Math.floor(Math.random() * variants.length));
+		}
+	}, [variants]);
+	const active = variants?.[arm];
+	const tagline = active?.tagline ?? creative.tagline;
+	const href = active?.href ?? creative.href;
+
+	return (
+		<motion.li
+			ref={ref}
+			layout
+			initial={{ opacity: 0 }}
+			animate={{ opacity: 1 }}
+			exit={{ opacity: 0 }}
+			transition={{ type: "spring", stiffness: 600, damping: 40 }}
+			className="border-border border-b bg-muted/40"
+		>
+			<a
+				href={href}
+				target="_blank"
+				rel="sponsored nofollow noopener"
+				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
+			>
+				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
+				    "Sponsored" on the right keeps the disclosure. */}
+				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
+					Ad
+				</span>
+				<img
+					src={creative.logo}
+					alt={creative.name}
+					className={cn(
+						"h-8 w-8 shrink-0 border border-border object-cover",
+						creative.logoShape === "square" ? "rounded-lg" : "rounded-full",
+					)}
+				/>
+				{/* Title + tagline on two lines in a lighter weight than the usernames, so the block
+				    matches the logo height and doesn't shout as loud as a real leaderboard entry. */}
+				<span className="min-w-0 flex-1">
+					<span className="block truncate">{creative.name}</span>
+					<span className="block truncate text-xs text-muted-foreground">
+						{tagline}
+					</span>
+				</span>
+				<span className="shrink-0 text-right text-xs text-muted-foreground">
+					Sponsored
+				</span>
+			</a>
+		</motion.li>
+	);
+}
+
+function EmptyRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
+	return (
+		<motion.li
+			ref={ref}
+			layout
+			initial={{ opacity: 0 }}
+			animate={{ opacity: 1 }}
+			exit={{ opacity: 0 }}
+			transition={{ type: "spring", stiffness: 600, damping: 40 }}
+			className="border-border border-b bg-muted/40"
+		>
+			<Link
+				to="/-/sponsoring"
+				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
+			>
+				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
+				    the right-hand label keeps the disclosure. */}
+				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
+					Ad
+				</span>
+				{/* Dashed placeholder where the sponsor's logo would sit — reads as "empty". */}
+				<span className="h-8 w-8 shrink-0 rounded-full border border-border border-dashed" />
+				<span className="min-w-0 flex-1">
+					<span className="block truncate">This sponsor slot is empty</span>
+					<span className="block truncate text-xs text-muted-foreground">
+						Put your product in front of thousands of developers
+					</span>
+				</span>
+				<span className="shrink-0 text-right text-xs text-muted-foreground">
+					Sponsoring
+				</span>
+			</Link>
+		</motion.li>
+	);
+}

--- a/src/content/sponsors.ts
+++ b/src/content/sponsors.ts
@@ -1,0 +1,68 @@
+/**
+ * Static sponsor creative for the two paid slots: the developer board and the organization board.
+ *
+ * The creative lives in code — not a DB, not a CMS. A slot changes maybe once a quarter, a logo
+ * has to be hosted somewhere regardless, and keeping it here means every change is a reviewable,
+ * revertable commit. *Selling* a slot is a Stripe concern (`src/lib/sponsor.ts`); *showing* the
+ * creative is this file. The two are deliberately decoupled: a fresh sale flips the /-/sponsoring
+ * page to "Booked" automatically, while the row below is swapped by hand once the sponsor mails
+ * their logo (same manual step the legacy Rebates deal uses today).
+ *
+ * `null` = the slot has no paid creative right now → the leaderboards show a self-advertising
+ * "empty slot" row linking to the /-/sponsoring pitch page.
+ */
+export type SponsorSlotId = "dev" | "org";
+
+/** One arm of an optional client-side A/B test on a sponsor's tagline. */
+export interface SponsorVariant {
+	tagline: string;
+	/** Outbound link for this arm (carries its own utm_content so clicks are attributable). */
+	href: string;
+}
+
+export interface SponsorCreative {
+	/** Product name, shown as the row title. */
+	name: string;
+	/** One-line tagline under the name (the control arm when `abVariants` is set). */
+	tagline: string;
+	/** Outbound link, already carrying any utm params (the control arm when `abVariants` is set). */
+	href: string;
+	/** Logo image URL (the sponsor mails it; hosted on their domain or in /public). */
+	logo: string;
+	/** Users' avatars are round, orgs' are square — match the board the slot sits on. */
+	logoShape?: "round" | "square";
+	/**
+	 * Optional A/B test on the tagline. When present the row flips to a random arm on the client;
+	 * `tagline`/`href` above stay the SSR/first-paint control so hydration matches.
+	 */
+	abVariants?: readonly SponsorVariant[];
+}
+
+// Rebates.ai occupies the developer slot (legacy deal, not a Stripe subscription). The slot-5
+// tagline A/B test rides along here — utm_content carries the arm so clicks are attributable.
+const rebatesHref = (utmContent: string) =>
+	`https://rebates.ai/?utm_source=commit-history.com&utm_medium=leaderboard&utm_campaign=commit-history_sponsorship&utm_content=${utmContent}`;
+
+export const SPONSORS: Record<SponsorSlotId, SponsorCreative | null> = {
+	dev: {
+		name: "Rebates.ai",
+		logo: "https://rebates.ai/brand/rebates-bandit.svg",
+		logoShape: "round",
+		// Arm "a" (control) is the SSR default; both arms live in abVariants for the client flip.
+		tagline: "The ads in your terminal pay you",
+		href: rebatesHref("slot5-test-79-a"),
+		abVariants: [
+			{
+				tagline: "The ads in your terminal pay you",
+				href: rebatesHref("slot5-test-79-a"),
+			},
+			{
+				tagline: "Watch ads while coding. Get paid.",
+				href: rebatesHref("slot5-test-79-b"),
+			},
+		],
+	},
+	// No paid org sponsor yet → the board shows the self-advertising empty row. When the org slot
+	// sells via Stripe, drop the sponsor's creative here and deploy.
+	org: null,
+};

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -1,0 +1,143 @@
+import { createServerFn } from "@tanstack/react-start";
+import type Stripe from "stripe";
+import type { SponsorSlotId } from "#/content/sponsors";
+
+/**
+ * Live per-slot sponsorship status, read from Stripe. Powers the "Rent this slot" / "Booked"
+ * cards on the /-/sponsoring page — and nothing else. The leaderboard creative (the ad rows) is a
+ * separate, static concern (`src/content/sponsors.ts`); this module never decides what is shown on
+ * a board, only whether a slot is currently for sale.
+ *
+ * No database: a slot's truth lives entirely in Stripe (subscription state per price) plus env
+ * (which price/link maps to which slot). "Booked" is derived from an active subscription existing,
+ * NOT from the Payment Link's `active` flag — that closes the checkout→webhook race, where a link
+ * is briefly still enabled after a purchase completes. Missing config or any Stripe failure yields
+ * `"unknown"`, which the page renders as the mailto fallback — this feature never throws a page.
+ *
+ * The Stripe SDK is Node-only and this module sits in a client-reachable import graph (the
+ * /-/sponsoring route imports the RPC stub + types), so `stripe` is loaded via dynamic import
+ * behind a server check — same idiom as `src/lib/db/index.ts` (the "Buffer is not defined"
+ * incident). A static top-level import would drag the SDK into the browser bundle.
+ */
+
+export type SlotStatus = "available" | "booked" | "unknown";
+
+export interface SlotState {
+	id: SponsorSlotId;
+	status: SlotStatus;
+	/** Present only when status === "available": the Stripe Payment Link to send the buyer to. */
+	buyUrl?: string;
+}
+
+interface SlotEnv {
+	/** Recurring price the slot's subscription is billed on — the "is it booked?" lookup key. */
+	priceId?: string;
+	/** Payment Link id — the webhook deactivates this on first purchase (single-occupancy). */
+	linkId?: string;
+	/** Payment Link URL — the page sends the buyer here. Not derivable from the id. */
+	linkUrl?: string;
+}
+
+/** Per-slot Stripe wiring, read from env at call time (never at module load — values arrive late
+ *  in Coolify). Shared by the status lookup and the webhook. */
+export function sponsorSlotEnv(): Record<SponsorSlotId, SlotEnv> {
+	return {
+		dev: {
+			priceId: process.env.SPONSOR_DEV_PRICE_ID,
+			linkId: process.env.SPONSOR_DEV_PAYMENT_LINK_ID,
+			linkUrl: process.env.SPONSOR_DEV_PAYMENT_LINK_URL,
+		},
+		org: {
+			priceId: process.env.SPONSOR_ORG_PRICE_ID,
+			linkId: process.env.SPONSOR_ORG_PAYMENT_LINK_ID,
+			linkUrl: process.env.SPONSOR_ORG_PAYMENT_LINK_URL,
+		},
+	};
+}
+
+const SLOT_IDS: readonly SponsorSlotId[] = ["dev", "org"];
+
+// A slot counts as taken while a subscription on its price is live-ish. past_due is included
+// deliberately: a lapsing sponsor is still the occupant until Stripe cancels the sub outright.
+const OCCUPIED_STATUSES = new Set<Stripe.Subscription.Status>([
+	"active",
+	"trialing",
+	"past_due",
+]);
+
+/**
+ * Build a Stripe client, or null when unusable (browser, or no secret key configured). Callers
+ * treat null as "Stripe unconfigured" and degrade gracefully. Server-only; never call from the
+ * client — the dynamic import keeps the SDK out of the browser bundle either way.
+ */
+export async function getStripeClient(): Promise<Stripe | null> {
+	if (typeof window !== "undefined") return null;
+	const key = process.env.STRIPE_SECRET_KEY;
+	if (!key) return null;
+	const { default: StripeCtor } = await import("stripe");
+	return new StripeCtor(key);
+}
+
+async function computeSlot(
+	id: SponsorSlotId,
+	env: SlotEnv,
+	stripe: Stripe | null,
+): Promise<SlotState> {
+	// The dev slot is held by the legacy Rebates deal (not a Stripe sub) → forced "booked" via env
+	// until that deal ends. Checked before Stripe so it holds even with Stripe unconfigured.
+	if (id === "dev" && process.env.SPONSOR_DEV_SLOT_FORCE_BOOKED === "1") {
+		return { id, status: "booked" };
+	}
+	if (!stripe || !env.priceId || !env.linkUrl) return { id, status: "unknown" };
+
+	// status: "all" then filter locally — the list filter takes a single status, but a slot is
+	// occupied by any of several. The slot has at most a handful of subs, so the page is tiny.
+	const subs = await stripe.subscriptions.list({
+		price: env.priceId,
+		status: "all",
+		limit: 100,
+	});
+	const occupied = subs.data.some((s) => OCCUPIED_STATUSES.has(s.status));
+	return occupied
+		? { id, status: "booked" }
+		: { id, status: "available", buyUrl: env.linkUrl };
+}
+
+// Module-level cache: one Stripe round-trip per minute, shared across the server process (the
+// webhook busts it on a sale so the page flips within the round-trip, not the full 60s). Purely a
+// perf shim — the truth is always Stripe, so a cold cache after a restart just refills on next read.
+const CACHE_MS = 60_000;
+let cache: { at: number; slots: SlotState[] } | null = null;
+
+/** Drop the cached slot statuses so the next read re-hits Stripe. Called by the webhook. */
+export function bustSponsorSlotCache(): void {
+	cache = null;
+}
+
+async function loadSlots(): Promise<SlotState[]> {
+	const stripe = await getStripeClient().catch(() => null);
+	const env = sponsorSlotEnv();
+	return Promise.all(
+		SLOT_IDS.map((id) =>
+			// One slot's Stripe hiccup mustn't blank the other — isolate each to "unknown".
+			computeSlot(id, env[id], stripe).catch(
+				(): SlotState => ({ id, status: "unknown" }),
+			),
+		),
+	);
+}
+
+/**
+ * Per-slot sponsorship status for the /-/sponsoring page. GET server function, so it's covered by
+ * the global same-origin + rate-limit middleware (`src/start.ts`). Called client-side (no
+ * initialData) so the page stays prerendered and build never touches Stripe.
+ */
+export const getSponsorSlots = createServerFn({ method: "GET" }).handler(
+	async (): Promise<SlotState[]> => {
+		const now = Date.now();
+		if (cache && now - cache.at < CACHE_MS) return cache.slots;
+		const slots = await loadSlots();
+		cache = { at: now, slots };
+		return slots;
+	},
+);

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,36 +9,27 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as SponsoringRouteImport } from './routes/sponsoring'
-import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
-import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
-import { Route as UserRouteImport } from './routes/$user'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as OrganizationsSlugRouteImport } from './routes/organizations.$slug'
-import { Route as MetricsExplainedRouteImport } from './routes/metrics.explained'
-import { Route as MetricsSlugRouteImport } from './routes/metrics.$slug'
-import { Route as EmbedUserRouteImport } from './routes/embed.$user'
-import { Route as CompanySlugRouteImport } from './routes/company.$slug'
-import { Route as Char91Char93SponsoringRouteImport } from './routes/[-].sponsoring'
+import { Route as UserRouteImport } from './routes/$user'
+import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
+import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
+import { Route as SponsoringRouteImport } from './routes/sponsoring'
 import { Route as Char91Char93SlugRouteImport } from './routes/[-].$slug'
+import { Route as Char91Char93SponsoringRouteImport } from './routes/[-].sponsoring'
+import { Route as CompanySlugRouteImport } from './routes/company.$slug'
+import { Route as EmbedUserRouteImport } from './routes/embed.$user'
+import { Route as MetricsSlugRouteImport } from './routes/metrics.$slug'
+import { Route as MetricsExplainedRouteImport } from './routes/metrics.explained'
+import { Route as OrganizationsSlugRouteImport } from './routes/organizations.$slug'
+import { Route as Char91Char93ApiStripeWebhookRouteImport } from './routes/[-].api.stripe-webhook'
 import { Route as Char91Char93MetricsIndexRouteImport } from './routes/[-].metrics.index'
-import { Route as OgKindLoginRouteImport } from './routes/og.$kind.$login'
-import { Route as Char91Char93OrganizationsSlugRouteImport } from './routes/[-].organizations.$slug'
 import { Route as Char91Char93MetricsSlugRouteImport } from './routes/[-].metrics.$slug'
+import { Route as Char91Char93OrganizationsSlugRouteImport } from './routes/[-].organizations.$slug'
+import { Route as OgKindLoginRouteImport } from './routes/og.$kind.$login'
 
-const SponsoringRoute = SponsoringRouteImport.update({
-  id: '/sponsoring',
-  path: '/sponsoring',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
-  id: '/sitemap.xml',
-  path: '/sitemap.xml',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
-  id: '/robots.txt',
-  path: '/robots.txt',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const UserRoute = UserRouteImport.update({
@@ -46,39 +37,19 @@ const UserRoute = UserRouteImport.update({
   path: '/$user',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
+  id: '/robots.txt',
+  path: '/robots.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
-const OrganizationsSlugRoute = OrganizationsSlugRouteImport.update({
-  id: '/organizations/$slug',
-  path: '/organizations/$slug',
+const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
+  id: '/sitemap.xml',
+  path: '/sitemap.xml',
   getParentRoute: () => rootRouteImport,
 } as any)
-const MetricsExplainedRoute = MetricsExplainedRouteImport.update({
-  id: '/metrics/explained',
-  path: '/metrics/explained',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MetricsSlugRoute = MetricsSlugRouteImport.update({
-  id: '/metrics/$slug',
-  path: '/metrics/$slug',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const EmbedUserRoute = EmbedUserRouteImport.update({
-  id: '/embed/$user',
-  path: '/embed/$user',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CompanySlugRoute = CompanySlugRouteImport.update({
-  id: '/company/$slug',
-  path: '/company/$slug',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const Char91Char93SponsoringRoute = Char91Char93SponsoringRouteImport.update({
-  id: '/-/sponsoring',
-  path: '/-/sponsoring',
+const SponsoringRoute = SponsoringRouteImport.update({
+  id: '/sponsoring',
+  path: '/sponsoring',
   getParentRoute: () => rootRouteImport,
 } as any)
 const Char91Char93SlugRoute = Char91Char93SlugRouteImport.update({
@@ -86,15 +57,51 @@ const Char91Char93SlugRoute = Char91Char93SlugRouteImport.update({
   path: '/-/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const Char91Char93SponsoringRoute = Char91Char93SponsoringRouteImport.update({
+  id: '/-/sponsoring',
+  path: '/-/sponsoring',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompanySlugRoute = CompanySlugRouteImport.update({
+  id: '/company/$slug',
+  path: '/company/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EmbedUserRoute = EmbedUserRouteImport.update({
+  id: '/embed/$user',
+  path: '/embed/$user',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MetricsSlugRoute = MetricsSlugRouteImport.update({
+  id: '/metrics/$slug',
+  path: '/metrics/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MetricsExplainedRoute = MetricsExplainedRouteImport.update({
+  id: '/metrics/explained',
+  path: '/metrics/explained',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OrganizationsSlugRoute = OrganizationsSlugRouteImport.update({
+  id: '/organizations/$slug',
+  path: '/organizations/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Char91Char93ApiStripeWebhookRoute =
+  Char91Char93ApiStripeWebhookRouteImport.update({
+    id: '/-/api/stripe-webhook',
+    path: '/-/api/stripe-webhook',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const Char91Char93MetricsIndexRoute =
   Char91Char93MetricsIndexRouteImport.update({
     id: '/-/metrics/',
     path: '/-/metrics/',
     getParentRoute: () => rootRouteImport,
   } as any)
-const OgKindLoginRoute = OgKindLoginRouteImport.update({
-  id: '/og/$kind/$login',
-  path: '/og/$kind/$login',
+const Char91Char93MetricsSlugRoute = Char91Char93MetricsSlugRouteImport.update({
+  id: '/-/metrics/$slug',
+  path: '/-/metrics/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
 const Char91Char93OrganizationsSlugRoute =
@@ -103,9 +110,9 @@ const Char91Char93OrganizationsSlugRoute =
     path: '/-/organizations/$slug',
     getParentRoute: () => rootRouteImport,
   } as any)
-const Char91Char93MetricsSlugRoute = Char91Char93MetricsSlugRouteImport.update({
-  id: '/-/metrics/$slug',
-  path: '/-/metrics/$slug',
+const OgKindLoginRoute = OgKindLoginRouteImport.update({
+  id: '/og/$kind/$login',
+  path: '/og/$kind/$login',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -122,6 +129,7 @@ export interface FileRoutesByFullPath {
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
+  '/-/api/stripe-webhook': typeof Char91Char93ApiStripeWebhookRoute
   '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
   '/-/organizations/$slug': typeof Char91Char93OrganizationsSlugRoute
   '/og/$kind/$login': typeof OgKindLoginRoute
@@ -140,6 +148,7 @@ export interface FileRoutesByTo {
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
+  '/-/api/stripe-webhook': typeof Char91Char93ApiStripeWebhookRoute
   '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
   '/-/organizations/$slug': typeof Char91Char93OrganizationsSlugRoute
   '/og/$kind/$login': typeof OgKindLoginRoute
@@ -159,6 +168,7 @@ export interface FileRoutesById {
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
+  '/-/api/stripe-webhook': typeof Char91Char93ApiStripeWebhookRoute
   '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
   '/-/organizations/$slug': typeof Char91Char93OrganizationsSlugRoute
   '/og/$kind/$login': typeof OgKindLoginRoute
@@ -179,6 +189,7 @@ export interface FileRouteTypes {
     | '/metrics/$slug'
     | '/metrics/explained'
     | '/organizations/$slug'
+    | '/-/api/stripe-webhook'
     | '/-/metrics/$slug'
     | '/-/organizations/$slug'
     | '/og/$kind/$login'
@@ -197,6 +208,7 @@ export interface FileRouteTypes {
     | '/metrics/$slug'
     | '/metrics/explained'
     | '/organizations/$slug'
+    | '/-/api/stripe-webhook'
     | '/-/metrics/$slug'
     | '/-/organizations/$slug'
     | '/og/$kind/$login'
@@ -215,6 +227,7 @@ export interface FileRouteTypes {
     | '/metrics/$slug'
     | '/metrics/explained'
     | '/organizations/$slug'
+    | '/-/api/stripe-webhook'
     | '/-/metrics/$slug'
     | '/-/organizations/$slug'
     | '/og/$kind/$login'
@@ -234,6 +247,7 @@ export interface RootRouteChildren {
   MetricsSlugRoute: typeof MetricsSlugRoute
   MetricsExplainedRoute: typeof MetricsExplainedRoute
   OrganizationsSlugRoute: typeof OrganizationsSlugRoute
+  Char91Char93ApiStripeWebhookRoute: typeof Char91Char93ApiStripeWebhookRoute
   Char91Char93MetricsSlugRoute: typeof Char91Char93MetricsSlugRoute
   Char91Char93OrganizationsSlugRoute: typeof Char91Char93OrganizationsSlugRoute
   OgKindLoginRoute: typeof OgKindLoginRoute
@@ -242,25 +256,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/sponsoring': {
-      id: '/sponsoring'
-      path: '/sponsoring'
-      fullPath: '/sponsoring'
-      preLoaderRoute: typeof SponsoringRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sitemap.xml': {
-      id: '/sitemap.xml'
-      path: '/sitemap.xml'
-      fullPath: '/sitemap.xml'
-      preLoaderRoute: typeof SitemapDotxmlRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/robots.txt': {
-      id: '/robots.txt'
-      path: '/robots.txt'
-      fullPath: '/robots.txt'
-      preLoaderRoute: typeof RobotsDottxtRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$user': {
@@ -270,53 +270,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/robots.txt': {
+      id: '/robots.txt'
+      path: '/robots.txt'
+      fullPath: '/robots.txt'
+      preLoaderRoute: typeof RobotsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/organizations/$slug': {
-      id: '/organizations/$slug'
-      path: '/organizations/$slug'
-      fullPath: '/organizations/$slug'
-      preLoaderRoute: typeof OrganizationsSlugRouteImport
+    '/sitemap.xml': {
+      id: '/sitemap.xml'
+      path: '/sitemap.xml'
+      fullPath: '/sitemap.xml'
+      preLoaderRoute: typeof SitemapDotxmlRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/metrics/explained': {
-      id: '/metrics/explained'
-      path: '/metrics/explained'
-      fullPath: '/metrics/explained'
-      preLoaderRoute: typeof MetricsExplainedRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/metrics/$slug': {
-      id: '/metrics/$slug'
-      path: '/metrics/$slug'
-      fullPath: '/metrics/$slug'
-      preLoaderRoute: typeof MetricsSlugRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/embed/$user': {
-      id: '/embed/$user'
-      path: '/embed/$user'
-      fullPath: '/embed/$user'
-      preLoaderRoute: typeof EmbedUserRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/company/$slug': {
-      id: '/company/$slug'
-      path: '/company/$slug'
-      fullPath: '/company/$slug'
-      preLoaderRoute: typeof CompanySlugRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/-/sponsoring': {
-      id: '/-/sponsoring'
-      path: '/-/sponsoring'
-      fullPath: '/-/sponsoring'
-      preLoaderRoute: typeof Char91Char93SponsoringRouteImport
+    '/sponsoring': {
+      id: '/sponsoring'
+      path: '/sponsoring'
+      fullPath: '/sponsoring'
+      preLoaderRoute: typeof SponsoringRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/-/$slug': {
@@ -326,6 +298,55 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91Char93SlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/-/sponsoring': {
+      id: '/-/sponsoring'
+      path: '/-/sponsoring'
+      fullPath: '/-/sponsoring'
+      preLoaderRoute: typeof Char91Char93SponsoringRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/company/$slug': {
+      id: '/company/$slug'
+      path: '/company/$slug'
+      fullPath: '/company/$slug'
+      preLoaderRoute: typeof CompanySlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/embed/$user': {
+      id: '/embed/$user'
+      path: '/embed/$user'
+      fullPath: '/embed/$user'
+      preLoaderRoute: typeof EmbedUserRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/metrics/$slug': {
+      id: '/metrics/$slug'
+      path: '/metrics/$slug'
+      fullPath: '/metrics/$slug'
+      preLoaderRoute: typeof MetricsSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/metrics/explained': {
+      id: '/metrics/explained'
+      path: '/metrics/explained'
+      fullPath: '/metrics/explained'
+      preLoaderRoute: typeof MetricsExplainedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/organizations/$slug': {
+      id: '/organizations/$slug'
+      path: '/organizations/$slug'
+      fullPath: '/organizations/$slug'
+      preLoaderRoute: typeof OrganizationsSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/-/api/stripe-webhook': {
+      id: '/-/api/stripe-webhook'
+      path: '/-/api/stripe-webhook'
+      fullPath: '/-/api/stripe-webhook'
+      preLoaderRoute: typeof Char91Char93ApiStripeWebhookRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/-/metrics/': {
       id: '/-/metrics/'
       path: '/-/metrics'
@@ -333,11 +354,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91Char93MetricsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/og/$kind/$login': {
-      id: '/og/$kind/$login'
-      path: '/og/$kind/$login'
-      fullPath: '/og/$kind/$login'
-      preLoaderRoute: typeof OgKindLoginRouteImport
+    '/-/metrics/$slug': {
+      id: '/-/metrics/$slug'
+      path: '/-/metrics/$slug'
+      fullPath: '/-/metrics/$slug'
+      preLoaderRoute: typeof Char91Char93MetricsSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/-/organizations/$slug': {
@@ -347,11 +368,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof Char91Char93OrganizationsSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/-/metrics/$slug': {
-      id: '/-/metrics/$slug'
-      path: '/-/metrics/$slug'
-      fullPath: '/-/metrics/$slug'
-      preLoaderRoute: typeof Char91Char93MetricsSlugRouteImport
+    '/og/$kind/$login': {
+      id: '/og/$kind/$login'
+      path: '/og/$kind/$login'
+      fullPath: '/og/$kind/$login'
+      preLoaderRoute: typeof OgKindLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -370,6 +391,7 @@ const rootRouteChildren: RootRouteChildren = {
   MetricsSlugRoute: MetricsSlugRoute,
   MetricsExplainedRoute: MetricsExplainedRoute,
   OrganizationsSlugRoute: OrganizationsSlugRoute,
+  Char91Char93ApiStripeWebhookRoute: Char91Char93ApiStripeWebhookRoute,
   Char91Char93MetricsSlugRoute: Char91Char93MetricsSlugRoute,
   Char91Char93OrganizationsSlugRoute: Char91Char93OrganizationsSlugRoute,
   OgKindLoginRoute: OgKindLoginRoute,

--- a/src/routes/[-].api.stripe-webhook.tsx
+++ b/src/routes/[-].api.stripe-webhook.tsx
@@ -1,0 +1,87 @@
+import { createFileRoute } from "@tanstack/react-router";
+import type { SponsorSlotId } from "#/content/sponsors";
+import {
+	bustSponsorSlotCache,
+	getStripeClient,
+	sponsorSlotEnv,
+} from "#/lib/sponsor";
+
+/**
+ * Stripe webhook → POST /-/api/stripe-webhook.
+ *
+ * A raw `server.handlers` route (like robots.txt / the OG endpoints): router handlers bypass the
+ * server-function CSRF middleware, which is correct here — the request comes from Stripe, not our
+ * frontend, and the Stripe *signature* is the auth. We verify it against the raw request body
+ * before trusting a single field.
+ *
+ * Single-occupancy: on the first `checkout.session.completed` we deactivate the slot's Payment
+ * Link, so a second buyer physically can't reach checkout. Deactivation is idempotent — Stripe
+ * retries and duplicate deliveries re-run it harmlessly, so no event-id bookkeeping is needed.
+ * A `customer.subscription.deleted` only busts the cache and logs; re-opening the link stays a
+ * deliberate manual dashboard toggle (the owner swaps the homepage creative first).
+ */
+
+const err = (msg: string, status: number) => new Response(msg, { status });
+
+export const Route = createFileRoute("/-/api/stripe-webhook")({
+	server: {
+		handlers: {
+			POST: async ({ request }) => {
+				const secret = process.env.STRIPE_WEBHOOK_SECRET;
+				const stripe = await getStripeClient();
+				// Unconfigured → 400 (not 500): nothing to verify against, and a 400 tells a
+				// misconfigured endpoint apart from a genuine server fault in the Stripe dashboard.
+				if (!secret || !stripe) return err("Stripe not configured", 400);
+
+				const signature = request.headers.get("stripe-signature");
+				if (!signature) return err("Missing stripe-signature", 400);
+
+				// Raw body — constructEventAsync recomputes the HMAC over the exact bytes Stripe
+				// signed, so it must be the untouched text, not a re-serialized JSON object.
+				const body = await request.text();
+				let event: import("stripe").Stripe.Event;
+				try {
+					event = await stripe.webhooks.constructEventAsync(
+						body,
+						signature,
+						secret,
+					);
+				} catch {
+					return err("Invalid signature", 400);
+				}
+
+				try {
+					if (event.type === "checkout.session.completed") {
+						const session = event.data.object;
+						const linkId =
+							typeof session.payment_link === "string"
+								? session.payment_link
+								: (session.payment_link?.id ?? null);
+						const env = sponsorSlotEnv();
+						const slot = (Object.keys(env) as SponsorSlotId[]).find(
+							(id) => linkId !== null && env[id].linkId === linkId,
+						);
+						const targetLinkId = slot ? env[slot].linkId : undefined;
+						if (targetLinkId) {
+							// Turn the link off so nobody else can pay. Idempotent: safe to repeat.
+							await stripe.paymentLinks.update(targetLinkId, { active: false });
+							bustSponsorSlotCache();
+						}
+					} else if (event.type === "customer.subscription.deleted") {
+						bustSponsorSlotCache();
+						console.info(
+							"[sponsor] subscription deleted — slot freed, awaiting manual re-open",
+						);
+					}
+				} catch (sideEffect) {
+					// A Stripe call failing here is likely transient. Return 500 so Stripe retries
+					// the (idempotent) deactivation, rather than silently dropping single-occupancy.
+					console.error("[sponsor] webhook side-effect failed", sideEffect);
+					return err("Webhook handler error", 500);
+				}
+
+				return new Response("ok", { status: 200 });
+			},
+		},
+	},
+});

--- a/src/routes/[-].sponsoring.tsx
+++ b/src/routes/[-].sponsoring.tsx
@@ -1,4 +1,7 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
+import type { SponsorSlotId } from "#/content/sponsors";
+import { getSponsorSlots, type SlotState } from "#/lib/sponsor";
 
 const SITE = "https://commit-history.com";
 const TITLE = "Sponsoring commit-history.com";
@@ -23,7 +26,14 @@ const STATS = [
 	{ value: "38%", label: "bounce rate" },
 ] as const;
 
+interface SponsoringSearch {
+	/** Set by the Stripe Payment Link's after-payment redirect (?thanks=1) → shows the banner. */
+	thanks?: true;
+}
+
 export const Route = createFileRoute("/-/sponsoring")({
+	validateSearch: (search: Record<string, unknown>): SponsoringSearch =>
+		search.thanks === "1" || search.thanks === true ? { thanks: true } : {},
 	head: () => ({
 		meta: [
 			{ title: `${TITLE} · Commit History` },
@@ -44,6 +54,7 @@ export const Route = createFileRoute("/-/sponsoring")({
 });
 
 function SponsoringPage() {
+	const { thanks } = Route.useSearch();
 	return (
 		<main className="mx-auto max-w-3xl px-6 py-12">
 			<Link
@@ -59,18 +70,15 @@ function SponsoringPage() {
 				</span>
 			</h1>
 			<p className="mt-3 text-muted-foreground">
-				One sponsor slot, rendered like a leaderboard entry, in 5th place of
-				both the developer and the organization leaderboard — the first thing
-				people scroll past on every visit.
+				One sponsor slot on each leaderboard, rendered like a leaderboard entry
+				in 5th place of the developer and the organization board — the first
+				thing people scroll past on every visit.
 			</p>
 
-			{/* CTA up top: interested sponsors shouldn't have to scroll to find the contact. */}
-			<div className="mt-6 flex flex-wrap items-center gap-3">
-				<a href={MAILTO} className="btn-primary">
-					Get in touch
-				</a>
-				<span className="text-sm text-muted-foreground">{CONTACT}</span>
-			</div>
+			{thanks && <ThanksBanner />}
+
+			{/* Live per-slot status: rent on the spot when a slot is open, mailto fallback otherwise. */}
+			<SlotsSection />
 
 			<h2 className="mt-12 text-xl font-semibold">The numbers</h2>
 			<p className="mt-2 text-muted-foreground">
@@ -115,12 +123,118 @@ function SponsoringPage() {
 			</p>
 
 			<p className="mt-12 text-muted-foreground">
-				Interested?{" "}
+				Questions, or want to sort out a logo and the details first?{" "}
 				<a href={MAILTO} className="font-medium text-foreground underline">
 					Send a mail to {CONTACT}
 				</a>{" "}
 				and we’ll figure out the rest.
 			</p>
 		</main>
+	);
+}
+
+// Copy shown alongside each slot's status card.
+const SLOT_META: Record<SponsorSlotId, { title: string; blurb: string }> = {
+	dev: {
+		title: "Developer board",
+		blurb: "5th place on the developer leaderboard.",
+	},
+	org: {
+		title: "Organization board",
+		blurb:
+			"5th place on the organization leaderboard, shown on every org’s page.",
+	},
+};
+
+const SLOT_ORDER: readonly SponsorSlotId[] = ["dev", "org"];
+
+/**
+ * The two slot cards with live status. Loads client-side (no initialData) so the page stays
+ * prerendered — the card starts on the mailto fallback and upgrades to "Rent this slot" / "Booked"
+ * once Stripe answers. Any unconfigured/failed slot simply stays on the fallback.
+ */
+function SlotsSection() {
+	const { data } = useQuery({
+		queryKey: ["sponsor-slots"],
+		queryFn: () => getSponsorSlots(),
+		staleTime: 60_000,
+	});
+	const byId = new Map((data ?? []).map((s) => [s.id, s]));
+	return (
+		<section className="mt-10">
+			<h2 className="text-xl font-semibold">The slots</h2>
+			<p className="mt-2 text-muted-foreground">
+				Two slots, one sponsor each. Rent one and it’s yours until you cancel —
+				billed monthly, no double-booking.
+			</p>
+			<div className="mt-6 grid gap-4 sm:grid-cols-2">
+				{SLOT_ORDER.map((id) => (
+					<SlotCard key={id} id={id} state={byId.get(id)} />
+				))}
+			</div>
+		</section>
+	);
+}
+
+function SlotCard({ id, state }: { id: SponsorSlotId; state?: SlotState }) {
+	const meta = SLOT_META[id];
+	const status = state?.status ?? "unknown";
+	return (
+		<div className="flex flex-col rounded-lg border p-5">
+			<div className="flex items-center justify-between gap-2">
+				<h3 className="font-semibold">{meta.title}</h3>
+				{status === "available" && (
+					<span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+						Available
+					</span>
+				)}
+				{status === "booked" && (
+					<span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+						Booked
+					</span>
+				)}
+			</div>
+			<p className="mt-1 flex-1 text-sm text-muted-foreground">{meta.blurb}</p>
+			<div className="mt-4">
+				{status === "available" && state?.buyUrl ? (
+					// External Stripe-hosted checkout — full page nav, not client routing.
+					<a
+						href={state.buyUrl}
+						className="btn-primary flex w-full justify-center"
+					>
+						Rent this slot
+					</a>
+				) : status === "booked" ? (
+					<p className="text-sm text-muted-foreground">
+						Taken right now.{" "}
+						<a href={MAILTO} className="underline hover:text-foreground">
+							Ask to be next
+						</a>
+						.
+					</p>
+				) : (
+					// Unknown: Stripe unconfigured or unreachable → the reliable mailto path.
+					<a href={MAILTO} className="btn-secondary flex w-full justify-center">
+						Get in touch
+					</a>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/** Shown after a successful Payment Link checkout (?thanks=1): the next step is the logo email. */
+function ThanksBanner() {
+	return (
+		<div className="mt-6 rounded-lg border border-primary/30 bg-primary/5 p-4">
+			<p className="font-medium">Thanks for renting a slot! 🎉</p>
+			<p className="mt-1 text-sm text-muted-foreground">
+				One thing left: email your logo (SVG or PNG) to{" "}
+				<a href={MAILTO} className="underline hover:text-foreground">
+					{CONTACT}
+				</a>{" "}
+				and we’ll put your creative live on the leaderboard.
+			</p>
+		</div>
 	);
 }

--- a/src/routes/[-].sponsoring.tsx
+++ b/src/routes/[-].sponsoring.tsx
@@ -136,13 +136,12 @@ function SponsoringPage() {
 // Copy shown alongside each slot's status card.
 const SLOT_META: Record<SponsorSlotId, { title: string; blurb: string }> = {
 	dev: {
-		title: "Developer board",
-		blurb: "5th place on the developer leaderboard.",
+		title: "Slot #5 on the Developer Leaderboard",
+		blurb: "The sponsor row in 5th place, seen on every visit.",
 	},
 	org: {
-		title: "Organization board",
-		blurb:
-			"5th place on the organization leaderboard, shown on every org’s page.",
+		title: "Slot #5 on the Organization Leaderboards",
+		blurb: "Including each organization’s internal leaderboard.",
 	},
 };
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { BadgeCheck } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { ExplainerLink } from "#/components/ExplainerLink";
+import { SponsorRow } from "#/components/SponsorRow";
 import {
 	getLeaderboard,
 	getRecentLookups,
@@ -329,124 +330,6 @@ function RecentSection({ recent }: { recent: RecentEntry[] }) {
 }
 
 /**
- * A single hardcoded sponsor row, shown in the slot after rank 5 on the developer board.
- *
- * Same visual treatment as the (parked) DB-driven sponsorship system on `feat/sponsorships`,
- * but with no database — the creative is hardcoded for now. Uses the sponsor's own favicon and
- * page title, and links out with rel="sponsored nofollow".
- */
-// A/B test on the Rebates ad subtitle. "a" is the control (original copy), "b" the
-// challenger. utm_content carries the variant so clicks are attributable per arm.
-const REBATES_VARIANTS = {
-	a: {
-		subtitle: "The ads in your terminal pay you",
-		utmContent: "slot5-test-79-a",
-	},
-	b: {
-		subtitle: "Watch ads while coding. Get paid.",
-		utmContent: "slot5-test-79-b",
-	},
-} as const;
-
-function rebatesHref(utmContent: string): string {
-	return `https://rebates.ai/?utm_source=commit-history.com&utm_medium=leaderboard&utm_campaign=commit-history_sponsorship&utm_content=${utmContent}`;
-}
-
-function SponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
-	// Default to the control on the server/first paint so hydration matches, then flip
-	// to a random 50/50 arm on the client. Math.random() during render would desync SSR.
-	const [variant, setVariant] = useState<"a" | "b">("a");
-	useEffect(() => {
-		setVariant(Math.random() < 0.5 ? "a" : "b");
-	}, []);
-	const { subtitle, utmContent } = REBATES_VARIANTS[variant];
-
-	return (
-		<motion.li
-			ref={ref}
-			layout
-			initial={{ opacity: 0 }}
-			animate={{ opacity: 1 }}
-			exit={{ opacity: 0 }}
-			transition={{ type: "spring", stiffness: 600, damping: 40 }}
-			className="border-border border-b bg-muted/40"
-		>
-			<a
-				href={rebatesHref(utmContent)}
-				target="_blank"
-				rel="sponsored nofollow noopener"
-				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
-			>
-				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
-				    "Sponsored" on the right keeps the disclosure. */}
-				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
-					Ad
-				</span>
-				<img
-					src="https://rebates.ai/brand/rebates-bandit.svg"
-					alt="Rebates.ai"
-					className="h-8 w-8 shrink-0 rounded-full border border-border object-cover"
-				/>
-				{/* Title + tagline on two lines in a lighter weight than the usernames, so the block
-				    matches the logo height and doesn't shout as loud as a real leaderboard entry. */}
-				<span className="min-w-0 flex-1">
-					<span className="block truncate">Rebates.ai</span>
-					<span className="block truncate text-xs text-muted-foreground">
-						{subtitle}
-					</span>
-				</span>
-				<span className="shrink-0 text-right text-xs text-muted-foreground">
-					Sponsored
-				</span>
-			</a>
-		</motion.li>
-	);
-}
-
-/**
- * The empty sponsor slot, shown in the slot after rank 5 on the organization board.
- *
- * That slot has no paid creative yet; until a sponsor signs, it advertises itself and
- * links to the /sponsoring pitch page. Same row treatment as a booked sponsor so buyers
- * see exactly what they'd get.
- */
-function EmptySponsorRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
-	return (
-		<motion.li
-			ref={ref}
-			layout
-			initial={{ opacity: 0 }}
-			animate={{ opacity: 1 }}
-			exit={{ opacity: 0 }}
-			transition={{ type: "spring", stiffness: 600, damping: 40 }}
-			className="border-border border-b bg-muted/40"
-		>
-			<Link
-				to="/-/sponsoring"
-				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
-			>
-				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
-				    the right-hand label keeps the disclosure. */}
-				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
-					Ad
-				</span>
-				{/* Dashed placeholder where the sponsor's logo would sit — reads as "empty". */}
-				<span className="h-8 w-8 shrink-0 rounded-full border border-border border-dashed" />
-				<span className="min-w-0 flex-1">
-					<span className="block truncate">This sponsor slot is empty</span>
-					<span className="block truncate text-xs text-muted-foreground">
-						Put your product in front of thousands of developers
-					</span>
-				</span>
-				<span className="shrink-0 text-right text-xs text-muted-foreground">
-					Sponsoring
-				</span>
-			</Link>
-		</motion.li>
-	);
-}
-
-/**
  * A single hardcoded self-promo row, asking readers to support the author.
  *
  * Pure markup — no database, no ads — pointing at the author's GitHub and Ko-fi.
@@ -718,7 +601,7 @@ function Leaderboard({ initialPage }: { initialPage: LeaderEntry[] }) {
 						];
 						// Sponsor sits in the slot after rank 5 (only once there's more below).
 						if (i === 4 && rows.length > 5)
-							items.push(<SponsorRow key="sponsor" />);
+							items.push(<SponsorRow key="sponsor" slot="dev" />);
 						// Self-promo after slots 10, 50 and 100 (only once there's more below).
 						if (i === 9 && rows.length > 10)
 							items.push(<SelfPromoRow key="promo-10" />);
@@ -831,10 +714,10 @@ function OrgBoard({ rows }: { rows: OrgLeaderEntry[] }) {
 							</Link>
 						</li>,
 					];
-					// Sponsor slot after rank 5, mirroring the developer board — but this one
-					// is unbooked, so it advertises itself.
+					// Sponsor slot after rank 5, mirroring the developer board. The org slot's
+					// creative (or the self-advertising empty row) comes from SponsorRow.
 					if (i === 4 && rows.length > 5)
-						items.push(<EmptySponsorRow key="sponsor" />);
+						items.push(<SponsorRow key="sponsor" slot="org" />);
 					return items;
 				})}
 			</ol>


### PR DESCRIPTION
Closes #131. Lets a visitor rent a leaderboard sponsor slot on the spot instead of the mailto back-and-forth: the /-/sponsoring page shows live per-slot status with a "Rent this slot" button (Stripe-hosted checkout), and falls back to the existing mailto CTA whenever Stripe is unconfigured or down.

**Why:** the pitch page ended in a mailto — no money moved without an email thread. And each slot must be rentable by exactly one sponsor at a time.

**How:** no database — a slot's truth is Stripe subscription state (per price) plus env. Single-occupancy is enforced by a signature-verified webhook that deactivates the slot's Payment Link on first purchase; the page reads *subscription* state (not the link's `active` flag) so the checkout→webhook race can't show a slot as free. The one judgment call: the Stripe SDK is dynamically imported behind a server check (db/index.ts idiom) so it never enters the client bundle — verified the built client assets carry no Stripe code.

Also moved the leaderboard creative (incl. Rebates) into a static `src/content/sponsors.ts` + reusable `SponsorRow`, so a second sponsor is a one-file change and the org slot's ad now renders on each org's internal member board too.

Ships inert: with no Stripe env the page is unchanged (mailto). Go-live is dashboard setup + the 9 env vars in `.env.example`, test mode first.