### PR TITLE
Stop truncating org membership at 1,000, add pnpm refresh-org

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "suspend": "bun scripts/suspend.ts",
     "refresh": "bun scripts/refresh.ts",
     "refresh-user": "bun scripts/refresh-user.ts",
+    "refresh-org": "bun scripts/refresh-org.ts",
+    "backfill-orgs": "bun scripts/backfill-orgs.ts",
     "monthly:user": "node --env-file-if-exists=.env --import tsx scripts/monthly-user-refresh.ts",
     "backfill": "bun scripts/backfill-contributions.ts",
     "backup": "bash scripts/backup.sh",

--- a/scripts/backfill-orgs.ts
+++ b/scripts/backfill-orgs.ts
@@ -10,6 +10,10 @@
  * needs NO database migration. (The per-month resolution / company chart is separate future work
  * on the refresh-orgs worker; this deliberately does none of that.)
  *
+ * The per-org work itself lives in src/lib/org-refresh.ts, shared with `pnpm refresh-org` — this
+ * script is the bulk driver (which orgs, in what order, at what pace); that module is the engine.
+ * To refresh ONE org on demand, reach for `pnpm refresh-org` instead.
+ *
  * Politeness: paced well under GitHub's 5,000 points/hour with a reserved floor for live traffic,
  * same model as backfill-contributions.ts. Run with bun (auto-loads .env; beware a shell-exported
  * GITHUB_TOKEN overriding it — prefix with `env -u GITHUB_TOKEN` if your shell sets one):
@@ -29,15 +33,8 @@
  */
 import { and, asc, eq, isNull, sql } from "drizzle-orm";
 import { db } from "#/lib/db";
-import { entities, orgMembers } from "#/lib/db/schema";
-import {
-	fetchOrgMembers,
-	fetchOrgMemberContributions,
-	fetchOrgProfile,
-	GitHubError,
-	type OrgMemberTotals,
-	yearlyWindows,
-} from "#/lib/github";
+import { entities } from "#/lib/db/schema";
+import { refreshOrg, respectRateFloor } from "#/lib/org-refresh";
 
 if (!process.env.DATABASE_URL)
 	throw new Error("DATABASE_URL is required (add it to .env)");
@@ -47,232 +44,12 @@ if (!db) throw new Error("Database client failed to initialise.");
 const token = GITHUB_TOKEN;
 const database = db;
 
-const orgEntityId = (login: string) => `org:${login.trim().toLowerCase()}`;
-const userEntityId = (login: string) => `user:${login.trim().toLowerCase()}`;
-
 // Requests/hour we aim to spend (≈ GraphQL points), well under the 5,000/hr limit so the live
 // site keeps working. Override with REFRESH_RATE=<n>.
 const TARGET_RATE = Number(process.env.REFRESH_RATE ?? 2500);
-// Never let the remaining budget drop below this — headroom for live traffic.
-const REMAINING_FLOOR = 500;
-const CHUNK_ROWS = 100;
-// fetchOrgMemberContributions batches windows this many at a time; used only to pace, not for
-// correctness — an over-estimate just spends the budget more conservatively.
-const WINDOWS_PER_REQUEST = 6;
 // --force re-fetches every member even if already filled (to refresh numbers). Default: resume,
 // i.e. skip members that already have a lastFetched from any prior run.
 const force = process.argv.slice(2).includes("--force");
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-interface RateLimit {
-	remaining: number;
-	resetAt: string;
-}
-
-/** Query GitHub's current rate-limit budget. `rateLimit` queries themselves cost 0 points. */
-async function rateLimit(): Promise<RateLimit | null> {
-	try {
-		const res = await fetch("https://api.github.com/graphql", {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${token}`,
-				"Content-Type": "application/json",
-				"User-Agent": "commit-history-backfill-orgs",
-			},
-			body: JSON.stringify({
-				query: "query { rateLimit { remaining resetAt } }",
-			}),
-		});
-		const json = (await res.json()) as { data?: { rateLimit: RateLimit } };
-		return json.data?.rateLimit ?? null;
-	} catch {
-		return null;
-	}
-}
-
-/** If we're near the reserved floor, sleep until GitHub's window resets (plus a small buffer). */
-async function respectFloor(): Promise<void> {
-	const rl = await rateLimit();
-	if (!rl) return;
-	if (rl.remaining > REMAINING_FLOOR) return;
-	const waitMs = Math.max(0, new Date(rl.resetAt).getTime() - Date.now()) + 2000;
-	console.log(
-		`… budget low (${rl.remaining} left) — pausing ${Math.ceil(waitMs / 1000)}s until reset`,
-	);
-	await sleep(waitMs);
-}
-
-/**
- * Fill one org with lifetime totals. Returns the (approximate) number of GitHub requests spent.
- * Re-fetches the profile, (re-)enumerates members, fetches each member's org-scoped lifetime
- * totals, then rolls the sums onto the org's `entities` row and stamps `builtAt`.
- */
-async function fillOrg(login: string): Promise<number> {
-	const orgId = orgEntityId(login);
-	const runStart = new Date();
-	let requests = 0;
-	console.log(`${login}: resolving profile…`);
-
-	// Profile first — validates the login, yields nodeId (keys every org-scoped query) + createdAt
-	// (bounds each member's windows). Upsert so a never-looked-up org (e.g. a fresh google) is
-	// recorded here rather than requiring a prior page visit. builtAt stays null until the roll-up.
-	const profile = await fetchOrgProfile(login, token);
-	requests += 1;
-	const profileCols = {
-		login: profile.login,
-		name: profile.name,
-		avatarUrl: profile.avatarUrl,
-		htmlUrl: profile.htmlUrl,
-		createdAt: new Date(profile.createdAt),
-		bio: profile.description,
-		location: profile.location,
-		websiteUrl: profile.websiteUrl,
-		twitterUsername: profile.twitterUsername,
-		publicRepos: profile.publicRepos,
-		isVerified: profile.isVerified,
-		githubNodeId: profile.nodeId,
-		memberCount: profile.memberCount,
-		lastFetched: runStart,
-	};
-	await database
-		.insert(entities)
-		.values({ id: orgId, kind: "org", ...profileCols })
-		.onConflictDoUpdate({ target: entities.id, set: profileCols });
-	const orgCreated = new Date(profile.createdAt);
-
-	// Enumerate members → a user stub (FK target, never overwrites a real user row) + a pending
-	// org_members row each. Both idempotent.
-	const members = await fetchOrgMembers(login, token);
-	requests += Math.max(1, Math.ceil(members.length / 100));
-	for (let i = 0; i < members.length; i += CHUNK_ROWS) {
-		const chunk = members.slice(i, i + CHUNK_ROWS);
-		await database
-			.insert(entities)
-			.values(
-				chunk.map((m) => ({
-					id: userEntityId(m.login),
-					kind: "user",
-					login: m.login,
-					name: m.name,
-					avatarUrl: m.avatarUrl,
-					htmlUrl: `https://github.com/${m.login}`,
-					createdAt: new Date(m.createdAt),
-				})),
-			)
-			.onConflictDoNothing();
-		await database
-			.insert(orgMembers)
-			.values(
-				chunk.map((m) => ({
-					orgId,
-					memberId: userEntityId(m.login),
-					role: m.role,
-					source: "public_member",
-				})),
-			)
-			.onConflictDoNothing();
-	}
-
-	// Resume support: a member's `lastFetched` is set once we've fetched it — in this run OR a
-	// previous, aborted one. By default we skip anything already fetched, so re-running continues
-	// from exactly where an abort stopped (e.g. mid-Microsoft) instead of restarting the org.
-	// --force re-fetches everyone, to refresh an already-filled org's numbers.
-	const existing = await database
-		.select({
-			memberId: orgMembers.memberId,
-			lastFetched: orgMembers.lastFetched,
-		})
-		.from(orgMembers)
-		.where(eq(orgMembers.orgId, orgId));
-	const fetchedById = new Map(existing.map((r) => [r.memberId, r.lastFetched]));
-	const isDone = (login: string) =>
-		!force && fetchedById.get(userEntityId(login)) != null;
-	const already = members.filter((m) => isDone(m.login)).length;
-	console.log(
-		`  ${members.length} public members${already ? ` (${already} already done — resuming)` : ""} — fetching lifetime totals, ~${Math.round((Math.max(1, Math.ceil(20 / WINDOWS_PER_REQUEST)) / TARGET_RATE) * 3600)}s each`,
-	);
-
-	let done = 0;
-	for (const m of members) {
-		const memberId = userEntityId(m.login);
-		if (isDone(m.login)) continue;
-
-		// A member can't have contributed to the org before either account existed.
-		const start = new Date(
-			Math.max(orgCreated.getTime(), new Date(m.createdAt).getTime()),
-		);
-		const windows = yearlyWindows(start, runStart);
-		let totals: OrgMemberTotals = {
-			commits: 0,
-			issues: 0,
-			pullRequests: 0,
-			reviews: 0,
-		};
-		try {
-			totals = await fetchOrgMemberContributions(
-				m.login,
-				profile.nodeId,
-				token,
-				windows,
-			);
-		} catch (e) {
-			// Isolate per-member failures so one bad member can't sink the whole org:
-			//  - 404: deleted/renamed member — gone forever.
-			//  - 400: login our validator can't accept (shouldn't happen now that legacy
-			//    hyphen-ending usernames pass, but stay defensive).
-			// Record zeros + mark done so resume doesn't wedge on it. Rate limits (403/429) and
-			// 5xx still propagate → the run aborts and resumes later rather than storing false zeros.
-			if (!(e instanceof GitHubError && (e.status === 404 || e.status === 400))) {
-				throw e;
-			}
-			console.log(`  – ${m.login.padEnd(22)} skipped (${(e as GitHubError).status})`);
-		}
-		const req = Math.max(1, Math.ceil(windows.length / WINDOWS_PER_REQUEST));
-		requests += req;
-
-		await database
-			.update(orgMembers)
-			.set({ ...totals, lastFetched: new Date() })
-			.where(
-				and(eq(orgMembers.orgId, orgId), eq(orgMembers.memberId, memberId)),
-			);
-		done += 1;
-		console.log(
-			`  ✓ ${m.login.padEnd(22)} ${totals.commits.toLocaleString()} commits  (${done}/${members.length})`,
-		);
-		// Politeness pacing: spread this member's request cost across the target hourly rate.
-		await sleep((req / TARGET_RATE) * 3_600_000);
-	}
-
-	// Roll up org totals from org_members (departed rows, if any, stay frozen — same as #97) and
-	// stamp builtAt so the org now looks finished to the request path.
-	const [sums] = await database
-		.select({
-			commits: sql<number>`coalesce(sum(${orgMembers.commits}), 0)`,
-			pullRequests: sql<number>`coalesce(sum(${orgMembers.pullRequests}), 0)`,
-			reviews: sql<number>`coalesce(sum(${orgMembers.reviews}), 0)`,
-			issues: sql<number>`coalesce(sum(${orgMembers.issues}), 0)`,
-		})
-		.from(orgMembers)
-		.where(eq(orgMembers.orgId, orgId));
-	await database
-		.update(entities)
-		.set({
-			totalCommits: Number(sums?.commits ?? 0),
-			totalPullRequests: Number(sums?.pullRequests ?? 0),
-			totalReviews: Number(sums?.reviews ?? 0),
-			totalIssues: Number(sums?.issues ?? 0),
-			builtAt: new Date(),
-			lastFetched: new Date(),
-		})
-		.where(eq(entities.id, orgId));
-
-	console.log(
-		`✓ ${login.padEnd(24)} ${Number(sums?.commits ?? 0).toLocaleString()} commits · ${done} fetched${already ? ` + ${already} already done` : ""} / ${members.length} members`,
-	);
-	return requests;
-}
 
 const args = process.argv.slice(2).filter((a) => !a.startsWith("-"));
 
@@ -298,9 +75,21 @@ if (args.length > 0) {
 
 let spent = 0;
 for (const { login } of targets) {
-	await respectFloor();
+	await respectRateFloor(token, console.log);
 	try {
-		spent += await fillOrg(login);
+		const r = await refreshOrg({
+			database,
+			token,
+			login,
+			force,
+			ratePerHour: TARGET_RATE,
+			log: console.log,
+		});
+		spent += r.requests;
+		console.log(
+			`✓ ${r.login.padEnd(24)} ${r.after.totalCommits.toLocaleString()} commits · ` +
+				`${r.fetched} fetched${r.skipped ? ` + ${r.skipped} already done` : ""} / ${r.tracked} members`,
+		);
 	} catch (e) {
 		const msg = e instanceof Error ? e.message : String(e);
 		console.log(`✗ ${login.padEnd(24)} ${msg} — continuing`);

--- a/scripts/refresh-org.ts
+++ b/scripts/refresh-org.ts
@@ -1,0 +1,99 @@
+/**
+ * On-demand refresh of ONE organization — the org sibling of `pnpm refresh-user`.
+ *
+ * Why this exists: an org's membership is enumerated **once**, when the org is first built (see
+ * src/lib/org-cache.ts). Nothing on the request path ever re-reads `membersWithRole`, so a member
+ * who joins later — or who flips their membership from private to public, the exact case in #150 —
+ * never appears on the org page, no matter how many times anyone reloads it. This re-enumerates
+ * the membership, fetches whatever is missing, and rolls the totals back up.
+ *
+ * By default it only fills gaps: brand-new members plus anyone a previous run left pending. That
+ * makes the common case cheap (a 1,500-member org with one joiner costs ~2 requests, not ~3,000).
+ * Pass --force to re-fetch every member's numbers as well, which is what you want when the org's
+ * *existing* totals are stale rather than incomplete.
+ *
+ * Members who are no longer public are reported but kept — deleting them would silently shrink the
+ * org's lifetime totals (#97).
+ *
+ * Run with bun, which auto-loads the local (un-committed) `.env`, so no `--env-file` flag. Beware
+ * a shell-exported GITHUB_TOKEN overriding it — prefix with `env -u GITHUB_TOKEN` if your shell
+ * sets one:
+ *
+ *   bun run refresh-org NixOS              # pick up new/pending members, roll up
+ *   bun run refresh-org --force NixOS      # also re-fetch every member's numbers
+ *   REFRESH_RATE=1200 bun run refresh-org NixOS   # pace slower (default 2500 req/hr)
+ *
+ * Safe to re-run and to interrupt: every write is an idempotent upsert and each member is stamped
+ * as it lands, so a re-run resumes rather than restarting.
+ */
+import { db } from "#/lib/db";
+import { refreshOrg, respectRateFloor } from "#/lib/org-refresh";
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+if (!process.env.DATABASE_URL)
+	throw new Error("DATABASE_URL is required (add it to .env)");
+if (!GITHUB_TOKEN) throw new Error("GITHUB_TOKEN is required (add it to .env)");
+if (!db) throw new Error("Database client failed to initialise.");
+const token = GITHUB_TOKEN;
+const database = db;
+
+const argv = process.argv.slice(2);
+const force = argv.includes("--force");
+const logins = argv.filter((a) => !a.startsWith("-"));
+
+if (logins.length === 0) {
+	console.log(
+		[
+			"Usage:",
+			"  bun run refresh-org <login…>            re-enumerate members, fill gaps, roll up",
+			"  bun run refresh-org --force <login…>    also re-fetch every member's numbers",
+			"",
+			"  REFRESH_RATE=<n>  requests/hour to pace at (default 2500)",
+		].join("\n"),
+	);
+	process.exit(1);
+}
+
+const ratePerHour = Number(process.env.REFRESH_RATE ?? 2500);
+const delta = (n: number) => `${n >= 0 ? "+" : ""}${n.toLocaleString()}`;
+
+let failed = 0;
+for (const login of logins) {
+	await respectRateFloor(token, console.log);
+	try {
+		const r = await refreshOrg({
+			database,
+			token,
+			login,
+			force,
+			ratePerHour,
+			log: console.log,
+		});
+		const commitDelta = r.after.totalCommits - (r.before?.totalCommits ?? 0);
+		console.log(
+			`✓ ${r.login} — ${r.after.totalCommits.toLocaleString()} commits (${delta(commitDelta)}) · ` +
+				`${r.tracked.toLocaleString()}/${r.memberCount.toLocaleString()} members tracked · ` +
+				`${r.added} added · ${r.fetched} fetched · ~${r.requests.toLocaleString()} requests`,
+		);
+		// We keep these rows, so `tracked` legitimately runs ahead of GitHub's count over time —
+		// say so, otherwise the mismatch reads like the #150 bug all over again.
+		if (r.departed.length > 0) {
+			console.log(
+				`  note: ${r.departed.length} tracked member(s) no longer public — kept, their contributions still count (#97)`,
+			);
+			if (r.departed.length <= 20) {
+				console.log(`  ${r.departed.join(", ")}`);
+			}
+		}
+	} catch (e) {
+		failed++;
+		console.log(
+			`✗ ${login.padEnd(24)} ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
+}
+
+if (failed > 0) process.exitCode = 1;
+
+// postgres.js keeps its pool open — close it or the script never exits.
+await database.$client.end();

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	fetchMonthlyCommits,
+	fetchOrgMembers,
 	isValidLogin,
 	type MonthWindow,
 	monthlyWindows,
@@ -175,5 +176,61 @@ describe("fetchMonthlyCommits adaptive batching", () => {
 				repos: 0,
 			},
 		]);
+	});
+});
+
+describe("fetchOrgMembers pagination", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	/** A membersWithRole page of `size` synthetic members, numbered from `from`. */
+	const page = (from: number, size: number, hasNextPage: boolean) => ({
+		ok: true,
+		status: 200,
+		headers: { get: () => null },
+		json: async () => ({
+			data: {
+				organization: {
+					membersWithRole: {
+						pageInfo: { hasNextPage, endCursor: `cur${from + size}` },
+						edges: Array.from({ length: size }, (_, i) => ({
+							role: "MEMBER",
+							node: {
+								login: `member${from + i}`,
+								name: null,
+								avatarUrl: "",
+								createdAt: "2015-01-01T00:00:00Z",
+							},
+						})),
+					},
+				},
+			},
+		}),
+	});
+
+	it("keeps paginating past the first ten pages", async () => {
+		// The regression behind #150: at the old 10-page cap, NixOS (1,494 public members) was
+		// silently stored as its first 1,000 — everyone past the cut was invisible forever.
+		const TOTAL_PAGES = 15;
+		let seen = 0;
+		vi.stubGlobal("fetch", async () => {
+			const p = seen++;
+			const size = p === TOTAL_PAGES - 1 ? 94 : 100;
+			return page(p * 100, size, p < TOTAL_PAGES - 1);
+		});
+
+		const members = await fetchOrgMembers("NixOS", "tok");
+
+		expect(members).toHaveLength(1494);
+		expect(members.at(-1)?.login).toBe("member1493");
+	});
+
+	it("throws rather than returning a truncated membership at the cap", async () => {
+		// A backstop that trims the result set lies about who is in the org; one that fails is
+		// merely unhelpful. Always claim another page so the loop runs into the cap.
+		vi.stubGlobal("fetch", async () => page(0, 100, true));
+
+		await expect(fetchOrgMembers("hugeorg", "tok")).rejects.toThrow(
+			/more than 10000 public members/,
+		);
 	});
 });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -539,9 +539,13 @@ export async function fetchOrgProfile(
 	};
 }
 
-// Hard stop for the members pagination loop (pages of 100). The org build enforces its own,
-// lower member cap before fetching contributions — this is just a runaway/mega-org backstop.
-const MAX_MEMBER_PAGES = 10;
+// Hard stop for the members pagination loop (pages of 100). The org build enforces its own, far
+// lower member cap before fetching contributions, so only the backfill/refresh scripts ever
+// paginate deep — this is a runaway backstop, not a policy cap, and sits well above GitHub's
+// largest orgs. It used to be 10, which silently truncated NixOS to the first 1,000 of its 1,494
+// public members (#150): every member past page 10 was invisible forever. A backstop that trims
+// the result set is worse than one that fails, so hitting it now throws.
+const MAX_MEMBER_PAGES = 100;
 
 /**
  * Enumerate an org's members visible to the token — public members only unless the token itself
@@ -590,7 +594,12 @@ export async function fetchOrgMembers(
 		if (!conn.pageInfo.hasNextPage) return members;
 		cursor = conn.pageInfo.endCursor;
 	}
-	return members;
+	// Never return a partial membership — a truncated list reads as "these are all the members"
+	// and permanently hides everyone past the cut (#150).
+	throw new GitHubError(
+		`Organization "${login}" has more than ${MAX_MEMBER_PAGES * 100} public members — refusing to enumerate a partial membership.`,
+		413,
+	);
 }
 
 /** A member's summed lifetime contributions to one org (org-scoped, not their global totals). */

--- a/src/lib/org-refresh.ts
+++ b/src/lib/org-refresh.ts
@@ -1,0 +1,361 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { DB } from "#/lib/db";
+import { entities, orgMembers } from "#/lib/db/schema";
+import {
+	fetchOrgMemberContributions,
+	fetchOrgMembers,
+	fetchOrgProfile,
+	GitHubError,
+	type OrgMemberTotals,
+	yearlyWindows,
+} from "#/lib/github";
+
+/**
+ * Off-request-path fill of ONE organization: profile → member enumeration → each member's
+ * org-scoped lifetime contributions → roll-up onto the org's `entities` row.
+ *
+ * This is the engine behind both `pnpm refresh-org <login>` (one org, on demand) and
+ * `pnpm backfill-orgs` (every recorded-but-unfilled org). They differ only in how they pick
+ * targets, so the actual GitHub/DB work lives here rather than in two drifting copies.
+ *
+ * Why it can't live on the request path: at ~1-4 GitHub requests per member, a 1,500-member org
+ * is thousands of requests. org-cache.ts refuses anything over MAX_ORG_MEMBERS (25) live and
+ * leaves a `builtAt`-null row for exactly this code to pick up.
+ *
+ * Two properties everything else depends on:
+ *
+ * - **Resumable.** A member's `org_members.lastFetched` is the done-marker, written the moment its
+ *   totals land. An aborted run leaves the org `builtAt`-null with some members stamped; the next
+ *   run skips those and continues. Every write is an idempotent upsert.
+ * - **Re-enumerating.** Unlike the request-path build (which enumerates once and never again),
+ *   this always re-reads `membersWithRole`, so members who joined or flipped their membership
+ *   public since the last run get picked up. That is the whole point of the refresh mode.
+ *
+ * Departed members are reported but never deleted — see #97: dropping them would silently shrink
+ * the org's lifetime totals even though GitHub still attributes those commits to the org's repos.
+ */
+
+// Never let the token's remaining budget drop below this — headroom for live traffic.
+const REMAINING_FLOOR = 500;
+const CHUNK_ROWS = 100;
+// fetchOrgMemberContributions batches windows this many at a time; used only to pace, not for
+// correctness — an over-estimate just spends the budget more conservatively.
+const WINDOWS_PER_REQUEST = 6;
+
+const orgEntityId = (login: string) => `org:${login.trim().toLowerCase()}`;
+const userEntityId = (login: string) => `user:${login.trim().toLowerCase()}`;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export interface OrgTotals {
+	totalCommits: number;
+	totalPullRequests: number;
+	totalReviews: number;
+	totalIssues: number;
+}
+
+export interface OrgRefreshResult {
+	login: string;
+	/** Public members GitHub reports right now. */
+	memberCount: number;
+	/** `org_members` rows after this run's enumeration. */
+	tracked: number;
+	/** Members enumerated for the first time by this run. */
+	added: number;
+	/** Tracked members GitHub no longer lists as public — kept, not deleted (#97). */
+	departed: string[];
+	/** Members whose contributions this run (re-)fetched. */
+	fetched: number;
+	/** Members left alone because they were already filled (0 when `force`). */
+	skipped: number;
+	/** Approximate GitHub requests spent. */
+	requests: number;
+	/** Totals before the roll-up — null when the org had no row yet. */
+	before: OrgTotals | null;
+	after: OrgTotals;
+}
+
+export interface OrgRefreshOptions {
+	database: DB;
+	token: string;
+	login: string;
+	/**
+	 * Re-fetch members that already have totals instead of skipping them. Needed to pick up
+	 * retroactive changes (a member turning on private-contribution visibility, new commits since
+	 * the last run); without it a refresh only fills gaps.
+	 */
+	force?: boolean;
+	/** Requests/hour to pace at — well under GitHub's 5,000/hr so the live site keeps working. */
+	ratePerHour?: number;
+	/** Per-member progress lines. Default: silent. */
+	log?: (line: string) => void;
+}
+
+/** Query GitHub's current rate-limit budget. `rateLimit` queries themselves cost 0 points. */
+export async function rateLimitBudget(
+	token: string,
+): Promise<{ remaining: number; resetAt: string } | null> {
+	try {
+		const res = await fetch("https://api.github.com/graphql", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				"User-Agent": "commit-history-org-refresh",
+			},
+			body: JSON.stringify({
+				query: "query { rateLimit { remaining resetAt } }",
+			}),
+		});
+		const json = (await res.json()) as {
+			data?: { rateLimit: { remaining: number; resetAt: string } };
+		};
+		return json.data?.rateLimit ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/** If we're near the reserved floor, sleep until GitHub's window resets (plus a small buffer). */
+export async function respectRateFloor(
+	token: string,
+	log: (line: string) => void = () => {},
+): Promise<void> {
+	const rl = await rateLimitBudget(token);
+	if (!rl || rl.remaining > REMAINING_FLOOR) return;
+	const waitMs =
+		Math.max(0, new Date(rl.resetAt).getTime() - Date.now()) + 2000;
+	log(
+		`… budget low (${rl.remaining} left) — pausing ${Math.ceil(waitMs / 1000)}s until reset`,
+	);
+	await sleep(waitMs);
+}
+
+export async function refreshOrg({
+	database,
+	token,
+	login,
+	force = false,
+	ratePerHour = 2500,
+	log = () => {},
+}: OrgRefreshOptions): Promise<OrgRefreshResult> {
+	const orgId = orgEntityId(login);
+	const runStart = new Date();
+	let requests = 0;
+
+	const [prior] = await database
+		.select({
+			totalCommits: entities.totalCommits,
+			totalPullRequests: entities.totalPullRequests,
+			totalReviews: entities.totalReviews,
+			totalIssues: entities.totalIssues,
+		})
+		.from(entities)
+		.where(eq(entities.id, orgId))
+		.limit(1);
+	const before: OrgTotals | null = prior
+		? {
+				totalCommits: prior.totalCommits,
+				totalPullRequests: prior.totalPullRequests ?? 0,
+				totalReviews: prior.totalReviews ?? 0,
+				totalIssues: prior.totalIssues ?? 0,
+			}
+		: null;
+
+	log(`${login}: resolving profile…`);
+
+	// Profile first — validates the login, yields nodeId (keys every org-scoped query) + createdAt
+	// (bounds each member's windows). Upsert so a never-looked-up org (e.g. a fresh google) is
+	// recorded here rather than requiring a prior page visit. builtAt stays null until the roll-up.
+	const profile = await fetchOrgProfile(login, token);
+	requests += 1;
+	const profileCols = {
+		login: profile.login,
+		name: profile.name,
+		avatarUrl: profile.avatarUrl,
+		htmlUrl: profile.htmlUrl,
+		createdAt: new Date(profile.createdAt),
+		bio: profile.description,
+		location: profile.location,
+		websiteUrl: profile.websiteUrl,
+		twitterUsername: profile.twitterUsername,
+		publicRepos: profile.publicRepos,
+		isVerified: profile.isVerified,
+		githubNodeId: profile.nodeId,
+		memberCount: profile.memberCount,
+		lastFetched: runStart,
+	};
+	await database
+		.insert(entities)
+		.values({ id: orgId, kind: "org", ...profileCols })
+		.onConflictDoUpdate({ target: entities.id, set: profileCols });
+	const orgCreated = new Date(profile.createdAt);
+
+	// What we tracked going in — the baseline for the added/departed drift report below.
+	const existing = await database
+		.select({
+			memberId: orgMembers.memberId,
+			lastFetched: orgMembers.lastFetched,
+		})
+		.from(orgMembers)
+		.where(eq(orgMembers.orgId, orgId));
+	const fetchedById = new Map(existing.map((r) => [r.memberId, r.lastFetched]));
+
+	// (Re-)enumerate → a user stub (FK target, never overwrites a real user row) + a pending
+	// org_members row each. Both idempotent, so this picks up joiners without disturbing anyone.
+	const members = await fetchOrgMembers(login, token);
+	requests += Math.max(1, Math.ceil(members.length / 100));
+	for (let i = 0; i < members.length; i += CHUNK_ROWS) {
+		const chunk = members.slice(i, i + CHUNK_ROWS);
+		await database
+			.insert(entities)
+			.values(
+				chunk.map((m) => ({
+					id: userEntityId(m.login),
+					kind: "user",
+					login: m.login,
+					name: m.name,
+					avatarUrl: m.avatarUrl,
+					htmlUrl: `https://github.com/${m.login}`,
+					createdAt: new Date(m.createdAt),
+				})),
+			)
+			.onConflictDoNothing();
+		await database
+			.insert(orgMembers)
+			.values(
+				chunk.map((m) => ({
+					orgId,
+					memberId: userEntityId(m.login),
+					role: m.role,
+					source: "public_member",
+				})),
+			)
+			.onConflictDoNothing();
+	}
+
+	const currentIds = new Set(members.map((m) => userEntityId(m.login)));
+	const added = members.filter((m) => !fetchedById.has(userEntityId(m.login)));
+	// Tracked but no longer listed: left the org, or flipped membership back to private. Their rows
+	// (and their contributions) stay — see #97.
+	const departed = existing
+		.filter((r) => !currentIds.has(r.memberId))
+		.map((r) => r.memberId.replace(/^user:/, ""));
+
+	// A member's `lastFetched` marks it done — in this run OR a previous, aborted one. By default we
+	// skip anything already fetched, so a re-run continues from exactly where an abort stopped
+	// instead of restarting the org. --force re-fetches everyone, to refresh existing numbers.
+	const isDone = (memberLogin: string) =>
+		!force && fetchedById.get(userEntityId(memberLogin)) != null;
+	const skipped = members.filter((m) => isDone(m.login)).length;
+	const todo = members.length - skipped;
+
+	log(
+		`  ${members.length} public members` +
+			(added.length ? ` (+${added.length} new)` : "") +
+			(departed.length ? ` (−${departed.length} no longer public)` : "") +
+			(skipped ? ` · ${skipped} already filled, skipping` : "") +
+			` — fetching ${todo}`,
+	);
+
+	let fetched = 0;
+	for (const m of members) {
+		const memberId = userEntityId(m.login);
+		if (isDone(m.login)) continue;
+
+		// A member can't have contributed to the org before either account existed.
+		const start = new Date(
+			Math.max(orgCreated.getTime(), new Date(m.createdAt).getTime()),
+		);
+		const windows = yearlyWindows(start, runStart);
+		let totals: OrgMemberTotals = {
+			commits: 0,
+			issues: 0,
+			pullRequests: 0,
+			reviews: 0,
+		};
+		try {
+			totals = await fetchOrgMemberContributions(
+				m.login,
+				profile.nodeId,
+				token,
+				windows,
+			);
+		} catch (e) {
+			// Isolate per-member failures so one bad member can't sink the whole org:
+			//  - 404: deleted/renamed member — gone forever.
+			//  - 400: login our validator can't accept (shouldn't happen now that legacy
+			//    hyphen-ending usernames pass, but stay defensive).
+			// Record zeros + mark done so resume doesn't wedge on it. Rate limits (403/429) and
+			// 5xx still propagate → the run aborts and resumes later rather than storing false zeros.
+			if (
+				!(e instanceof GitHubError && (e.status === 404 || e.status === 400))
+			) {
+				throw e;
+			}
+			log(`  – ${m.login.padEnd(22)} skipped (${(e as GitHubError).status})`);
+		}
+		const req = Math.max(1, Math.ceil(windows.length / WINDOWS_PER_REQUEST));
+		requests += req;
+
+		await database
+			.update(orgMembers)
+			.set({ ...totals, lastFetched: new Date() })
+			.where(
+				and(eq(orgMembers.orgId, orgId), eq(orgMembers.memberId, memberId)),
+			);
+		fetched += 1;
+		log(
+			`  ✓ ${m.login.padEnd(22)} ${totals.commits.toLocaleString()} commits  (${fetched}/${todo})`,
+		);
+		// Politeness pacing: spread this member's request cost across the target hourly rate.
+		await sleep((req / ratePerHour) * 3_600_000);
+	}
+
+	const after = await rollUp(database, orgId);
+	const [tracked] = await database
+		.select({ n: sql<number>`count(*)` })
+		.from(orgMembers)
+		.where(eq(orgMembers.orgId, orgId));
+
+	return {
+		login: profile.login,
+		memberCount: profile.memberCount,
+		tracked: Number(tracked?.n ?? 0),
+		added: added.length,
+		departed,
+		fetched,
+		skipped,
+		requests,
+		before,
+		after,
+	};
+}
+
+/**
+ * Sum `org_members` into the org's entity totals and stamp `builtAt` — the run's final step, so an
+ * interrupted org never looks finished. Departed rows are included on purpose (#97).
+ */
+async function rollUp(database: DB, orgId: string): Promise<OrgTotals> {
+	const [sums] = await database
+		.select({
+			commits: sql<number>`coalesce(sum(${orgMembers.commits}), 0)`,
+			pullRequests: sql<number>`coalesce(sum(${orgMembers.pullRequests}), 0)`,
+			reviews: sql<number>`coalesce(sum(${orgMembers.reviews}), 0)`,
+			issues: sql<number>`coalesce(sum(${orgMembers.issues}), 0)`,
+		})
+		.from(orgMembers)
+		.where(eq(orgMembers.orgId, orgId));
+	const totals: OrgTotals = {
+		totalCommits: Number(sums?.commits ?? 0),
+		totalPullRequests: Number(sums?.pullRequests ?? 0),
+		totalReviews: Number(sums?.reviews ?? 0),
+		totalIssues: Number(sums?.issues ?? 0),
+	};
+	const now = new Date();
+	await database
+		.update(entities)
+		.set({ ...totals, builtAt: now, lastFetched: now })
+		.where(eq(entities.id, orgId));
+	return totals;
+}


### PR DESCRIPTION
Fixes #150.

`fetchOrgMembers` capped pagination at 10 pages of 100 and returned the partial list, so every org over 1,000 public members was stored as an arbitrary prefix of its membership. Raises the backstop to 100 pages, makes hitting it throw, and adds `pnpm refresh-org <login>` to re-enumerate an org on demand.

**Why:** NixOS has 1,494 public members; we kept 1,000. The reporter sits at index 1,189, so his membership was invisible regardless of his visibility setting — which is what he was told to go check. Ten orgs are truncated in production (microsoft 1001/4373, IBM 1001/3102, Azure 1000/2906, apache 1000/1643, …), 13,508 members missing between them. The second half of the bug is that [`org-cache`](https://github.com/peetzweg/commit-history/blob/main/src/lib/org-cache.ts) enumerates `membersWithRole` exactly once per build, so joiners and private→public flips could never surface either.

**How:** the judgment call is that the cap now [throws instead of returning short](https://github.com/peetzweg/commit-history/blob/fix/org-member-pagination-truncation/src/lib/github.ts#L594) — a backstop that trims the result set lies about who is in the org, and the request path refuses anything over 25 members before enumerating, so only the scripts paginate deep. `refresh-org` fills gaps by default (one joiner in a 1,500-member org costs ~2 requests, not ~3,000); `--force` re-fetches everyone for stale totals. Departed members are reported, never deleted, per #97. The per-org engine moves to `src/lib/org-refresh.ts` so `backfill-orgs` and `refresh-org` share one copy of the resume/pacing logic.

Regression tests cover both the past-page-10 case and the throw-at-cap case. No migration. The ten truncated orgs need a `pnpm refresh-org <login>` pass after merge to actually pick up their missing members.