### PR TITLE
Add aggregate GitHub activity page

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { getRepoStars } from "#/lib/commit-history";
 
-// Dark top bar, a homage to star-history.com's header (#363636 / light text).
+// Dark top bar (#363636 / light text).
 export function Header() {
 	// Live GitHub star count, shown next to the source link. Cached for the session; absent until it
 	// loads (and if the fetch fails, just omitted).
@@ -18,16 +18,7 @@ export function Header() {
 					<img src="/crown.svg" alt="" className="h-6 w-auto shrink-0" />
 				</Link>
 			</div>
-			<div className="flex h-full flex-row items-center gap-1 sm:gap-4">
-				<a
-					href="https://www.star-history.com/"
-					target="_blank"
-					rel="noopener"
-					className="header-link hidden text-sm sm:flex"
-					title="Inspired by star-history.com"
-				>
-					a homage to star-history
-				</a>
+			<div className="flex h-full flex-row items-center">
 				<a
 					href="https://github.com/peetzweg/commit-history"
 					target="_blank"

--- a/src/components/MetricBar.tsx
+++ b/src/components/MetricBar.tsx
@@ -43,6 +43,10 @@ export function MetricBar() {
 	if (routeId === "/") {
 		// The organization board (?kind=org) ranks by commits only — no metric to pick yet.
 		modes = boardKind === "org" ? null : LEADER_MODES;
+	} else if (routeId === "/-/github") {
+		// The aggregate page always exposes the full contribution vocabulary. A metric may be zero
+		// in an early database, but keeping its tab stable makes the page's interface predictable.
+		modes = ALL_METRICS;
 	} else if (routeId === "/$user") {
 		if (lookup?.kind === "org") {
 			// Org pages have a single number set — nothing to pick (no per-metric boards yet).

--- a/src/lib/github-history.test.ts
+++ b/src/lib/github-history.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { cumulativeGithubPoints } from "#/lib/github-history";
+
+describe("cumulativeGithubPoints", () => {
+	it("accumulates each monthly metric without mixing public and private commits", () => {
+		expect(
+			cumulativeGithubPoints([
+				{
+					date: "2025-01-01",
+					commits: 10,
+					restricted: 2,
+					issues: 3,
+					pullRequests: 4,
+					reviews: 5,
+					repos: 1,
+				},
+				{
+					date: "2025-02-01",
+					commits: 7,
+					restricted: 6,
+					issues: 0,
+					pullRequests: 2,
+					reviews: 1,
+					repos: 0,
+				},
+			]),
+		).toEqual([
+			{
+				date: "2025-01-01",
+				commits: 10,
+				cumulative: 10,
+				restricted: 2,
+				restrictedCumulative: 2,
+				issues: 3,
+				pullRequests: 4,
+				reviews: 5,
+				repos: 1,
+			},
+			{
+				date: "2025-02-01",
+				commits: 7,
+				cumulative: 17,
+				restricted: 6,
+				restrictedCumulative: 8,
+				issues: 0,
+				pullRequests: 2,
+				reviews: 1,
+				repos: 0,
+			},
+		]);
+	});
+});

--- a/src/lib/github-history.ts
+++ b/src/lib/github-history.ts
@@ -1,0 +1,104 @@
+import { createServerFn } from "@tanstack/react-start";
+import type { CommitPoint } from "#/lib/github";
+
+/** One calendar month's activity across every tracked GitHub user. */
+export interface GithubMonth {
+	date: string;
+	commits: number;
+	restricted: number;
+	issues: number;
+	pullRequests: number;
+	reviews: number;
+	repos: number;
+}
+
+export interface GithubHistory {
+	/** Cumulative monthly activity across every tracked user with stored monthly data. */
+	points: CommitPoint[];
+	/** Users represented in at least one of the source months. */
+	trackedUsers: number;
+}
+
+/**
+ * Adds cumulative values to aggregate monthly rows. Kept separate from the database query so
+ * the public interface is easy to exercise without a database and every chart receives the same
+ * `CommitPoint` shape as an individual profile.
+ */
+export function cumulativeGithubPoints(months: GithubMonth[]): CommitPoint[] {
+	let cumulative = 0;
+	let restrictedCumulative = 0;
+	return months.map((month) => {
+		cumulative += month.commits;
+		restrictedCumulative += month.restricted;
+		return {
+			date: month.date,
+			commits: month.commits,
+			cumulative,
+			restricted: month.restricted,
+			restrictedCumulative,
+			issues: month.issues,
+			pullRequests: month.pullRequests,
+			reviews: month.reviews,
+			repos: month.repos,
+		};
+	});
+}
+
+async function queryGithubHistory(): Promise<GithubHistory> {
+	// This module is imported by a route, so database code must stay inside the server handler.
+	// A top-level import would make Vite traverse postgres.js from the browser-facing graph.
+	const [{ asc, eq, sql }, { db }, { entities, monthlyCommits }] =
+		await Promise.all([
+			import("drizzle-orm"),
+			import("#/lib/db"),
+			import("#/lib/db/schema"),
+		]);
+	if (!db) return { points: [], trackedUsers: 0 };
+
+	// Only user rows belong here. Organization totals are derived from member contributions and
+	// including them would count the same work twice. Suspended/unreachable users stay included:
+	// this is a historical dataset, not a current leaderboard population.
+	const [rows, userCountRows] = await Promise.all([
+		db
+			.select({
+				date: monthlyCommits.month,
+				commits: sql<string>`sum(${monthlyCommits.commits})`,
+				restricted: sql<string>`sum(${monthlyCommits.restricted})`,
+				issues: sql<string>`sum(${monthlyCommits.issues})`,
+				pullRequests: sql<string>`sum(${monthlyCommits.pullRequests})`,
+				reviews: sql<string>`sum(${monthlyCommits.reviews})`,
+				repos: sql<string>`sum(${monthlyCommits.repos})`,
+			})
+			.from(monthlyCommits)
+			.innerJoin(entities, eq(entities.id, monthlyCommits.entityId))
+			.where(eq(entities.kind, "user"))
+			.groupBy(monthlyCommits.month)
+			.orderBy(asc(monthlyCommits.month)),
+		db
+			.select({
+				count: sql<string>`count(distinct ${monthlyCommits.entityId})`,
+			})
+			.from(monthlyCommits)
+			.innerJoin(entities, eq(entities.id, monthlyCommits.entityId))
+			.where(eq(entities.kind, "user")),
+	]);
+
+	const months: GithubMonth[] = rows.map((row) => ({
+		date: row.date,
+		commits: Number(row.commits),
+		restricted: Number(row.restricted),
+		issues: Number(row.issues),
+		pullRequests: Number(row.pullRequests),
+		reviews: Number(row.reviews),
+		repos: Number(row.repos),
+	}));
+	return {
+		points: cumulativeGithubPoints(months),
+		trackedUsers: Number(userCountRows[0]?.count ?? 0),
+	};
+}
+
+/** Aggregate time series for the public GitHub activity page. */
+export const getGithubHistory = createServerFn({ method: "GET" }).handler(
+	(): Promise<GithubHistory> => queryGithubHistory(),
+);

--- a/src/lib/github-history.ts
+++ b/src/lib/github-history.ts
@@ -44,7 +44,8 @@ export function cumulativeGithubPoints(months: GithubMonth[]): CommitPoint[] {
 	});
 }
 
-async function queryGithubHistory(): Promise<GithubHistory> {
+/** Database-backed implementation shared by the page loader and its Open Graph renderer. */
+export async function queryGithubHistory(): Promise<GithubHistory> {
 	// This module is imported by a route, so database code must stay inside the server handler.
 	// A top-level import would make Vite traverse postgres.js from the browser-facing graph.
 	const [{ asc, eq, sql }, { db }, { entities, monthlyCommits }] =

--- a/src/lib/og-card.test.ts
+++ b/src/lib/og-card.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { displayNameLines, orgCard, trendDataUrl } from "#/lib/og-card";
+import {
+	displayNameLines,
+	githubCard,
+	orgCard,
+	trendDataUrl,
+} from "#/lib/og-card";
 
 function svg(values: readonly number[]) {
 	const dataUrl = trendDataUrl(values);
@@ -37,6 +42,30 @@ describe("orgCard", () => {
 		const rendered = JSON.stringify(card);
 		expect(rendered).toContain("+19");
 		expect(rendered).not.toContain('"25"');
+	});
+});
+
+describe("githubCard", () => {
+	it("labels the aggregate scope, metric total, and uses its supplied live trend", () => {
+		const card = githubCard({
+			metricLabel: "public commits",
+			total: 123_456,
+			trackedUsers: 789,
+			trendValues: [2, 3, 5],
+		});
+		const rendered = JSON.stringify(card);
+		const visual = card.props.children as unknown as {
+			props: { src: string };
+		}[];
+		const graphSvg = Buffer.from(
+			visual[0].props.src.split(",")[1],
+			"base64",
+		).toString("utf8");
+		expect(rendered).toContain("GitHub activity");
+		expect(rendered).toContain("789 tracked users");
+		expect(rendered).toContain("123,456");
+		expect(rendered).toContain("public commits");
+		expect(graphSvg).toContain("M8.0,251.2");
 	});
 });
 

--- a/src/lib/og-card.ts
+++ b/src/lib/og-card.ts
@@ -415,6 +415,76 @@ export function developerCard(input: DeveloperCardInput): OgNode {
 	);
 }
 
+export interface GithubCardInput {
+	/** Metric noun, e.g. "public commits". */
+	metricLabel: string;
+	/** Cumulative total for the shown metric. */
+	total: number;
+	/** Number of tracked users represented by the chart. */
+	trackedUsers: number;
+	/** Aggregate per-month values for the shown metric. */
+	trendValues: readonly number[];
+}
+
+/**
+ * Live aggregate card for /-/github. It deliberately shares the user card's cumulative trend,
+ * hand-drawn font, and green accent, while replacing person/rank identity with dataset scope.
+ */
+export function githubCard(input: GithubCardInput): OgNode {
+	return frame(
+		trendVisual(input.trendValues),
+		wordmark(32),
+		el(
+			"div",
+			{
+				style: {
+					display: "flex",
+					flexDirection: "column",
+					marginTop: "auto",
+					marginBottom: "auto",
+					maxWidth: 620,
+				},
+			},
+			el(
+				"div",
+				{
+					style: { display: "flex", fontSize: 72, lineHeight: 1.1, color: FG },
+				},
+				"GitHub activity",
+			),
+			el(
+				"div",
+				{
+					style: {
+						display: "flex",
+						marginTop: 22,
+						fontSize: 32,
+						lineHeight: 1.35,
+						color: MUTED,
+					},
+				},
+				`${input.trackedUsers.toLocaleString()} tracked users`,
+			),
+		),
+		el(
+			"div",
+			{ style: { display: "flex", flexDirection: "column" } },
+			el(
+				"div",
+				{ style: { display: "flex", fontSize: 52, lineHeight: 1, color: FG } },
+				input.total.toLocaleString(),
+			),
+			el(
+				"div",
+				{
+					style: { display: "flex", marginTop: 10, fontSize: 28, color: MUTED },
+				},
+				asciiFold(input.metricLabel),
+			),
+		),
+	);
+}
+
 export interface OrgCardInput {
 	login: string;
 	name: string | null;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as CompanySlugRouteImport } from './routes/company.$slug'
 import { Route as EmbedUserRouteImport } from './routes/embed.$user'
 import { Route as MetricsSlugRouteImport } from './routes/metrics.$slug'
 import { Route as MetricsExplainedRouteImport } from './routes/metrics.explained'
+import { Route as OgGithubRouteImport } from './routes/og.github'
 import { Route as OrganizationsSlugRouteImport } from './routes/organizations.$slug'
 import { Route as Char91Char93ApiStripeWebhookRouteImport } from './routes/[-].api.stripe-webhook'
 import { Route as Char91Char93MetricsIndexRouteImport } from './routes/[-].metrics.index'
@@ -88,6 +89,11 @@ const MetricsExplainedRoute = MetricsExplainedRouteImport.update({
   path: '/metrics/explained',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OgGithubRoute = OgGithubRouteImport.update({
+  id: '/og/github',
+  path: '/og/github',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OrganizationsSlugRoute = OrganizationsSlugRouteImport.update({
   id: '/organizations/$slug',
   path: '/organizations/$slug',
@@ -135,6 +141,7 @@ export interface FileRoutesByFullPath {
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
+  '/og/github': typeof OgGithubRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
   '/-/api/stripe-webhook': typeof Char91Char93ApiStripeWebhookRoute
   '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
@@ -155,6 +162,7 @@ export interface FileRoutesByTo {
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
+  '/og/github': typeof OgGithubRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
   '/-/api/stripe-webhook': typeof Char91Char93ApiStripeWebhookRoute
   '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
@@ -176,6 +184,7 @@ export interface FileRoutesById {
   '/embed/$user': typeof EmbedUserRoute
   '/metrics/$slug': typeof MetricsSlugRoute
   '/metrics/explained': typeof MetricsExplainedRoute
+  '/og/github': typeof OgGithubRoute
   '/organizations/$slug': typeof OrganizationsSlugRoute
   '/-/api/stripe-webhook': typeof Char91Char93ApiStripeWebhookRoute
   '/-/metrics/$slug': typeof Char91Char93MetricsSlugRoute
@@ -198,6 +207,7 @@ export interface FileRouteTypes {
     | '/embed/$user'
     | '/metrics/$slug'
     | '/metrics/explained'
+    | '/og/github'
     | '/organizations/$slug'
     | '/-/api/stripe-webhook'
     | '/-/metrics/$slug'
@@ -218,6 +228,7 @@ export interface FileRouteTypes {
     | '/embed/$user'
     | '/metrics/$slug'
     | '/metrics/explained'
+    | '/og/github'
     | '/organizations/$slug'
     | '/-/api/stripe-webhook'
     | '/-/metrics/$slug'
@@ -238,6 +249,7 @@ export interface FileRouteTypes {
     | '/embed/$user'
     | '/metrics/$slug'
     | '/metrics/explained'
+    | '/og/github'
     | '/organizations/$slug'
     | '/-/api/stripe-webhook'
     | '/-/metrics/$slug'
@@ -259,6 +271,7 @@ export interface RootRouteChildren {
   EmbedUserRoute: typeof EmbedUserRoute
   MetricsSlugRoute: typeof MetricsSlugRoute
   MetricsExplainedRoute: typeof MetricsExplainedRoute
+  OgGithubRoute: typeof OgGithubRoute
   OrganizationsSlugRoute: typeof OrganizationsSlugRoute
   Char91Char93ApiStripeWebhookRoute: typeof Char91Char93ApiStripeWebhookRoute
   Char91Char93MetricsSlugRoute: typeof Char91Char93MetricsSlugRoute
@@ -353,6 +366,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MetricsExplainedRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/og/github': {
+      id: '/og/github'
+      path: '/og/github'
+      fullPath: '/og/github'
+      preLoaderRoute: typeof OgGithubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/organizations/$slug': {
       id: '/organizations/$slug'
       path: '/organizations/$slug'
@@ -411,6 +431,7 @@ const rootRouteChildren: RootRouteChildren = {
   EmbedUserRoute: EmbedUserRoute,
   MetricsSlugRoute: MetricsSlugRoute,
   MetricsExplainedRoute: MetricsExplainedRoute,
+  OgGithubRoute: OgGithubRoute,
   OrganizationsSlugRoute: OrganizationsSlugRoute,
   Char91Char93ApiStripeWebhookRoute: Char91Char93ApiStripeWebhookRoute,
   Char91Char93MetricsSlugRoute: Char91Char93MetricsSlugRoute,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as SponsoringRouteImport } from './routes/sponsoring'
 import { Route as Char91Char93SlugRouteImport } from './routes/[-].$slug'
+import { Route as Char91Char93GithubRouteImport } from './routes/[-].github'
 import { Route as Char91Char93SponsoringRouteImport } from './routes/[-].sponsoring'
 import { Route as CompanySlugRouteImport } from './routes/company.$slug'
 import { Route as EmbedUserRouteImport } from './routes/embed.$user'
@@ -55,6 +56,11 @@ const SponsoringRoute = SponsoringRouteImport.update({
 const Char91Char93SlugRoute = Char91Char93SlugRouteImport.update({
   id: '/-/$slug',
   path: '/-/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const Char91Char93GithubRoute = Char91Char93GithubRouteImport.update({
+  id: '/-/github',
+  path: '/-/github',
   getParentRoute: () => rootRouteImport,
 } as any)
 const Char91Char93SponsoringRoute = Char91Char93SponsoringRouteImport.update({
@@ -123,6 +129,7 @@ export interface FileRoutesByFullPath {
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/sponsoring': typeof SponsoringRoute
   '/-/$slug': typeof Char91Char93SlugRoute
+  '/-/github': typeof Char91Char93GithubRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
@@ -142,6 +149,7 @@ export interface FileRoutesByTo {
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/sponsoring': typeof SponsoringRoute
   '/-/$slug': typeof Char91Char93SlugRoute
+  '/-/github': typeof Char91Char93GithubRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
@@ -162,6 +170,7 @@ export interface FileRoutesById {
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/sponsoring': typeof SponsoringRoute
   '/-/$slug': typeof Char91Char93SlugRoute
+  '/-/github': typeof Char91Char93GithubRoute
   '/-/sponsoring': typeof Char91Char93SponsoringRoute
   '/company/$slug': typeof CompanySlugRoute
   '/embed/$user': typeof EmbedUserRoute
@@ -183,6 +192,7 @@ export interface FileRouteTypes {
     | '/sitemap.xml'
     | '/sponsoring'
     | '/-/$slug'
+    | '/-/github'
     | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
@@ -202,6 +212,7 @@ export interface FileRouteTypes {
     | '/sitemap.xml'
     | '/sponsoring'
     | '/-/$slug'
+    | '/-/github'
     | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
@@ -221,6 +232,7 @@ export interface FileRouteTypes {
     | '/sitemap.xml'
     | '/sponsoring'
     | '/-/$slug'
+    | '/-/github'
     | '/-/sponsoring'
     | '/company/$slug'
     | '/embed/$user'
@@ -241,6 +253,7 @@ export interface RootRouteChildren {
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   SponsoringRoute: typeof SponsoringRoute
   Char91Char93SlugRoute: typeof Char91Char93SlugRoute
+  Char91Char93GithubRoute: typeof Char91Char93GithubRoute
   Char91Char93SponsoringRoute: typeof Char91Char93SponsoringRoute
   CompanySlugRoute: typeof CompanySlugRoute
   EmbedUserRoute: typeof EmbedUserRoute
@@ -296,6 +309,13 @@ declare module '@tanstack/react-router' {
       path: '/-/$slug'
       fullPath: '/-/$slug'
       preLoaderRoute: typeof Char91Char93SlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/-/github': {
+      id: '/-/github'
+      path: '/-/github'
+      fullPath: '/-/github'
+      preLoaderRoute: typeof Char91Char93GithubRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/-/sponsoring': {
@@ -385,6 +405,7 @@ const rootRouteChildren: RootRouteChildren = {
   SitemapDotxmlRoute: SitemapDotxmlRoute,
   SponsoringRoute: SponsoringRoute,
   Char91Char93SlugRoute: Char91Char93SlugRoute,
+  Char91Char93GithubRoute: Char91Char93GithubRoute,
   Char91Char93SponsoringRoute: Char91Char93SponsoringRoute,
   CompanySlugRoute: CompanySlugRoute,
   EmbedUserRoute: EmbedUserRoute,

--- a/src/routes/[-].github.tsx
+++ b/src/routes/[-].github.tsx
@@ -1,0 +1,134 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { motion } from "motion/react";
+import {
+	type ChartMode,
+	CommitChart,
+	chartCaption,
+	chartTitle,
+	cumulativeSeries,
+	metricDelta,
+} from "#/components/CommitChart";
+import { ExplainerLink } from "#/components/ExplainerLink";
+import { getGithubHistory } from "#/lib/github-history";
+import { METRIC_LABEL } from "#/lib/metrics";
+
+const SITE = "https://commit-history.com";
+const URL = `${SITE}/-/github`;
+const TITLE = "GitHub activity over time";
+const DESCRIPTION =
+	"Cumulative GitHub activity, month by month, across every user tracked by Commit History.";
+
+const METRIC_PARAMS: readonly ChartMode[] = [
+	"prs",
+	"issues",
+	"reviews",
+	"repos",
+	"private",
+	"total",
+];
+
+function isMetricParam(value: unknown): value is ChartMode {
+	return (
+		typeof value === "string" && (METRIC_PARAMS as string[]).includes(value)
+	);
+}
+
+interface GithubSearch {
+	metric?: ChartMode;
+}
+
+export const Route = createFileRoute("/-/github")({
+	validateSearch: (search: Record<string, unknown>): GithubSearch =>
+		isMetricParam(search.metric) ? { metric: search.metric } : {},
+	loader: () => getGithubHistory(),
+	head: () => ({
+		meta: [
+			{ title: `${TITLE} · Commit History` },
+			{ name: "description", content: DESCRIPTION },
+			{ property: "og:title", content: TITLE },
+			{ property: "og:description", content: DESCRIPTION },
+			{ property: "og:url", content: URL },
+			{ name: "twitter:title", content: TITLE },
+			{ name: "twitter:description", content: DESCRIPTION },
+		],
+		links: [{ rel: "canonical", href: URL }],
+	}),
+	component: GithubActivity,
+});
+
+function Stat({ label, value }: { label: string; value: string }) {
+	return (
+		<div>
+			<div className="text-xl font-semibold tabular-nums">{value}</div>
+			<div className="text-xs uppercase tracking-wide text-muted-foreground">
+				{label}
+			</div>
+		</div>
+	);
+}
+
+function GithubActivity() {
+	const { points, trackedUsers } = Route.useLoaderData();
+	const { metric: mode = "public" } = Route.useSearch();
+	const total = cumulativeSeries(points, mode).at(-1) ?? 0;
+	const busiest = points.reduce(
+		(best, point) =>
+			metricDelta(point, mode) > metricDelta(best, mode) ? point : best,
+		points[0],
+	);
+	const title =
+		mode === "public" ? "GitHub Commit History" : `GitHub ${chartTitle(mode)}`;
+
+	return (
+		<main className="mx-auto max-w-3xl px-6 py-12">
+			<Link
+				to="/"
+				className="text-sm text-muted-foreground hover:text-foreground"
+			>
+				← commit-history
+			</Link>
+			<h1 className="mt-6 text-3xl font-bold leading-tight">{TITLE}</h1>
+			<p className="mt-3 max-w-2xl text-muted-foreground">{DESCRIPTION}</p>
+
+			{points.length === 0 ? (
+				<p className="mt-10 rounded-xl border border-border p-6 text-muted-foreground">
+					No tracked monthly activity is available yet.
+				</p>
+			) : (
+				<>
+					<div className="mt-8 flex flex-wrap gap-10">
+						<Stat label="Tracked users" value={trackedUsers.toLocaleString()} />
+						<Stat label={METRIC_LABEL[mode]} value={total.toLocaleString()} />
+						<Stat
+							label="Busiest month"
+							value={`${new Date(busiest.date).toLocaleDateString("en-US", { month: "short", year: "numeric" })} (+${metricDelta(busiest, mode).toLocaleString()})`}
+						/>
+					</div>
+					<motion.div
+						initial={{ opacity: 0, filter: "blur(8px)" }}
+						animate={{ opacity: 1, filter: "blur(0px)" }}
+						transition={{ duration: 0.5 }}
+						className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
+					>
+						<CommitChart points={points} mode={mode} title={title} />
+					</motion.div>
+					<p className="mt-2 text-xs text-muted-foreground sm:mt-4">
+						{chartCaption(mode)} across {trackedUsers.toLocaleString()} users
+						tracked by Commit History. <ExplainerLink metric={mode} />
+					</p>
+				</>
+			)}
+
+			<section className="mt-14 border-t border-border pt-8 text-sm text-muted-foreground">
+				<h2 className="font-semibold text-foreground">What this includes</h2>
+				<p className="mt-2 max-w-2xl">
+					Each point is the sum of the completed calendar months stored for
+					tracked user profiles. Organizations are excluded so member work is
+					never counted twice; profiles under review and unreachable profiles
+					remain in the historical total. This is a growing sample of tracked
+					GitHub users, not a census of all GitHub activity.
+				</p>
+			</section>
+		</main>
+	);
+}

--- a/src/routes/[-].github.tsx
+++ b/src/routes/[-].github.tsx
@@ -41,18 +41,32 @@ export const Route = createFileRoute("/-/github")({
 	validateSearch: (search: Record<string, unknown>): GithubSearch =>
 		isMetricParam(search.metric) ? { metric: search.metric } : {},
 	loader: () => getGithubHistory(),
-	head: () => ({
-		meta: [
-			{ title: `${TITLE} · Commit History` },
-			{ name: "description", content: DESCRIPTION },
-			{ property: "og:title", content: TITLE },
-			{ property: "og:description", content: DESCRIPTION },
-			{ property: "og:url", content: URL },
-			{ name: "twitter:title", content: TITLE },
-			{ name: "twitter:description", content: DESCRIPTION },
-		],
-		links: [{ rel: "canonical", href: URL }],
-	}),
+	head: ({ match }: { match: { search: GithubSearch } }) => {
+		const metric = match.search.metric;
+		const ogImage = `${SITE}/og/github${metric ? `?metric=${metric}` : ""}`;
+		return {
+			meta: [
+				{ title: `${TITLE} · Commit History` },
+				{ name: "description", content: DESCRIPTION },
+				{ property: "og:title", content: TITLE },
+				{ property: "og:description", content: DESCRIPTION },
+				{ property: "og:url", content: URL },
+				{ property: "og:image", content: ogImage },
+				{
+					property: "og:image:alt",
+					content: "GitHub activity across tracked users",
+				},
+				{ name: "twitter:title", content: TITLE },
+				{ name: "twitter:description", content: DESCRIPTION },
+				{ name: "twitter:image", content: ogImage },
+				{
+					name: "twitter:image:alt",
+					content: "GitHub activity across tracked users",
+				},
+			],
+			links: [{ rel: "canonical", href: URL }],
+		};
+	},
 	component: GithubActivity,
 });
 

--- a/src/routes/[-].github.tsx
+++ b/src/routes/[-].github.tsx
@@ -16,7 +16,7 @@ const SITE = "https://commit-history.com";
 const URL = `${SITE}/-/github`;
 const TITLE = "GitHub activity over time";
 const DESCRIPTION =
-	"Cumulative GitHub activity, month by month, across every user tracked by Commit History.";
+	"GitHub contribution statistics over time: cumulative commits, pull requests, issues, reviews, repositories, and private contributions across tracked GitHub users.";
 
 const METRIC_PARAMS: readonly ChartMode[] = [
 	"prs",
@@ -46,8 +46,16 @@ export const Route = createFileRoute("/-/github")({
 		const ogImage = `${SITE}/og/github${metric ? `?metric=${metric}` : ""}`;
 		return {
 			meta: [
-				{ title: `${TITLE} · Commit History` },
+				{
+					title:
+						"GitHub activity over time — contribution totals | Commit History",
+				},
 				{ name: "description", content: DESCRIPTION },
+				{
+					name: "keywords",
+					content:
+						"GitHub statistics, GitHub contribution graph, GitHub commits over time, GitHub activity, GitHub totals",
+				},
 				{ property: "og:title", content: TITLE },
 				{ property: "og:description", content: DESCRIPTION },
 				{ property: "og:url", content: URL },
@@ -65,6 +73,34 @@ export const Route = createFileRoute("/-/github")({
 				},
 			],
 			links: [{ rel: "canonical", href: URL }],
+			scripts: [
+				{
+					type: "application/ld+json",
+					children: JSON.stringify({
+						"@context": "https://schema.org",
+						"@type": ["Dataset", "CollectionPage"],
+						name: TITLE,
+						description: DESCRIPTION,
+						url: URL,
+						keywords: [
+							"GitHub statistics",
+							"GitHub contribution graph",
+							"GitHub commits",
+							"GitHub activity",
+						],
+						variableMeasured: [
+							"public commits",
+							"pull requests",
+							"issues",
+							"pull-request reviews",
+							"repositories created",
+							"private contributions",
+						],
+						isBasedOn:
+							"Monthly contribution data stored for tracked public GitHub users.",
+					}),
+				},
+			],
 		};
 	},
 	component: GithubActivity,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { BadgeCheck } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
+import { metricDelta } from "#/components/CommitChart";
 import { ExplainerLink } from "#/components/ExplainerLink";
 import { SponsorRow } from "#/components/SponsorRow";
 import {
@@ -14,6 +15,7 @@ import {
 	type LeaderMode,
 	type RecentEntry,
 } from "#/lib/commit-history";
+import { getGithubHistory } from "#/lib/github-history";
 import { getOrgLeaderboard, type OrgLeaderEntry } from "#/lib/org";
 import { cn } from "#/lib/utils";
 
@@ -97,16 +99,20 @@ export const Route = createFileRoute("/")({
 	loaderDeps: ({ search }) => ({ kind: search.kind }),
 	loader: async ({ deps }) => {
 		if (deps.kind === "org") {
-			const [recent, orgs] = await Promise.all([
+			const [recent, orgs, github] = await Promise.all([
 				getRecentLookups(),
 				getOrgLeaderboard({
 					data: { offset: 0, limit: ORG_PAGE_SIZE },
 				}),
+				getGithubHistory(),
 			]);
-			return { recent, leaderboard: [] as LeaderEntry[], orgs };
+			return { recent, leaderboard: [] as LeaderEntry[], orgs, github };
 		}
-		const start = await getStartPageData();
-		return { ...start, orgs: [] as OrgLeaderEntry[] };
+		const [start, github] = await Promise.all([
+			getStartPageData(),
+			getGithubHistory(),
+		]);
+		return { ...start, orgs: [] as OrgLeaderEntry[], github };
 	},
 	component: Home,
 });
@@ -149,9 +155,9 @@ function Home() {
 				Commit History
 			</h1>
 			<p className="mt-4 text-center text-lg text-muted-foreground">
-				A <span className="accent-text font-medium">star-history</span>, but for
-				a GitHub user’s cumulative commits over their whole lifetime.
+				A GitHub user’s cumulative commits over their whole lifetime.
 			</p>
+			<GithubTotal history={initial.github} />
 
 			<form onSubmit={submit} className="mt-10 flex items-stretch gap-2">
 				<div className="flex min-w-0 flex-1 items-center rounded-md border shadow-inner focus-within:shadow-[0_0_0_0.125em_var(--ring)]">
@@ -194,6 +200,35 @@ function Home() {
 				</Link>
 			</p>
 		</main>
+	);
+}
+
+function GithubTotal({
+	history,
+}: {
+	history: Awaited<ReturnType<typeof getGithubHistory>>;
+}) {
+	const months = history.points.map((point) => metricDelta(point, "total"));
+	const latest = months.at(-1) ?? 0;
+	const total = months.reduce((sum, value) => sum + value, 0);
+	const previousTotal = total - latest;
+	if (history.points.length === 0 || previousTotal <= 0) return null;
+	const change = (latest / previousTotal) * 100;
+	const month = history.points.at(-1)?.date;
+	const monthLabel = month
+		? new Date(month).toLocaleDateString("en-US", {
+				month: "long",
+				year: "numeric",
+			})
+		: "the last completed month";
+	return (
+		<p className="mt-2 text-center text-sm text-muted-foreground">
+			Tracked GitHub activity totals{" "}
+			<Link to="/-/github" className="accent-text font-medium hover:underline">
+				{total.toLocaleString()} contributions
+			</Link>
+			, a {change.toFixed(1)}% change in {monthLabel}.
+		</p>
 	);
 }
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -209,25 +209,19 @@ function GithubTotal({
 	history: Awaited<ReturnType<typeof getGithubHistory>>;
 }) {
 	const months = history.points.map((point) => metricDelta(point, "total"));
-	const latest = months.at(-1) ?? 0;
 	const total = months.reduce((sum, value) => sum + value, 0);
-	const previousTotal = total - latest;
-	if (history.points.length === 0 || previousTotal <= 0) return null;
-	const change = (latest / previousTotal) * 100;
-	const month = history.points.at(-1)?.date;
-	const monthLabel = month
-		? new Date(month).toLocaleDateString("en-US", {
-				month: "long",
-				year: "numeric",
-			})
-		: "the last completed month";
+	if (history.points.length === 0) return null;
 	return (
 		<p className="mt-2 text-center text-sm text-muted-foreground">
 			Tracked GitHub activity totals{" "}
-			<Link to="/-/github" className="accent-text font-medium hover:underline">
+			<Link
+				to="/-/github"
+				search={{ metric: "total" }}
+				className="accent-text font-medium hover:underline"
+			>
 				{total.toLocaleString()} contributions
 			</Link>
-			, a {change.toFixed(1)}% change in {monthLabel}.
+			.
 		</p>
 	);
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -182,6 +182,12 @@ function Home() {
 				)
 			)}
 			<p className="mt-14 text-center text-sm text-muted-foreground">
+				<Link to="/-/github" className="underline hover:text-foreground">
+					GitHub activity over time
+				</Link>
+				<span className="px-2" aria-hidden="true">
+					·
+				</span>
 				Wondering what these numbers mean?{" "}
 				<Link to="/-/metrics" className="underline hover:text-foreground">
 					The metrics, explained

--- a/src/routes/og.github.tsx
+++ b/src/routes/og.github.tsx
@@ -1,0 +1,57 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { type ChartMode, metricDelta } from "#/components/CommitChart";
+import { queryGithubHistory } from "#/lib/github-history";
+import { METRIC_NOUN } from "#/lib/metrics";
+import { githubCard, renderPng } from "#/lib/og-card";
+
+const PNG_HEADERS = {
+	"content-type": "image/png",
+	"x-robots-tag": "noindex",
+	"cache-control": "public, max-age=3600, s-maxage=3600",
+	"netlify-cdn-cache-control":
+		"public, durable, s-maxage=3600, stale-while-revalidate=86400",
+};
+
+const METRICS: readonly ChartMode[] = [
+	"public",
+	"prs",
+	"issues",
+	"reviews",
+	"repos",
+	"private",
+	"total",
+];
+
+function metricFrom(request: Request): ChartMode {
+	const value = new URL(request.url).searchParams.get("metric");
+	return value && (METRICS as string[]).includes(value)
+		? (value as ChartMode)
+		: "public";
+}
+
+/** Dynamic Open Graph card for /-/github, including the selected aggregate metric's live curve. */
+export const Route = createFileRoute("/og/github")({
+	server: {
+		handlers: {
+			GET: async ({ request }) => {
+				const metric = metricFrom(request);
+				try {
+					const { points, trackedUsers } = await queryGithubHistory();
+					const values = points.map((point) => metricDelta(point, metric));
+					const total = values.reduce((sum, value) => sum + value, 0);
+					const png = await renderPng(
+						githubCard({
+							metricLabel: METRIC_NOUN[metric],
+							total,
+							trackedUsers,
+							trendValues: values,
+						}),
+					);
+					return new Response(new Uint8Array(png), { headers: PNG_HEADERS });
+				} catch {
+					return new Response(null, { status: 503, headers: PNG_HEADERS });
+				}
+			},
+		},
+	},
+});

--- a/src/routes/sitemap[.]xml.tsx
+++ b/src/routes/sitemap[.]xml.tsx
@@ -27,6 +27,7 @@ function renderSitemap(): string {
 	const today = new Date().toISOString().slice(0, 10);
 	const entries: SitemapEntry[] = [
 		{ path: "/", changefreq: "weekly", priority: "1.0", lastmod: today },
+		{ path: "/-/github", changefreq: "daily", priority: "0.8", lastmod: today },
 		{ path: "/-/metrics", changefreq: "monthly", priority: "0.8" },
 		{ path: "/-/sponsoring", changefreq: "monthly", priority: "0.5" },
 		...articles.map((a) => ({


### PR DESCRIPTION
## Summary
- add /-/github with cumulative monthly activity across tracked users
- add a live Open Graph card that mirrors the user-card trend visual and follows the selected metric
- surface the tracked GitHub total and month-over-month change in the home hero, linking to the aggregate page
- replace the star-history homage copy in the hero and top navigation
- add search-focused metadata and Dataset/CollectionPage structured data

## Data scope
- sums existing monthly_commits rows for user entities only
- excludes organizations to avoid double-counting member activity
- includes historical rows for suspended and unreachable users
- no schema changes or new migration required

## Verification
- pnpm check
- pnpm test -- og-card.test.ts github-history.test.ts
- pnpm build
- rendered the live Open Graph PNG against the dev database