### PR TITLE
Disable GitHub-wide activity history in production

### DIFF
--- a/src/lib/github-history.test.ts
+++ b/src/lib/github-history.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { cumulativeGithubPoints } from "#/lib/github-history";
+import {
+	cumulativeGithubPoints,
+	isGithubHistoryEnabled,
+} from "#/lib/github-history";
+
+describe("isGithubHistoryEnabled", () => {
+	it("disables the expensive aggregate in production only", () => {
+		expect(isGithubHistoryEnabled({ NODE_ENV: "production" })).toBe(false);
+		expect(isGithubHistoryEnabled({ NODE_ENV: "development" })).toBe(true);
+		expect(isGithubHistoryEnabled({})).toBe(true);
+	});
+});
 
 describe("cumulativeGithubPoints", () => {
 	it("accumulates each monthly metric without mixing public and private commits", () => {

--- a/src/lib/github-history.ts
+++ b/src/lib/github-history.ts
@@ -20,6 +20,16 @@ export interface GithubHistory {
 }
 
 /**
+ * The site-wide history scans every stored monthly contribution row. Keep it available while
+ * developing the replacement aggregate locally, but do not let it hold up production navigation.
+ */
+export function isGithubHistoryEnabled(
+	env: Pick<NodeJS.ProcessEnv, "NODE_ENV"> = process.env,
+): boolean {
+	return env.NODE_ENV !== "production";
+}
+
+/**
  * Adds cumulative values to aggregate monthly rows. Kept separate from the database query so
  * the public interface is easy to exercise without a database and every chart receives the same
  * `CommitPoint` shape as an individual profile.
@@ -101,5 +111,10 @@ export async function queryGithubHistory(): Promise<GithubHistory> {
 
 /** Aggregate time series for the public GitHub activity page. */
 export const getGithubHistory = createServerFn({ method: "GET" }).handler(
-	(): Promise<GithubHistory> => queryGithubHistory(),
+	async (): Promise<GithubHistory & { enabled: boolean }> => {
+		if (!isGithubHistoryEnabled()) {
+			return { points: [], trackedUsers: 0, enabled: false };
+		}
+		return { ...(await queryGithubHistory()), enabled: true };
+	},
 );

--- a/src/routes/[-].github.tsx
+++ b/src/routes/[-].github.tsx
@@ -118,7 +118,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 }
 
 function GithubActivity() {
-	const { points, trackedUsers } = Route.useLoaderData();
+	const { enabled, points, trackedUsers } = Route.useLoaderData();
 	const { metric: mode = "public" } = Route.useSearch();
 	const total = cumulativeSeries(points, mode).at(-1) ?? 0;
 	const busiest = points.reduce(
@@ -140,7 +140,12 @@ function GithubActivity() {
 			<h1 className="mt-6 text-3xl font-bold leading-tight">{TITLE}</h1>
 			<p className="mt-3 max-w-2xl text-muted-foreground">{DESCRIPTION}</p>
 
-			{points.length === 0 ? (
+			{!enabled ? (
+				<p className="mt-10 rounded-xl border border-border p-6 text-muted-foreground">
+					This view is temporarily unavailable while we improve its data
+					pipeline.
+				</p>
+			) : points.length === 0 ? (
 				<p className="mt-10 rounded-xl border border-border p-6 text-muted-foreground">
 					No tracked monthly activity is available yet.
 				</p>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -208,6 +208,7 @@ function GithubTotal({
 }: {
 	history: Awaited<ReturnType<typeof getGithubHistory>>;
 }) {
+	if (!history.enabled) return null;
 	const months = history.points.map((point) => metricDelta(point, "total"));
 	const total = months.reduce((sum, value) => sum + value, 0);
 	if (history.points.length === 0) return null;

--- a/src/routes/og.github.tsx
+++ b/src/routes/og.github.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { type ChartMode, metricDelta } from "#/components/CommitChart";
-import { queryGithubHistory } from "#/lib/github-history";
+import {
+	isGithubHistoryEnabled,
+	queryGithubHistory,
+} from "#/lib/github-history";
 import { METRIC_NOUN } from "#/lib/metrics";
 import { githubCard, renderPng } from "#/lib/og-card";
 
@@ -34,6 +37,12 @@ export const Route = createFileRoute("/og/github")({
 	server: {
 		handlers: {
 			GET: async ({ request }) => {
+				if (!isGithubHistoryEnabled()) {
+					return new Response(null, {
+						status: 302,
+						headers: { location: new URL("/og.png", request.url).toString() },
+					});
+				}
 				const metric = metricFrom(request);
 				try {
 					const { points, trackedUsers } = await queryGithubHistory();


### PR DESCRIPTION
## Summary

- stop production request handlers from running the GitHub-wide monthly-history aggregate
- hide the homepage total and show a temporary-unavailable state on `/-/github`
- redirect the dynamic GitHub-history Open Graph route to the static card

This removes the 6–9 second production navigation path while preserving the feature locally for its aggregate-backed replacement.

## Follow-up

Tracked in #167.

## Verification

- `pnpm vitest run src/lib/github-history.test.ts`
- `pnpm biome check src/lib/github-history.ts src/lib/github-history.test.ts src/routes/index.tsx src/routes/[-].github.tsx src/routes/og.github.tsx`
- `pnpm build`
- production-mode local server: `/` 73ms TTFB; `/-/github` 4ms TTFB; `/og/github` redirects to `/og.png`