### PR TITLE
Bound recent lookup retention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,18 @@ the self-hosting playbook live in the private `peetzweg/devops` repo.
   `src/lib/db/index.ts` (postgres.js, "Buffer is not defined" incident) and
   `optimizeDeps.exclude` in `vite.config.ts` (@resvg/resvg-js, dev optimizer crash).
   Verify any change near this graph **in a real browser** — curl only proves SSR.
-- **Databases:** `DATABASE_URL` in `.env` should point at `commit_history_dev`
-  (reached over Tailscale: `coolify:5432`). Production (`commit_history`) is the same host,
-  used from a laptop only deliberately (moderation via `pnpm suspend`, dumps via
-  `pnpm backup`). `pnpm db:refresh-dev` resets dev to a prod copy. No DB configured →
-  the app falls back to an in-memory store; that's supported.
+- **Databases:** the local files intentionally select different databases on the same Postgres
+  host (`coolify:5432` over Tailscale): `.env` → production `commit_history`; `.env.new` →
+  development `commit_history_dev`. Never print either URL because it contains credentials;
+  verify a target safely by parsing `new URL(process.env.DATABASE_URL).pathname` and checking the
+  database name before any write. `drizzle.config.ts` loads `.env`, so an unqualified
+  `pnpm db:migrate` targets **production** in this checkout. Use explicit commands instead:
+  `node --env-file=.env.new ./node_modules/drizzle-kit/bin.cjs migrate` for development, and only
+  with deliberate production authorization use
+  `node --env-file=.env ./node_modules/drizzle-kit/bin.cjs migrate`. Node does not overwrite an
+  existing `DATABASE_URL` when the config subsequently loads `.env`, so the `.env.new` selection
+  remains effective. `pnpm db:refresh-dev` resets dev to a prod copy. No DB configured → the app
+  falls back to an in-memory store; that's supported.
 - **Ambient `GITHUB_TOKEN` in the shell shadows `.env`** and lacks `read:org` — prefix
   dev/bun script runs with `env -u GITHUB_TOKEN` when org lookups misbehave.
 

--- a/drizzle/0008_faulty_sabretooth.sql
+++ b/drizzle/0008_faulty_sabretooth.sql
@@ -1,0 +1,25 @@
+-- Lookups are UI recency state, not an event log. Retain one newest row per entity and then
+-- trim the list before making that invariant enforceable with a unique index.
+DELETE FROM "lookups"
+WHERE "id" IN (
+	SELECT "id"
+	FROM (
+		SELECT
+			"id",
+			row_number() OVER (
+				PARTITION BY "entity_id"
+				ORDER BY "searched_at" DESC, "id" DESC
+			) AS "position"
+		FROM "lookups"
+	) AS "ranked"
+	WHERE "position" > 1
+);--> statement-breakpoint
+DELETE FROM "lookups"
+WHERE "id" IN (
+	SELECT "id"
+	FROM "lookups"
+	ORDER BY "searched_at" DESC, "id" DESC
+	OFFSET 64
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "lookups_entity_id_idx" ON "lookups" USING btree ("entity_id");--> statement-breakpoint
+CREATE INDEX "lookups_searched_at_idx" ON "lookups" USING btree ("searched_at");

--- a/drizzle/0008_faulty_sabretooth.sql
+++ b/drizzle/0008_faulty_sabretooth.sql
@@ -1,5 +1,8 @@
 -- Lookups are UI recency state, not an event log. Retain one newest row per entity and then
 -- trim the list before making that invariant enforceable with a unique index.
+-- The old application keeps inserting duplicate rows until the new version is deployed. Take
+-- the write-blocking lock before cleanup so no duplicate can slip in before index creation.
+LOCK TABLE "lookups" IN SHARE MODE;--> statement-breakpoint
 DELETE FROM "lookups"
 WHERE "id" IN (
 	SELECT "id"

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,508 @@
+{
+  "id": "4ba87ded-db35-4633-9880-81fa58fcacc8",
+  "prevId": "dc0dc8cc-187f-4e69-8266-868e35b0c0e5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_commits": {
+          "name": "total_commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_restricted": {
+          "name": "total_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_issues": {
+          "name": "total_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pull_requests": {
+          "name": "total_pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_reviews": {
+          "name": "total_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_repos": {
+          "name": "total_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers": {
+          "name": "followers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following": {
+          "name": "following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_username": {
+          "name": "twitter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_node_id": {
+          "name": "github_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_at": {
+          "name": "built_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "members_enumerated_at": {
+          "name": "members_enumerated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreachable_at": {
+          "name": "unreachable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lookups": {
+      "name": "lookups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searched_at": {
+          "name": "searched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lookups_entity_id_idx": {
+          "name": "lookups_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lookups_searched_at_idx": {
+          "name": "lookups_searched_at_idx",
+          "columns": [
+            {
+              "expression": "searched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lookups_entity_id_entities_id_fk": {
+          "name": "lookups_entity_id_entities_id_fk",
+          "tableFrom": "lookups",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monthly_commits": {
+      "name": "monthly_commits",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted": {
+          "name": "restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issues": {
+          "name": "issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_requests": {
+          "name": "pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repos": {
+          "name": "repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monthly_commits_entity_id_entities_id_fk": {
+          "name": "monthly_commits_entity_id_entities_id_fk",
+          "tableFrom": "monthly_commits",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monthly_commits_entity_id_month_pk": {
+          "name": "monthly_commits_entity_id_month_pk",
+          "columns": [
+            "entity_id",
+            "month"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public_member'"
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_requests": {
+          "name": "pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issues": {
+          "name": "issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_members_member_idx": {
+          "name": "org_members_member_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_entities_id_fk": {
+          "name": "org_members_org_id_entities_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_members_member_id_entities_id_fk": {
+          "name": "org_members_member_id_entities_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_members_org_id_member_id_pk": {
+          "name": "org_members_org_id_member_id_pk",
+          "columns": [
+            "org_id",
+            "member_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785750031946,
       "tag": "0007_lonely_echo",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1787584331934,
+      "tag": "0008_faulty_sabretooth",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -455,6 +455,11 @@ const RECENT_LOOKUP_RETENTION = 64;
 export async function recordLookup(database: DB, id: string, now: Date) {
 	try {
 		await database.transaction(async (tx) => {
+			// The row cap is a global invariant. Without serialization, concurrent inserts can each
+			// prune the same previously-visible row and leave the table above the retention limit.
+			await tx.execute(
+				sql`select pg_advisory_xact_lock(hashtext('commit-history'), hashtext('recent-lookups'))`,
+			);
 			// One row per entity: revisiting a profile moves it to the front rather than storing an
 			// unbounded stream of events that the homepage would have to aggregate on every request.
 			await tx
@@ -462,7 +467,11 @@ export async function recordLookup(database: DB, id: string, now: Date) {
 				.values({ entityId: id, searchedAt: now })
 				.onConflictDoUpdate({
 					target: lookups.entityId,
-					set: { searchedAt: now },
+					// `now` is captured at request start. A slower older request can finish after a newer
+					// one, so only move recency forward.
+					set: {
+						searchedAt: sql`greatest(${lookups.searchedAt}, ${now})`,
+					},
 				});
 			await tx.execute(sql`
 				delete from ${lookups}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -470,7 +470,9 @@ export async function recordLookup(database: DB, id: string, now: Date) {
 					// `now` is captured at request start. A slower older request can finish after a newer
 					// one, so only move recency forward.
 					set: {
-						searchedAt: sql`greatest(${lookups.searchedAt}, ${now})`,
+						// Use the insert value so Drizzle applies the timestamp column's encoder in VALUES;
+						// interpolating `now` again inside raw SQL leaves postgres.js an untyped Date.
+						searchedAt: sql`greatest(${lookups.searchedAt}, excluded.searched_at)`,
 					},
 				});
 			await tx.execute(sql`

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -54,7 +54,7 @@ export async function getCommitHistory(
 ): Promise<CommitHistory> {
 	// `record: false` serves the data without writing a lookups row. Embed renders use it:
 	// they're third-party image fetches (GitHub camo, CDN cache misses), not someone searching,
-	// and counting them pollutes "recently looked up" and the all-time leaderboard.
+	// and including them would pollute the small "recently looked up" list.
 	const { now = new Date(), record = true } = opts;
 	if (!token) {
 		// Defer to the uncached path so it throws the canonical "missing token" error.
@@ -449,9 +449,31 @@ async function persistEntity(
 	}
 }
 
+/** Enough history for the UI with room for the 16-row display to turn over naturally. */
+const RECENT_LOOKUP_RETENTION = 64;
+
 export async function recordLookup(database: DB, id: string, now: Date) {
 	try {
-		await database.insert(lookups).values({ entityId: id, searchedAt: now });
+		await database.transaction(async (tx) => {
+			// One row per entity: revisiting a profile moves it to the front rather than storing an
+			// unbounded stream of events that the homepage would have to aggregate on every request.
+			await tx
+				.insert(lookups)
+				.values({ entityId: id, searchedAt: now })
+				.onConflictDoUpdate({
+					target: lookups.entityId,
+					set: { searchedAt: now },
+				});
+			await tx.execute(sql`
+				delete from ${lookups}
+				where ${lookups.id} in (
+					select ${lookups.id}
+					from ${lookups}
+					order by ${lookups.searchedAt} desc, ${lookups.id} desc
+					offset ${RECENT_LOOKUP_RETENTION}
+				)
+			`);
+		});
 	} catch {
 		/* best-effort */
 	}

--- a/src/lib/commit-history.ts
+++ b/src/lib/commit-history.ts
@@ -190,7 +190,6 @@ async function queryRecent(limit: number): Promise<RecentEntry[]> {
 			avatarUrl: entities.avatarUrl,
 			kind: entities.kind,
 			isVerified: entities.isVerified,
-			last: sql<string>`max(${lookups.searchedAt})`,
 		})
 		.from(lookups)
 		.innerJoin(entities, eq(entities.id, lookups.entityId))
@@ -202,8 +201,7 @@ async function queryRecent(limit: number): Promise<RecentEntry[]> {
 				inArray(entities.kind, ["user", "org"]),
 			),
 		)
-		.groupBy(entities.id)
-		.orderBy(desc(sql`max(${lookups.searchedAt})`))
+		.orderBy(desc(lookups.searchedAt), desc(lookups.id))
 		.limit(limit);
 	return rows.map((r) => ({
 		login: r.login,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -8,6 +8,7 @@ import {
 	serial,
 	text,
 	timestamp,
+	uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 /**
@@ -130,13 +131,23 @@ export const orgMembers = pgTable(
 	],
 );
 
-/** Every search — powers "recent lookups" and the all-time leaderboard. */
-export const lookups = pgTable("lookups", {
-	id: serial("id").primaryKey(),
-	entityId: text("entity_id")
-		.notNull()
-		.references(() => entities.id),
-	searchedAt: timestamp("searched_at", { withTimezone: true })
-		.notNull()
-		.defaultNow(),
-});
+/**
+ * A small, deduplicated recency list — this is product UI state, not an analytics event log.
+ * The writer caps it at 64 rows; the indexes make the homepage read a short ordered scan.
+ */
+export const lookups = pgTable(
+	"lookups",
+	{
+		id: serial("id").primaryKey(),
+		entityId: text("entity_id")
+			.notNull()
+			.references(() => entities.id),
+		searchedAt: timestamp("searched_at", { withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [
+		uniqueIndex("lookups_entity_id_idx").on(t.entityId),
+		index("lookups_searched_at_idx").on(t.searchedAt),
+	],
+);

--- a/src/lib/recent-lookups.test.ts
+++ b/src/lib/recent-lookups.test.ts
@@ -64,9 +64,12 @@ describe("recent lookup retention", () => {
 		);
 
 		expect(conflictConfig).toBeDefined();
-		expect(
-			sqlText(conflictConfig?.set.searchedAt as Parameters<typeof sqlText>[0]),
-		).toContain("greatest(");
+		const update = dialect.sqlToQuery(
+			conflictConfig?.set.searchedAt as Parameters<typeof sqlText>[0],
+		);
+		expect(update.sql).toContain("greatest(");
+		expect(update.sql).toContain("excluded.searched_at");
+		expect(update.params).toEqual([]);
 	});
 
 	it("blocks legacy writers before migration cleanup begins", () => {

--- a/src/lib/recent-lookups.test.ts
+++ b/src/lib/recent-lookups.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("#/lib/db", () => ({ db: null }));
+
+import { recordLookup } from "#/lib/cache";
+
+const dialect = new PgDialect();
+
+function sqlText(query: Parameters<PgDialect["sqlToQuery"]>[0]): string {
+	return dialect.sqlToQuery(query).sql;
+}
+
+describe("recent lookup retention", () => {
+	it("serializes the global upsert-and-prune invariant", async () => {
+		const operations: string[] = [];
+		const execute = vi.fn(async (query) => {
+			operations.push(sqlText(query));
+		});
+		const onConflictDoUpdate = vi.fn(async () => {
+			operations.push("upsert");
+		});
+		const transaction = vi.fn(async (callback) =>
+			callback({
+				execute,
+				insert: () => ({
+					values: () => ({ onConflictDoUpdate }),
+				}),
+			}),
+		);
+
+		await recordLookup(
+			{ transaction } as never,
+			"user:example",
+			new Date("2026-08-25T08:00:00Z"),
+		);
+
+		expect(operations).toHaveLength(3);
+		expect(operations[0]).toContain("pg_advisory_xact_lock");
+		expect(operations[1]).toBe("upsert");
+		expect(operations[2]).toContain('delete from "lookups"');
+	});
+
+	it("never replaces a newer lookup timestamp with an older request", async () => {
+		let conflictConfig: { set: { searchedAt: unknown } } | undefined;
+		const transaction = vi.fn(async (callback) =>
+			callback({
+				execute: vi.fn(async () => undefined),
+				insert: () => ({
+					values: () => ({
+						onConflictDoUpdate: vi.fn(async (config) => {
+							conflictConfig = config;
+						}),
+					}),
+				}),
+			}),
+		);
+
+		await recordLookup(
+			{ transaction } as never,
+			"user:example",
+			new Date("2026-08-25T08:00:00Z"),
+		);
+
+		expect(conflictConfig).toBeDefined();
+		expect(
+			sqlText(conflictConfig?.set.searchedAt as Parameters<typeof sqlText>[0]),
+		).toContain("greatest(");
+	});
+
+	it("blocks legacy writers before migration cleanup begins", () => {
+		const migration = readFileSync(
+			new URL("../../drizzle/0008_faulty_sabretooth.sql", import.meta.url),
+			"utf8",
+		);
+		const lock = migration.indexOf('LOCK TABLE "lookups"');
+		const firstDelete = migration.indexOf('DELETE FROM "lookups"');
+
+		expect(lock).toBeGreaterThanOrEqual(0);
+		expect(lock).toBeLessThan(firstDelete);
+	});
+});


### PR DESCRIPTION
## Summary

- replace the unbounded lookup event log with a deduplicated, 64-account recency list
- read the homepage list directly in recency order instead of aggregating all historical lookup rows
- add a migration that keeps the newest row per account, removes all but the 64 most recent accounts, and adds unique/recency indexes

## Why

The existing homepage query grouped and sorted roughly 623k lookup records on every request, taking about 1.6–2.2 seconds in production and spilling sorting work to disk. Lookup history is not used as analytics, so retaining it indefinitely has no product benefit.

## Deployment

Run `pnpm db:migrate` against production **before deploying this application version**. The runtime image does not contain Drizzle or execute migrations automatically. The migration intentionally deletes historical lookup records, retaining only the latest 64 distinct accounts.

## Verification

- `pnpm biome check src/lib/db/schema.ts src/lib/cache.ts src/lib/commit-history.ts`
- `pnpm vitest run src/lib/github-history.test.ts`
- `pnpm build`
- production-mode app connected to the current production database: homepage TTFB 0.39–0.77s (before the migration indexes; the direct read still scans the legacy table)