### PR TITLE
Gate the monthly refresh on month completeness, not row existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,26 @@ In production it runs as a Coolify **scheduled task** on the app image, no separ
 | **Command** | `node .output/worker/monthly-user-refresh.mjs` |
 | **Schedule (UTC)** | `0 3 1 * *` main pass · `0 9 1 * *` and `0 3 2 * *` retry passes |
 
-Run it several times rather than once. Every pass is idempotent: users that already have the
-target month are skipped without a GitHub call, so a missing month row *is* the retry queue.
+Run it several times rather than once. Every pass is idempotent: users whose target month is
+already **complete** are skipped without a GitHub call, so an incomplete month row *is* the retry
+queue.
+
+"Complete" means the row's `monthly_commits.fetched_at` is at/after the month's own end — not
+merely that a row exists. Those differ: before `a44f442` a lookup mid-month stored a few days of
+data under the whole month's label, and the 2026-08-01 pass skipped 2229 of 2230 candidates
+because a row was present. A NULL `fetched_at` (written before the column existed) counts as
+incomplete, so anything unproven gets re-read rather than trusted.
 Overlapping runs are prevented by a Postgres advisory lock (the loser exits 0). The worker
 enforces the UTC month boundary itself — it refuses to touch an incomplete month and exits early
 if invoked before `MONTHLY_USER_SAFE_AFTER_UTC` on the 1st — so scheduler timezone drift can't
 record a half-finished month. It also stays above a reserved GraphQL points floor, since the
 token is shared with live traffic.
+
+A login GitHub stops resolving (deleted, renamed) is stamped `entities.unreachable_at` and drops
+out of the cohort. That is **not** moderation: unlike `suspended_at` it keeps the profile ranked and
+viewable, with a notice — the stored contributions were real, there is just nothing left to fetch.
+Without it one dead account fails every pass of every month forever, since an incomplete month row
+is the retry queue. A later lookup that resolves clears the flag automatically.
 
 ## ☁️ Deploy (self-hosted)
 

--- a/drizzle/0006_brainy_the_hood.sql
+++ b/drizzle/0006_brainy_the_hood.sql
@@ -1,0 +1,32 @@
+ALTER TABLE "entities" ADD COLUMN "unreachable_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "monthly_commits" ADD COLUMN "fetched_at" timestamp with time zone;--> statement-breakpoint
+-- Backfill provenance for rows that predate the column.
+--
+-- `fetched_at` exists so the monthly refresh can tell "this month is done" from "a row happens to
+-- exist". Leaving every historical row NULL would be correct but would make the next pass re-fetch
+-- the whole cohort, so we stamp the rows we can actually vouch for: a month whose entity was last
+-- fetched at/after that month's end can only have been read as a completed month (monthlyWindows
+-- has never emitted an in-progress window since a44f442, and before that the entity's last_fetched
+-- was necessarily inside the month it was writing).
+--
+-- The stamp is `last_fetched`, which is the entity's read time, not the row's — good enough for a
+-- >= month-end comparison, and deliberately conservative: anything it cannot vouch for stays NULL
+-- and gets re-fetched. Verified against GitHub on a 25-row sample before shipping (24 exact, 1 off
+-- by a single private contribution, which drifts on GitHub's side).
+--
+-- What stays NULL within that range is the residue this column was added for: 112 rows for
+-- 2026-07-01 and 8 for 2026-06-01, written mid-month before a44f442 (2026-07-01 05:31 UTC) excluded
+-- the in-progress month from lookups. They hold a few days of data under a full month's label
+-- (jdx: 0 stored vs 837 actual) and the old existence-based gate skipped them forever.
+--
+-- Scoped to 2026 deliberately: 195k rows instead of the table's 4.18M / 494 MB. The gate only ever
+-- asks about the month that just ended, so stamping a decade of settled history would rewrite the
+-- whole table (and its WAL) on a 4 GB host to answer a question nobody asks. Pre-2026 rows keep
+-- NULL = "provenance unknown", which fails safe: a pass deliberately aimed at an old month
+-- re-reads rather than trusts.
+UPDATE "monthly_commits" mc
+SET "fetched_at" = e."last_fetched"
+FROM "entities" e
+WHERE e."id" = mc."entity_id"
+  AND mc."month" >= DATE '2026-01-01'
+  AND e."last_fetched" >= ((mc."month" + interval '1 month') AT TIME ZONE 'UTC');

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,471 @@
+{
+  "id": "284a1302-095f-4214-8b52-89154a60a826",
+  "prevId": "36846044-13e2-4e4e-aa2a-3bf3cdc91e3c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_commits": {
+          "name": "total_commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_restricted": {
+          "name": "total_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_issues": {
+          "name": "total_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pull_requests": {
+          "name": "total_pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_reviews": {
+          "name": "total_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_repos": {
+          "name": "total_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers": {
+          "name": "followers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following": {
+          "name": "following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_username": {
+          "name": "twitter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_node_id": {
+          "name": "github_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_at": {
+          "name": "built_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreachable_at": {
+          "name": "unreachable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lookups": {
+      "name": "lookups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searched_at": {
+          "name": "searched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lookups_entity_id_entities_id_fk": {
+          "name": "lookups_entity_id_entities_id_fk",
+          "tableFrom": "lookups",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monthly_commits": {
+      "name": "monthly_commits",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted": {
+          "name": "restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issues": {
+          "name": "issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_requests": {
+          "name": "pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repos": {
+          "name": "repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monthly_commits_entity_id_entities_id_fk": {
+          "name": "monthly_commits_entity_id_entities_id_fk",
+          "tableFrom": "monthly_commits",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monthly_commits_entity_id_month_pk": {
+          "name": "monthly_commits_entity_id_month_pk",
+          "columns": [
+            "entity_id",
+            "month"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public_member'"
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_requests": {
+          "name": "pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issues": {
+          "name": "issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_members_member_idx": {
+          "name": "org_members_member_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_entities_id_fk": {
+          "name": "org_members_org_id_entities_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_members_member_id_entities_id_fk": {
+          "name": "org_members_member_id_entities_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_members_org_id_member_id_pk": {
+          "name": "org_members_org_id_member_id_pk",
+          "columns": [
+            "org_id",
+            "member_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783493299385,
       "tag": "0005_clammy_bloodaxe",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785614812438,
+      "tag": "0006_brainy_the_hood",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-contributions.ts
+++ b/scripts/backfill-contributions.ts
@@ -136,6 +136,7 @@ async function backfill(id: string, login: string): Promise<{ log: string; reque
 					pullRequests: p.pullRequests,
 					reviews: p.reviews,
 					repos: p.repos,
+					fetchedAt: now,
 				})),
 			)
 			.onConflictDoUpdate({
@@ -147,6 +148,7 @@ async function backfill(id: string, login: string): Promise<{ log: string; reque
 					pullRequests: sql`excluded.pull_requests`,
 					reviews: sql`excluded.reviews`,
 					repos: sql`excluded.repos`,
+					fetchedAt: sql`excluded.fetched_at`,
 				},
 			});
 	}

--- a/scripts/refresh-user.ts
+++ b/scripts/refresh-user.ts
@@ -138,6 +138,7 @@ if (points.length > 0) {
 				pullRequests: p.pullRequests,
 				reviews: p.reviews,
 				repos: p.repos,
+				fetchedAt: now,
 			})),
 		)
 		.onConflictDoUpdate({
@@ -149,6 +150,7 @@ if (points.length > 0) {
 				pullRequests: sql`excluded.pull_requests`,
 				reviews: sql`excluded.reviews`,
 				repos: sql`excluded.repos`,
+				fetchedAt: sql`excluded.fetched_at`,
 			},
 		});
 }

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -260,7 +260,9 @@ async function getFromDb(
 			}
 			const chunk = todo.slice(i, i + CHUNK_MONTHS);
 			const counts = await fetchMonthlyCommits(login, token, chunk);
-			await persistMonths(database, id, chunk, counts);
+			// `now`, not the loop's clock: monthlyWindows only ever yields completed months, so any
+			// row written here is final, and the stamp is what proves it to the monthly refresh.
+			await persistMonths(database, id, chunk, counts, now);
 			points = appendTail(points, chunk, counts);
 		}
 	} catch (err) {
@@ -303,6 +305,10 @@ async function upsertProfile(database: DB, id: string, user: Profile) {
 		location: user.location,
 		websiteUrl: user.websiteUrl,
 		twitterUsername: user.twitterUsername,
+		// GitHub just resolved this login, so whatever made the refresh worker mark it unreachable
+		// is over (un-deleted, renamed back). This is the only path that clears the flag — the
+		// worker itself skips unreachable entities, so it can never un-mark one.
+		unreachableAt: null,
 	};
 	await database
 		.insert(entities)
@@ -326,6 +332,7 @@ async function persistMonths(
 	id: string,
 	windows: MonthWindow[],
 	counts: MonthlyCount[],
+	fetchedAt: Date,
 ) {
 	if (windows.length === 0) return;
 	await database
@@ -340,6 +347,7 @@ async function persistMonths(
 				pullRequests: counts[i]?.pullRequests ?? 0,
 				reviews: counts[i]?.reviews ?? 0,
 				repos: counts[i]?.repos ?? 0,
+				fetchedAt,
 			})),
 		)
 		.onConflictDoUpdate({
@@ -351,6 +359,7 @@ async function persistMonths(
 				pullRequests: sql`excluded.pull_requests`,
 				reviews: sql`excluded.reviews`,
 				repos: sql`excluded.repos`,
+				fetchedAt: sql`excluded.fetched_at`,
 			},
 		});
 }

--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -7,6 +7,7 @@ import {
 	inArray,
 	isNotNull,
 	isNull,
+	or,
 	sql,
 } from "drizzle-orm";
 import type { ChartMode } from "#/components/CommitChart";
@@ -96,6 +97,9 @@ export interface UserResult {
 	// True when the entity is suspended (under investigation) — the profile is still shown, but
 	// with an under-review notice. The internal reason is never sent to the client.
 	suspended: boolean;
+	// True when GitHub no longer resolves this login. Not moderation: the profile stays ranked and
+	// viewable (the stored history was real), it just carries a notice and stops being refreshed.
+	unreachable: boolean;
 	// Leaderboard position per metric (1 = top), among active entities, mirroring each metric's
 	// board ordering. Keyed by the metrics this profile has data for (always includes "public").
 	// Empty without a DB; suppressed in the UI for suspended profiles (hidden from every board).
@@ -268,15 +272,43 @@ export const getRecentLookups = createServerFn({ method: "GET" }).handler(
 	(): Promise<RecentEntry[]> => queryRecent(RECENT_LIMIT),
 );
 
-/** Which of these logins are currently suspended (lower-cased). Empty without a DB. */
-async function suspendedSet(logins: string[]): Promise<Set<string>> {
-	if (!db || logins.length === 0) return new Set();
+/**
+ * Per-login flags that live on the entity row rather than in the fetched history. One query for
+ * both, since a lookup needs them together. Logins are lower-cased. Empty without a DB.
+ */
+interface EntityFlags {
+	suspended: Set<string>;
+	unreachable: Set<string>;
+}
+
+const noFlags = (): EntityFlags => ({
+	suspended: new Set(),
+	unreachable: new Set(),
+});
+
+async function entityFlags(logins: string[]): Promise<EntityFlags> {
+	const flags = noFlags();
+	if (!db || logins.length === 0) return flags;
 	const ids = logins.map((l) => `user:${l.trim().toLowerCase()}`);
 	const rows = await db
-		.select({ login: entities.login })
+		.select({
+			login: entities.login,
+			suspendedAt: entities.suspendedAt,
+			unreachableAt: entities.unreachableAt,
+		})
 		.from(entities)
-		.where(and(inArray(entities.id, ids), isNotNull(entities.suspendedAt)));
-	return new Set(rows.map((r) => r.login.toLowerCase()));
+		.where(
+			and(
+				inArray(entities.id, ids),
+				or(isNotNull(entities.suspendedAt), isNotNull(entities.unreachableAt)),
+			),
+		);
+	for (const r of rows) {
+		const login = r.login.toLowerCase();
+		if (r.suspendedAt) flags.suspended.add(login);
+		if (r.unreachableAt) flags.unreachable.add(login);
+	}
+	return flags;
 }
 
 /**
@@ -332,18 +364,20 @@ export async function lookupUsers(rawLogins: string[]): Promise<UserResult[]> {
 	const logins = normalizeLogins(rawLogins);
 	const token = serverToken();
 	// allSettled (not all): one user's failed GitHub fetch must not reject the whole batch and
-	// blank out the others. suspendedSet is fetched alongside and is best-effort — a DB hiccup
-	// there shouldn't drop already-loaded profiles, so it falls back to "none suspended".
-	const [settled, suspended] = await Promise.all([
+	// blank out the others. entityFlags is fetched alongside and is best-effort — a DB hiccup
+	// there shouldn't drop already-loaded profiles, so it falls back to "no flags set".
+	const [settled, flags] = await Promise.all([
 		Promise.allSettled(
 			logins.map((login) => getCachedCommitHistory(login, token)),
 		),
-		suspendedSet(logins).catch(() => new Set<string>()),
+		entityFlags(logins).catch(noFlags),
 	]);
 	return Promise.all(
 		settled.map(async (outcome, i): Promise<UserResult> => {
 			const login = logins[i];
-			const isSuspended = suspended.has(login.toLowerCase());
+			const key = login.toLowerCase();
+			const isSuspended = flags.suspended.has(key);
+			const isUnreachable = flags.unreachable.has(key);
 			if (outcome.status === "rejected") {
 				const e = outcome.reason;
 				// The 503 "still building" rejection carries progress — surface it as `building`
@@ -362,6 +396,7 @@ export async function lookupUsers(rawLogins: string[]): Promise<UserResult[]> {
 							? e.message
 							: "Failed to load",
 					suspended: isSuspended,
+					unreachable: isUnreachable,
 					ranks: {},
 					building,
 				};
@@ -374,6 +409,7 @@ export async function lookupUsers(rawLogins: string[]): Promise<UserResult[]> {
 				history,
 				error: null,
 				suspended: isSuspended,
+				unreachable: isUnreachable,
 				ranks,
 				building: null,
 			};

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -51,9 +51,18 @@ export const entities = pgTable("entities", {
 	// "recently looked up" (still directly viewable, with an under-review notice) until cleared.
 	suspendedAt: timestamp("suspended_at", { withTimezone: true }),
 	suspendedReason: text("suspended_reason"), // internal note — never shown publicly
+	// GitHub no longer resolves this login (GraphQL NOT_FOUND / REST 404) — deleted, renamed, or
+	// blocked. Deliberately NOT moderation: the contributions we already stored were real, so the
+	// entity stays ranked and viewable (with a notice). It only drops out of the monthly refresh
+	// cohort, so a dead login can't burn a request and fail the scheduled task every pass.
+	// Cleared automatically the next time the login resolves.
+	unreachableAt: timestamp("unreachable_at", { withTimezone: true }),
 });
 
-/** Per-month commit counts. Past months are immutable; only the current month changes. */
+/**
+ * Per-month commit counts. GitHub's numbers for a past month are settled, but a *stored* row for
+ * one is only final if it was read after the month closed — see `fetchedAt`.
+ */
 export const monthlyCommits = pgTable(
 	"monthly_commits",
 	{
@@ -69,6 +78,13 @@ export const monthlyCommits = pgTable(
 		pullRequests: integer("pull_requests").notNull().default(0), // public PRs opened
 		reviews: integer("reviews").notNull().default(0), // public PR reviews
 		repos: integer("repos").notNull().default(0), // public repositories created
+		// When these counts were read from GitHub. The row is only trustworthy as a *final* month
+		// if this is at/after the month's end — before the in-progress month was excluded from
+		// monthlyWindows (a44f442, 2026-07-01) a lookup mid-month stored a few days of data under
+		// the month's label, and "a row exists" then wrongly looked like "the month is done".
+		// Null = written before this column existed, i.e. provenance unknown; the monthly refresh
+		// treats that as incomplete and re-fetches. Never gate on row existence alone.
+		fetchedAt: timestamp("fetched_at", { withTimezone: true }),
 	},
 	(t) => [primaryKey({ columns: [t.entityId, t.month] })],
 );

--- a/src/lib/monthly-user-refresh-store.ts
+++ b/src/lib/monthly-user-refresh-store.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 import type { DB } from "#/lib/db";
 import { entities, monthlyCommits } from "#/lib/db/schema";
 import type { MonthlyCount } from "#/lib/github";
@@ -16,6 +16,20 @@ import type {
 
 const USER_REFRESH_LOCK_KEY_1 = 20260701;
 const USER_REFRESH_LOCK_KEY_2 = 1;
+
+/**
+ * "This stored month is final": read at/after the month's own end. A null `fetched_at` predates the
+ * column and so is explicitly NOT complete — that is what makes the pre-a44f442 partial rows
+ * eligible for repair instead of being skipped forever.
+ *
+ * `at time zone 'UTC'` is load-bearing: `month` is a bare date, so `month + interval '1 month'` is
+ * a timestamp *without* zone, and comparing it to a timestamptz would otherwise resolve against the
+ * session's TimeZone and move the boundary by hours. Months here are UTC by definition.
+ */
+const completeMonthRow = (table: string) =>
+	sql.raw(
+		`${table}.fetched_at is not null and ${table}.fetched_at >= ((${table}.month + interval '1 month') at time zone 'UTC')`,
+	);
 
 export function createMonthlyUserRefreshStore(
 	database: DB,
@@ -60,7 +74,7 @@ export function createMonthlyUserRefreshStore(
 			return usersForMetric(database, metric, limit);
 		},
 
-		async countMissingMonth(ids, month) {
+		async countIncompleteMonth(ids, month) {
 			if (ids.length === 0) return 0;
 			const [row] = await database
 				.select({ n: sql<number>`count(*)` })
@@ -68,24 +82,32 @@ export function createMonthlyUserRefreshStore(
 				.where(
 					and(
 						inArray(entities.id, ids),
-						sql`not exists (select 1 from ${monthlyCommits} mc where mc.entity_id = ${entities.id} and mc.month = ${month})`,
+						sql`not exists (
+							select 1 from ${monthlyCommits} mc
+							where mc.entity_id = ${entities.id}
+							  and mc.month = ${month}
+							  and ${completeMonthRow("mc")})`,
 					),
 				);
 			return Number(row?.n ?? 0);
 		},
 
-		async hasMonth(id, month) {
+		async hasCompleteMonth(id, month) {
 			const [row] = await database
 				.select({ entityId: monthlyCommits.entityId })
 				.from(monthlyCommits)
 				.where(
-					and(eq(monthlyCommits.entityId, id), eq(monthlyCommits.month, month)),
+					and(
+						eq(monthlyCommits.entityId, id),
+						eq(monthlyCommits.month, month),
+						completeMonthRow("monthly_commits"),
+					),
 				)
 				.limit(1);
 			return row != null;
 		},
 
-		async upsertMonth(id, month, counts) {
+		async upsertMonth(id, month, counts, fetchedAt) {
 			await database
 				.insert(monthlyCommits)
 				.values({
@@ -97,6 +119,7 @@ export function createMonthlyUserRefreshStore(
 					pullRequests: counts.pullRequests,
 					reviews: counts.reviews,
 					repos: counts.repos,
+					fetchedAt,
 				})
 				.onConflictDoUpdate({
 					target: [monthlyCommits.entityId, monthlyCommits.month],
@@ -107,14 +130,24 @@ export function createMonthlyUserRefreshStore(
 						pullRequests: sql`excluded.pull_requests`,
 						reviews: sql`excluded.reviews`,
 						repos: sql`excluded.repos`,
+						fetchedAt: sql`excluded.fetched_at`,
 					},
 				});
 		},
 
+		async markUnreachable(id, at) {
+			await database
+				.update(entities)
+				.set({ unreachableAt: at })
+				.where(eq(entities.id, id));
+		},
+
 		async recomputeTotals(id, fetchedAt) {
 			const row = await monthlyTotals(database, id);
-			// `last_fetched` is the contribution-month freshness marker for this worker. It does
-			// not mean profile metadata was refreshed; profile columns stay on-demand/manual.
+			// `last_fetched` records that this worker touched the entity; it does NOT mean profile
+			// metadata was refreshed (profile columns stay on-demand/manual), and it is NOT the
+			// month-freshness gate — that is `monthly_commits.fetched_at`, which is per month row and
+			// can't be bumped by an unrelated profile refresh (`scripts/refresh.ts` sets this column).
 			//
 			// commits/restricted are NOT NULL and the app's own tail refresh already restamps
 			// total_commits from the month rows, so summing them here is the same operation.
@@ -153,7 +186,13 @@ async function usersForMetric(
 ): Promise<RefreshCandidate[]> {
 	// Same population, order and tiebreak as the metric's leaderboard — the cohort is defined as
 	// "the top N of each board", so any divergence here means a visible user never gets refreshed.
-	const active = activeRankedUser();
+	//
+	// One deliberate divergence: logins GitHub no longer resolves. They stay on the board (their
+	// stored history was real) but there is nothing left to fetch, so refreshing them only burns a
+	// request and fails the scheduled task. Filtering here rather than in `activeRankedUser()` keeps
+	// the board and the rank badge unchanged — the cohort is "the top N we can still refresh", so it
+	// backfills from the next user down instead of leaving a hole.
+	const active = and(activeRankedUser(), isNull(entities.unreachableAt));
 	const positive = metricPositiveColumn(metric);
 	return database
 		.select({ id: entities.id, login: entities.login })

--- a/src/lib/monthly-user-refresh.test.ts
+++ b/src/lib/monthly-user-refresh.test.ts
@@ -1,20 +1,58 @@
 import { describe, expect, it } from "vitest";
+import type { MonthlyCount, MonthWindow } from "#/lib/github";
 import {
-	resolveTargetMonth,
-	runMonthlyUserRefresh,
 	type MonthlyRefreshStore,
 	type RefreshCandidate,
+	resolveTargetMonth,
+	runMonthlyUserRefresh,
 } from "#/lib/monthly-user-refresh";
-import type { MonthlyCount, MonthWindow } from "#/lib/github";
+
+/** First instant after `month` (YYYY-MM-01) ends, in UTC — the completeness boundary. */
+function monthEnd(month: string): Date {
+	const [year, m] = month.split("-").map(Number);
+	return new Date(Date.UTC(year, m, 1));
+}
 
 class FakeStore implements MonthlyRefreshStore {
 	readonly metricRows: Partial<Record<string, RefreshCandidate[]>>;
-	readonly existing = new Set<string>();
-	readonly months = new Map<string, MonthlyCount>();
+	/** month key → the row as stored, mirroring the real table's (counts, fetched_at). */
+	readonly rows = new Map<
+		string,
+		{ counts: MonthlyCount; fetchedAt: Date | null }
+	>();
 	readonly totals = new Map<string, MonthlyCount>();
+	readonly unreachable = new Map<string, Date>();
 
 	constructor(metricRows: Partial<Record<string, RefreshCandidate[]>>) {
 		this.metricRows = metricRows;
+	}
+
+	/** Seed a row read *after* the month closed — the only kind that counts as done. */
+	seedComplete(id: string, month: string) {
+		this.rows.set(`${id}:${month}`, {
+			counts: zero(),
+			fetchedAt: new Date(monthEnd(month).getTime() + 60_000),
+		});
+	}
+
+	/**
+	 * Seed a row read *during* the month, the pre-a44f442 shape: it exists but holds a few days.
+	 * `fetchedAt: null` models the rows that predate the column entirely.
+	 */
+	seedPartial(id: string, month: string, fetchedAt: Date | null = null) {
+		this.rows.set(`${id}:${month}`, { counts: zero(), fetchedAt });
+	}
+
+	/** Row keys that exist at all, regardless of completeness. */
+	get storedKeys() {
+		return new Set(this.rows.keys());
+	}
+
+	private complete(key: string) {
+		const row = this.rows.get(key);
+		if (!row?.fetchedAt) return false;
+		const month = key.slice(key.lastIndexOf(":") + 1);
+		return row.fetchedAt.getTime() >= monthEnd(month).getTime();
 	}
 
 	async tryLock() {
@@ -24,20 +62,30 @@ class FakeStore implements MonthlyRefreshStore {
 	async releaseLock() {}
 
 	async usersForMetric(metric: string, limit: number) {
-		return (this.metricRows[metric] ?? []).slice(0, limit);
+		return (this.metricRows[metric] ?? [])
+			.filter((c) => !this.unreachable.has(c.id))
+			.slice(0, limit);
 	}
 
-	async countMissingMonth(ids: string[], month: string) {
-		return ids.filter((id) => !this.existing.has(`${id}:${month}`)).length;
+	async countIncompleteMonth(ids: string[], month: string) {
+		return ids.filter((id) => !this.complete(`${id}:${month}`)).length;
 	}
 
-	async hasMonth(id: string, month: string) {
-		return this.existing.has(`${id}:${month}`);
+	async hasCompleteMonth(id: string, month: string) {
+		return this.complete(`${id}:${month}`);
 	}
 
-	async upsertMonth(id: string, month: string, counts: MonthlyCount) {
-		this.existing.add(`${id}:${month}`);
-		this.months.set(`${id}:${month}`, counts);
+	async upsertMonth(
+		id: string,
+		month: string,
+		counts: MonthlyCount,
+		fetchedAt: Date,
+	) {
+		this.rows.set(`${id}:${month}`, { counts, fetchedAt });
+	}
+
+	async markUnreachable(id: string, at: Date) {
+		this.unreachable.set(id, at);
 	}
 
 	async recomputeTotals(id: string) {
@@ -49,19 +97,28 @@ class FakeStore implements MonthlyRefreshStore {
 			reviews: 0,
 			repos: 0,
 		};
-		for (const [key, counts] of this.months) {
+		for (const [key, row] of this.rows) {
 			if (!key.startsWith(`${id}:`)) continue;
-			total.commits += counts.commits;
-			total.restricted += counts.restricted;
-			total.issues += counts.issues;
-			total.pullRequests += counts.pullRequests;
-			total.reviews += counts.reviews;
-			total.repos += counts.repos;
+			total.commits += row.counts.commits;
+			total.restricted += row.counts.restricted;
+			total.issues += row.counts.issues;
+			total.pullRequests += row.counts.pullRequests;
+			total.reviews += row.counts.reviews;
+			total.repos += row.counts.repos;
 		}
 		this.totals.set(id, total);
 		return total;
 	}
 }
+
+const zero = (): MonthlyCount => ({
+	commits: 0,
+	restricted: 0,
+	issues: 0,
+	pullRequests: 0,
+	reviews: 0,
+	repos: 0,
+});
 
 const candidate = (login: string): RefreshCandidate => ({
 	id: `user:${login.toLowerCase()}`,
@@ -94,12 +151,12 @@ describe("resolveTargetMonth", () => {
 });
 
 describe("runMonthlyUserRefresh", () => {
-	it("refreshes a deterministic metric union, skipping users that already have the month", async () => {
+	it("refreshes a deterministic metric union, skipping users whose month is already complete", async () => {
 		const store = new FakeStore({
 			public: [candidate("Ada"), candidate("Grace")],
 			prs: [candidate("Grace"), candidate("Linus")],
 		});
-		store.existing.add("user:grace:2026-07-01");
+		store.seedComplete("user:grace", "2026-07-01");
 		const fetched: string[] = [];
 
 		const result = await runMonthlyUserRefresh({
@@ -130,8 +187,8 @@ describe("runMonthlyUserRefresh", () => {
 		expect(result).toMatchObject({
 			targetMonth: "2026-07-01",
 			candidates: 3,
-			missingTargetMonth: 2,
-			skippedFresh: 1,
+			incompleteTargetMonth: 2,
+			skippedComplete: 1,
 			refreshed: 2,
 			failed: 0,
 			dryRun: false,
@@ -167,7 +224,7 @@ describe("runMonthlyUserRefresh", () => {
 
 		expect(attempts).toBe(2);
 		expect(result.failed).toBe(1);
-		expect(store.existing.has("user:failing:2026-07-01")).toBe(false);
+		expect(store.storedKeys.has("user:failing:2026-07-01")).toBe(false);
 	});
 
 	it("waits for the window to reset when the budget dips below the floor", async () => {
@@ -248,7 +305,7 @@ describe("runMonthlyUserRefresh", () => {
 		expect(fetches).toBe(0);
 		expect(result.status).toBe("stopped");
 		expect(result.stopReason).toBe("rate_limit_floor");
-		expect(store.existing.size).toBe(0);
+		expect(store.rows.size).toBe(0);
 	});
 
 	it("re-polls the real budget before retrying a failed user", async () => {
@@ -293,7 +350,7 @@ describe("runMonthlyUserRefresh", () => {
 		expect(attempts).toBe(1);
 		expect(polls).toBe(2);
 		expect(result.failed).toBe(1);
-		expect(store.existing.has("user:failing:2026-07-01")).toBe(false);
+		expect(store.storedKeys.has("user:failing:2026-07-01")).toBe(false);
 	});
 
 	it("does not write during dry runs", async () => {
@@ -325,7 +382,7 @@ describe("runMonthlyUserRefresh", () => {
 
 		expect(calls).toBe(0);
 		expect(result.dryRunWouldRefresh).toBe(1);
-		expect(store.existing.size).toBe(0);
+		expect(store.rows.size).toBe(0);
 	});
 
 	it("refuses to write a manually overridden current month", async () => {
@@ -344,7 +401,7 @@ describe("runMonthlyUserRefresh", () => {
 				fetchMonthlyCommits: async () => [],
 			}),
 		).rejects.toThrow("not completed");
-		expect(store.existing.size).toBe(0);
+		expect(store.rows.size).toBe(0);
 	});
 
 	it("can explicitly allow a manually overridden current month", async () => {
@@ -373,7 +430,7 @@ describe("runMonthlyUserRefresh", () => {
 		});
 
 		expect(result.refreshed).toBe(1);
-		expect(store.existing.has("user:ada:2026-07-01")).toBe(true);
+		expect(store.storedKeys.has("user:ada:2026-07-01")).toBe(true);
 	});
 
 	it("caps the deterministic union by round-robining metric buckets", async () => {
@@ -411,5 +468,109 @@ describe("runMonthlyUserRefresh", () => {
 		expect(fetched).toEqual(["Charlie", "Grace"]);
 		expect(result.candidates).toBe(2);
 		expect(result.refreshed).toBe(2);
+	});
+
+	// Regression: the 2026-08-01 run skipped 2229 of 2230 candidates because the gate asked "is
+	// there a row?" instead of "was it read after the month closed?". Rows written mid-month before
+	// a44f442 (and every row predating fetched_at) must be re-fetched, not counted as done.
+	it("re-fetches a month whose row was stored before the month closed", async () => {
+		const store = new FakeStore({
+			public: [candidate("Peppy"), candidate("Antfu"), candidate("Grace")],
+		});
+		// Written on 2026-07-02, while July was still running — one day of data under July's label.
+		store.seedPartial(
+			"user:peppy",
+			"2026-07-01",
+			new Date("2026-07-02T09:00:00Z"),
+		);
+		// Predates the fetched_at column entirely: provenance unknown, so not trusted.
+		store.seedPartial("user:antfu", "2026-07-01", null);
+		// Genuinely done.
+		store.seedComplete("user:grace", "2026-07-01");
+		const fetched: string[] = [];
+
+		const result = await runMonthlyUserRefresh({
+			store,
+			token: "token",
+			now: new Date("2026-08-01T04:00:00Z"),
+			targetMonth: "2026-07-01",
+			metrics: ["public"],
+			limitPerMetric: 3,
+			ratePerHour: 3600,
+			sleep: async () => {},
+			clock: () => new Date("2026-08-01T04:05:00Z"),
+			fetchMonthlyCommits: async (login) => {
+				fetched.push(login);
+				return [{ ...zero(), commits: 88 }];
+			},
+		});
+
+		expect(fetched).toEqual(["Peppy", "Antfu"]);
+		expect(result).toMatchObject({
+			candidates: 3,
+			incompleteTargetMonth: 2,
+			skippedComplete: 1,
+			refreshed: 2,
+			failed: 0,
+		});
+		// Repaired rows now carry a stamp after the month's end, so the next pass skips them.
+		expect(await store.hasCompleteMonth("user:peppy", "2026-07-01")).toBe(true);
+	});
+
+	it("marks a login GitHub can no longer resolve instead of retrying and failing it", async () => {
+		const store = new FakeStore({ public: [candidate("ageesen")] });
+		let attempts = 0;
+
+		const result = await runMonthlyUserRefresh({
+			store,
+			token: "token",
+			now: new Date("2026-08-01T04:00:00Z"),
+			targetMonth: "2026-07-01",
+			metrics: ["public"],
+			limitPerMetric: 1,
+			ratePerHour: 3600,
+			sleep: async () => {},
+			clock: () => new Date("2026-08-01T04:05:00Z"),
+			fetchMonthlyCommits: async () => {
+				attempts += 1;
+				// Shape of the GitHubError github.ts raises for "Could not resolve to a User".
+				throw Object.assign(
+					new Error("Could not resolve to a User with the login of 'ageesen'."),
+					{ status: 404 },
+				);
+			},
+		});
+
+		// A 404 is terminal — retrying it only spends a second request on the shared token.
+		expect(attempts).toBe(1);
+		expect(result.unreachable).toBe(1);
+		expect(result.failed).toBe(0);
+		expect(store.unreachable.get("user:ageesen")).toEqual(
+			new Date("2026-08-01T04:05:00Z"),
+		);
+		// The month stays unwritten, but the entity drops out of the cohort, so it is not retried.
+		expect(store.storedKeys.has("user:ageesen:2026-07-01")).toBe(false);
+		expect(await store.usersForMetric("public", 1)).toEqual([]);
+	});
+
+	it("treats an empty fetch result as a failure rather than writing a zeroed month", async () => {
+		const store = new FakeStore({ public: [candidate("Ada")] });
+
+		const result = await runMonthlyUserRefresh({
+			store,
+			token: "token",
+			now: new Date("2026-08-01T04:00:00Z"),
+			targetMonth: "2026-07-01",
+			metrics: ["public"],
+			limitPerMetric: 1,
+			ratePerHour: 3600,
+			sleep: async () => {},
+			fetchMonthlyCommits: async () => [],
+		});
+
+		expect(result.failed).toBe(1);
+		expect(result.refreshed).toBe(0);
+		// Writing zeros would have looked like success and blanked the month permanently.
+		expect(store.storedKeys.has("user:ada:2026-07-01")).toBe(false);
 	});
 });

--- a/src/lib/monthly-user-refresh.ts
+++ b/src/lib/monthly-user-refresh.ts
@@ -22,11 +22,23 @@ export interface MonthlyRefreshStore {
 		metric: UserRefreshMetric,
 		limit: number,
 	): Promise<RefreshCandidate[]>;
-	/** How many of `ids` are still missing `month` — the startup log's retry-queue size. */
-	countMissingMonth(ids: string[], month: string): Promise<number>;
-	hasMonth(id: string, month: string): Promise<boolean>;
-	upsertMonth(id: string, month: string, counts: MonthlyCount): Promise<void>;
+	/** How many of `ids` still need `month` — the startup log's work-queue size. */
+	countIncompleteMonth(ids: string[], month: string): Promise<number>;
+	/**
+	 * Whether `month` is stored *and* was read after the month closed. Existence alone is not
+	 * enough: rows written before a44f442 hold a few mid-month days under the month's label, so
+	 * gating on existence froze them forever (2026-08-01 incident). See `monthly_commits.fetchedAt`.
+	 */
+	hasCompleteMonth(id: string, month: string): Promise<boolean>;
+	upsertMonth(
+		id: string,
+		month: string,
+		counts: MonthlyCount,
+		fetchedAt: Date,
+	): Promise<void>;
 	recomputeTotals(id: string, fetchedAt: Date): Promise<MonthlyCount>;
+	/** GitHub no longer resolves this login — drop it from future cohorts. */
+	markUnreachable(id: string, at: Date): Promise<void>;
 }
 
 export interface MonthlyRefreshLogger {
@@ -62,7 +74,14 @@ export interface RunMonthlyUserRefreshOptions {
 		windows: MonthWindow[],
 	) => Promise<MonthlyCount[]>;
 	sleep?: (ms: number) => Promise<void>;
+	/** Runtime-budget clock only (may be a fake counter). Never use it for stored timestamps. */
 	timeMs?: () => number;
+	/**
+	 * Wall clock for stored timestamps (`monthly_commits.fetched_at`, `entities.last_fetched`).
+	 * Read per user rather than once per run, so a 2-hour pass doesn't stamp every row it touches
+	 * with its startup time — that made the 2026-08-01 logs unreadable.
+	 */
+	clock?: () => Date;
 	logger?: MonthlyRefreshLogger;
 }
 
@@ -72,11 +91,13 @@ export interface MonthlyUserRefreshResult {
 	stopReason?: "max_runtime" | "rate_limit_floor";
 	targetMonth: string;
 	candidates: number;
-	missingTargetMonth: number;
-	skippedFresh: number;
+	incompleteTargetMonth: number;
+	skippedComplete: number;
 	dryRunWouldRefresh: number;
 	refreshed: number;
 	failed: number;
+	/** Logins GitHub no longer resolves. Marked and skipped from now on, not counted as failures. */
+	unreachable: number;
 	dryRun: boolean;
 }
 
@@ -134,6 +155,7 @@ export async function runMonthlyUserRefresh(
 	const safeAfterUtc = opts.safeAfterUtc ?? "03:00";
 	const sleep = opts.sleep ?? defaultSleep;
 	const timeMs = opts.timeMs ?? Date.now;
+	const clock = opts.clock ?? (() => new Date());
 	const startedAt = timeMs();
 	const target = opts.targetMonth
 		? normalizeTargetMonth(opts.targetMonth)
@@ -191,12 +213,12 @@ export async function runMonthlyUserRefresh(
 			await candidateUnion(opts.store, metrics, limitPerMetric)
 		).slice(0, maxUsers);
 		result.candidates = candidates.length;
-		result.missingTargetMonth = await opts.store.countMissingMonth(
+		result.incompleteTargetMonth = await opts.store.countIncompleteMonth(
 			candidates.map((c) => c.id),
 			targetMonth,
 		);
 		logger.info(
-			`monthly-user-refresh target_month=${targetMonth} candidates=${candidates.length} missing_target_month=${result.missingTargetMonth}`,
+			`monthly-user-refresh target_month=${targetMonth} candidates=${candidates.length} incomplete_target_month=${result.incompleteTargetMonth}`,
 		);
 
 		for (const candidate of candidates) {
@@ -213,8 +235,8 @@ export async function runMonthlyUserRefresh(
 				break;
 			}
 
-			if (await opts.store.hasMonth(candidate.id, targetMonth)) {
-				result.skippedFresh += 1;
+			if (await opts.store.hasCompleteMonth(candidate.id, targetMonth)) {
+				result.skippedComplete += 1;
 				continue;
 			}
 
@@ -233,18 +255,19 @@ export async function runMonthlyUserRefresh(
 				break;
 			}
 
-			const refreshed = await refreshOne({
+			const outcome = await refreshOne({
 				candidate,
 				token: opts.token,
 				window,
 				targetMonth,
-				now,
 				store: opts.store,
 				fetchMonthlyCommits: opts.fetchMonthlyCommits,
 				budget,
 				logger,
+				clock,
 			});
-			if (refreshed) result.refreshed += 1;
+			if (outcome === "refreshed") result.refreshed += 1;
+			else if (outcome === "unreachable") result.unreachable += 1;
 			else result.failed += 1;
 
 			await sleep((1 / ratePerHour) * 3_600_000);
@@ -254,7 +277,7 @@ export async function runMonthlyUserRefresh(
 	}
 
 	logger.info(
-		`monthly-user-refresh done target_month=${targetMonth} status=${result.status}${result.stopReason ? ` reason=${result.stopReason}` : ""} candidates=${result.candidates} missing_target_month=${result.missingTargetMonth} refreshed=${result.refreshed} skipped_fresh=${result.skippedFresh} failed=${result.failed} dry_run_would_refresh=${result.dryRunWouldRefresh}`,
+		`monthly-user-refresh done target_month=${targetMonth} status=${result.status}${result.stopReason ? ` reason=${result.stopReason}` : ""} candidates=${result.candidates} incomplete_target_month=${result.incompleteTargetMonth} refreshed=${result.refreshed} skipped_complete=${result.skippedComplete} failed=${result.failed} unreachable=${result.unreachable} dry_run_would_refresh=${result.dryRunWouldRefresh}`,
 	);
 	return result;
 }
@@ -362,12 +385,28 @@ async function candidateUnion(
 	return [...byId.values()];
 }
 
+type RefreshOutcome = "refreshed" | "unreachable" | "failed";
+
+/**
+ * A login GitHub can't resolve any more (deleted, renamed, blocked). `github.ts` already maps the
+ * GraphQL "Could not resolve to a User" error to status 404, so this is a structural check — the
+ * worker deliberately keeps no runtime dependency on that module (tests replace the fetcher
+ * wholesale), hence duck-typing rather than `instanceof GitHubError`.
+ */
+function isMissingUser(err: unknown): boolean {
+	return (
+		typeof err === "object" &&
+		err !== null &&
+		"status" in err &&
+		(err as { status: unknown }).status === 404
+	);
+}
+
 async function refreshOne(opts: {
 	candidate: RefreshCandidate;
 	token: string;
 	window: MonthWindow;
 	targetMonth: string;
-	now: Date;
 	store: MonthlyRefreshStore;
 	fetchMonthlyCommits: (
 		login: string,
@@ -376,30 +415,47 @@ async function refreshOne(opts: {
 	) => Promise<MonthlyCount[]>;
 	budget: BudgetGuard;
 	logger: MonthlyRefreshLogger;
-}): Promise<boolean> {
+	clock: () => Date;
+}): Promise<RefreshOutcome> {
 	for (let attempt = 1; attempt <= 2; attempt++) {
 		try {
 			opts.budget.spend();
-			const [counts] = await opts.fetchMonthlyCommits(
-				opts.candidate.login,
-				opts.token,
-				[opts.window],
-			);
+			const counts = (
+				await opts.fetchMonthlyCommits(opts.candidate.login, opts.token, [
+					opts.window,
+				])
+			)[0];
+			// No counts means the fetcher returned nothing for a window it did not reject. Writing
+			// zeros here would look like a successful refresh and permanently blank the month, so
+			// treat it as a failure and leave the month incomplete for the next pass.
+			if (!counts) throw new Error("no counts returned for the target month");
+			const fetchedAt = opts.clock();
 			await opts.store.upsertMonth(
 				opts.candidate.id,
 				opts.targetMonth,
-				counts ?? zeroMonth(),
+				counts,
+				fetchedAt,
 			);
 			const totals = await opts.store.recomputeTotals(
 				opts.candidate.id,
-				opts.now,
+				fetchedAt,
 			);
 			opts.logger.info(
 				`monthly-user-refresh target_month=${opts.targetMonth} login=${opts.candidate.login} status=refreshed commits=${totals.commits} total=${totalContributions(totals)}`,
 			);
-			return true;
+			return "refreshed";
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
+			// A login that no longer resolves will never resolve on a retry, and a missing month row
+			// is the retry queue — so without this marker one dead account fails every pass of every
+			// month forever. Mark it and move on; a later successful lookup clears the flag.
+			if (isMissingUser(err)) {
+				await opts.store.markUnreachable(opts.candidate.id, opts.clock());
+				opts.logger.warn(
+					`monthly-user-refresh target_month=${opts.targetMonth} login=${opts.candidate.login} status=unreachable error=${JSON.stringify(message)}`,
+				);
+				return "unreachable";
+			}
 			if (attempt === 1) {
 				opts.logger.warn(
 					`monthly-user-refresh target_month=${opts.targetMonth} login=${opts.candidate.login} status=retrying error=${JSON.stringify(message)}`,
@@ -411,17 +467,17 @@ async function refreshOne(opts: {
 					opts.logger.error(
 						`monthly-user-refresh target_month=${opts.targetMonth} login=${opts.candidate.login} status=failed reason=rate_limit_floor`,
 					);
-					return false;
+					return "failed";
 				}
 				continue;
 			}
 			opts.logger.error(
 				`monthly-user-refresh target_month=${opts.targetMonth} login=${opts.candidate.login} status=failed error=${JSON.stringify(message)}`,
 			);
-			return false;
+			return "failed";
 		}
 	}
-	return false;
+	return "failed";
 }
 
 function windowForMonth(month: string): MonthWindow {
@@ -482,17 +538,6 @@ function totalContributions(counts: MonthlyCount): number {
 	);
 }
 
-function zeroMonth(): MonthlyCount {
-	return {
-		commits: 0,
-		restricted: 0,
-		issues: 0,
-		pullRequests: 0,
-		reviews: 0,
-		repos: 0,
-	};
-}
-
 function emptyResult(
 	status: MonthlyUserRefreshResult["status"],
 	targetMonth: string,
@@ -502,11 +547,12 @@ function emptyResult(
 		status,
 		targetMonth,
 		candidates: 0,
-		missingTargetMonth: 0,
-		skippedFresh: 0,
+		incompleteTargetMonth: 0,
+		skippedComplete: 0,
 		dryRunWouldRefresh: 0,
 		refreshed: 0,
 		failed: 0,
+		unreachable: 0,
 		dryRun,
 	};
 }

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -472,6 +472,23 @@ function View() {
 	);
 }
 
+/**
+ * Shown when GitHub no longer resolves the login. The history stays on display and on the boards —
+ * it was really earned — so this explains the staleness rather than apologising for it.
+ */
+function UnreachableNotice() {
+	return (
+		<div className="mt-6 rounded-xl border border-muted-foreground/30 bg-muted/40 p-4 text-sm">
+			<p className="font-medium">This account is no longer on GitHub.</p>
+			<p className="mt-1 text-muted-foreground">
+				It was deleted or renamed, so these numbers stop where our last
+				successful read left off. The history stays here because the
+				contributions were real.
+			</p>
+		</div>
+	);
+}
+
 /** Shown on a suspended profile — public-facing, never reveals the internal reason. */
 function SuspendedNotice() {
 	return (
@@ -619,6 +636,7 @@ function SingleView({
 	return (
 		<>
 			{result.suspended && <SuspendedNotice />}
+			{result.unreachable && <UnreachableNotice />}
 			<div className="mt-6">
 				<ProfilePanel result={result} mode={effectiveMode} />
 			</div>
@@ -855,6 +873,7 @@ function ComparisonView({
 								color={SERIES_COLORS[i % SERIES_COLORS.length]}
 							/>
 							{r.suspended && <SuspendedNotice />}
+							{r.unreachable && <UnreachableNotice />}
 						</div>
 					))}
 				</div>


### PR DESCRIPTION
Follow-up to #145. The monthly refresh now decides "is this month finished?" from a new `monthly_commits.fetched_at`, instead of inferring it from a row merely existing.

**Why:** the 2026-08-01 pass skipped 2229 of its 2230 candidates and reported one failure. It was working as written — but "a row exists" isn't "the month is done". Before a44f442 excluded the in-progress month, a mid-month lookup stored a few days of data under the whole month's label, and the existence check then froze those rows forever — jdx's stored July read 0 commits against GitHub's actual 837. 120 rows are affected (112 July, 8 June, all written in the Jun 26 – Jul 1 05:31 UTC window).

**How:** the gate is `fetched_at >= month end`, with NULL meaning "provenance unknown" so anything unproven re-reads rather than being trusted — see `completeMonthRow` in `src/lib/monthly-user-refresh-store.ts`. The deliberate judgment call is *not* reusing `entities.last_fetched` for this: `scripts/refresh.ts` bumps it for a profile-only refresh, which would mark months complete that were never fetched. Separately, `entities.unreachable_at` retires logins GitHub stops resolving — kept distinct from `suspended_at` because the stored contributions were real, so the profile stays ranked and viewable with a notice and only leaves the refresh cohort.

**Migration is already applied to production** (the incident was live). It backfills 2026 months only — 195k rows rather than the table's 4.18M/494 MB — since the gate only ever asks about the month that just ended. Verified against GitHub on a 25-row sample before running: 24 exact, 1 off by a single private contribution. Dry run against prod after migrating reports `candidates=2230 incomplete_target_month=24 skipped_complete=2206`; the repair pass itself hasn't been run yet.