### PR TITLE
Hide the sponsor creative once its slot is up for rent again

### DIFF
--- a/src/components/SponsorRow.tsx
+++ b/src/components/SponsorRow.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { motion } from "motion/react";
 import { useEffect, useState } from "react";
@@ -6,19 +7,22 @@ import {
 	type SponsorCreative,
 	type SponsorSlotId,
 } from "#/content/sponsors";
+import { sponsorSlotsQueryOptions } from "#/lib/sponsor";
 import { cn } from "#/lib/utils";
 
 /**
  * The sponsor slot row shown after rank 5 on a leaderboard.
  *
- * Driven purely by the static creative in `src/content/sponsors.ts`: a booked slot renders the
- * sponsor's creative, an empty slot advertises itself and links to the /-/sponsoring pitch page.
- * Reused across the developer board, the organization board, and each organization's internal
- * member board, so the same paid slot is seen everywhere its board appears.
+ * Two inputs: the static creative in `src/content/sponsors.ts` (what a booked slot looks like) and
+ * the live Stripe status from `src/lib/sponsor.ts` (whether the slot is still sold). No creative,
+ * or a slot Stripe says is available, renders the self-advertising empty row linking to the
+ * /-/sponsoring pitch page. Reused across the developer board, the organization board, and each
+ * organization's internal member board, so the same paid slot is seen everywhere its board appears.
  *
- * Live "is it sold" status (the "Rent this slot" buttons) is a separate, Stripe-driven concern on
- * the /-/sponsoring page (`src/lib/sponsor.ts`) — swapping the creative here stays a manual,
- * reviewable commit made once a sponsor mails their logo.
+ * The status check exists because the two used to be fully decoupled, and a lapsed subscription
+ * left the old sponsor's ad running on the boards while /-/sponsoring already offered the same slot
+ * for rent. Putting a *new* creative up is still a manual, reviewable commit (nobody can invent a
+ * logo from a Stripe event); taking a lapsed one *down* needs no creative, so it happens by itself.
  *
  * Takes an optional `ref` because on the home boards it's a direct child of AnimatePresence
  * (mode="popLayout"), which attaches a ref to each child to measure it.
@@ -31,7 +35,16 @@ export function SponsorRow({
 	ref?: React.Ref<HTMLLIElement>;
 }) {
 	const creative = SPONSORS[slot];
-	return creative ? (
+	// Skipped when there is no creative: an empty slot renders the same either way, so the common
+	// case costs no RPC — and the request only ever fires for a slot with an ad to justify.
+	const { data } = useQuery({
+		...sponsorSlotsQueryOptions,
+		enabled: creative !== null,
+	});
+	const status = data?.find((s) => s.id === slot)?.status ?? "unknown";
+	// Only a definitive "available" pulls the ad. On the server, during the first paint, and through
+	// any Stripe outage the status reads "unknown" — a paying sponsor keeps their row regardless.
+	return creative && status !== "available" ? (
 		<BookedRow creative={creative} ref={ref} />
 	) : (
 		<EmptyRow ref={ref} />

--- a/src/content/sponsors.ts
+++ b/src/content/sponsors.ts
@@ -4,9 +4,13 @@
  * The creative lives in code — not a DB, not a CMS. A slot changes maybe once a quarter, a logo
  * has to be hosted somewhere regardless, and keeping it here means every change is a reviewable,
  * revertable commit. *Selling* a slot is a Stripe concern (`src/lib/sponsor.ts`); *showing* the
- * creative is this file. The two are deliberately decoupled: a fresh sale flips the /-/sponsoring
- * page to "Booked" automatically, while the row below is swapped by hand once the sponsor mails
- * their logo (same manual step the legacy Rebates deal uses today).
+ * creative is this file. A fresh sale flips the /-/sponsoring page to "Booked" automatically, and
+ * the entry below is added by hand once the sponsor mails their logo.
+ *
+ * An entry here is permission to show an ad, not proof the slot is still paid for: `SponsorRow`
+ * hides the creative whenever Stripe reports the slot available, so a lapsed subscription can't
+ * leave an ex-sponsor running for free. Do clear the stale entry anyway — the row falls back to
+ * the creative whenever Stripe is unreachable.
  *
  * `null` = the slot has no paid creative right now → the leaderboards show a self-advertising
  * "empty slot" row linking to the /-/sponsoring pitch page.
@@ -38,30 +42,11 @@ export interface SponsorCreative {
 	abVariants?: readonly SponsorVariant[];
 }
 
-// Rebates.ai occupies the developer slot (legacy deal, not a Stripe subscription). The slot-5
-// tagline A/B test rides along here — utm_content carries the arm so clicks are attributable.
-const rebatesHref = (utmContent: string) =>
-	`https://rebates.ai/?utm_source=commit-history.com&utm_medium=leaderboard&utm_campaign=commit-history_sponsorship&utm_content=${utmContent}`;
-
 export const SPONSORS: Record<SponsorSlotId, SponsorCreative | null> = {
-	dev: {
-		name: "Rebates.ai",
-		logo: "https://rebates.ai/brand/rebates-bandit.svg",
-		logoShape: "round",
-		// Arm "a" (control) is the SSR default; both arms live in abVariants for the client flip.
-		tagline: "The ads in your terminal pay you",
-		href: rebatesHref("slot5-test-79-a"),
-		abVariants: [
-			{
-				tagline: "The ads in your terminal pay you",
-				href: rebatesHref("slot5-test-79-a"),
-			},
-			{
-				tagline: "Watch ads while coding. Get paid.",
-				href: rebatesHref("slot5-test-79-b"),
-			},
-		],
-	},
+	// The Rebates.ai deal ended when its subscription lapsed — the board shows the self-advertising
+	// empty row again. Its creative (logo, the slot-5 tagline A/B test, utm_content arms) is in git
+	// history if the deal comes back.
+	dev: null,
 	// No paid org sponsor yet → the board shows the self-advertising empty row. When the org slot
 	// sells via Stripe, drop the sponsor's creative here and deploy.
 	org: null,

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -4,9 +4,10 @@ import type { SponsorSlotId } from "#/content/sponsors";
 
 /**
  * Live per-slot sponsorship status, read from Stripe. Powers the "Rent this slot" / "Booked"
- * cards on the /-/sponsoring page — and nothing else. The leaderboard creative (the ad rows) is a
- * separate, static concern (`src/content/sponsors.ts`); this module never decides what is shown on
- * a board, only whether a slot is currently for sale.
+ * cards on the /-/sponsoring page, and gates the leaderboard creative (`SponsorRow`) so a slot
+ * offered for rent can never still be running the previous sponsor's ad. Which creative a booked
+ * slot shows stays a static, manual concern (`src/content/sponsors.ts`) — this module only decides
+ * whether a slot is currently for sale.
  *
  * No database: a slot's truth lives entirely in Stripe (subscription state per price) plus env
  * (which price/link maps to which slot). "Booked" is derived from an active subscription existing,
@@ -83,8 +84,9 @@ async function computeSlot(
 	env: SlotEnv,
 	stripe: Stripe | null,
 ): Promise<SlotState> {
-	// The dev slot is held by the legacy Rebates deal (not a Stripe sub) → forced "booked" via env
-	// until that deal ends. Checked before Stripe so it holds even with Stripe unconfigured.
+	// Escape hatch for a slot sold outside Stripe (the legacy Rebates deal used it until that deal
+	// lapsed): env forces "booked" so the slot isn't offered for rent and its creative keeps
+	// running. Checked before Stripe so it holds even with Stripe unconfigured.
 	if (id === "dev" && process.env.SPONSOR_DEV_SLOT_FORCE_BOOKED === "1") {
 		return { id, status: "booked" };
 	}
@@ -141,3 +143,13 @@ export const getSponsorSlots = createServerFn({ method: "GET" }).handler(
 		return slots;
 	},
 );
+
+/**
+ * Shared react-query wiring, so the /-/sponsoring cards and every leaderboard sponsor row read one
+ * cache instead of each firing their own RPC. staleTime matches the server-side cache window.
+ */
+export const sponsorSlotsQueryOptions = {
+	queryKey: ["sponsor-slots"] as const,
+	queryFn: () => getSponsorSlots(),
+	staleTime: CACHE_MS,
+};

--- a/src/routes/[-].sponsoring.tsx
+++ b/src/routes/[-].sponsoring.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import type { SponsorSlotId } from "#/content/sponsors";
-import { getSponsorSlots, type SlotState } from "#/lib/sponsor";
+import { type SlotState, sponsorSlotsQueryOptions } from "#/lib/sponsor";
 
 const SITE = "https://commit-history.com";
 const TITLE = "Sponsoring commit-history.com";
@@ -162,11 +162,8 @@ const SLOT_ORDER: readonly SponsorSlotId[] = ["dev", "org"];
  * once Stripe answers. Any unconfigured/failed slot simply stays on the fallback.
  */
 function SlotsSection() {
-	const { data } = useQuery({
-		queryKey: ["sponsor-slots"],
-		queryFn: () => getSponsorSlots(),
-		staleTime: 60_000,
-	});
+	// Same query the leaderboard sponsor rows use, so both views of a slot can't disagree.
+	const { data } = useQuery(sponsorSlotsQueryOptions);
 	const byId = new Map((data ?? []).map((s) => [s.id, s]));
 	return (
 		<section className="mt-10">


### PR DESCRIPTION
Follow-up to #131. The leaderboard sponsor row now checks the live Stripe slot status before rendering an ad, and the lapsed Rebates.ai creative is cleared.

**Why:** the row and the /-/sponsoring cards read different sources — the row rendered whatever creative sat in `src/content/sponsors.ts`, the cards derive from Stripe. When the developer slot's subscription lapsed, the pitch page correctly offered the slot for rent while the boards kept running the ex-sponsor's ad for free.

**How:** `SponsorRow` reads the same query the pitch page does (shared options in `src/lib/sponsor.ts`) and drops the creative when Stripe reports the slot `available`. Deliberate: only a *definitive* `available` hides an ad — during SSR, first paint, and any Stripe outage the status is `unknown` and a paying sponsor keeps their row. The trade-off is that a lapsed ad flashes on first paint before the flip; resolving it server-side would mean threading status through the home, org, and user loaders. The query is skipped when a slot has no creative, so the empty case costs no extra RPC.

Verified in a real browser (post-hydration DOM) with the status forced both ways: `available` flips the row to empty, `booked` keeps the ad.