### PR TITLE
Show sponsor slot prices

### DIFF
--- a/src/components/SponsorRow.tsx
+++ b/src/components/SponsorRow.tsx
@@ -8,6 +8,7 @@ import {
 	type SponsorSlotId,
 } from "#/content/sponsors";
 import { sponsorSlotsQueryOptions } from "#/lib/sponsor";
+import { formatSponsorPrice, type SponsorPrice } from "#/lib/sponsor-price";
 import { cn } from "#/lib/utils";
 
 /**
@@ -35,19 +36,17 @@ export function SponsorRow({
 	ref?: React.Ref<HTMLLIElement>;
 }) {
 	const creative = SPONSORS[slot];
-	// Skipped when there is no creative: an empty slot renders the same either way, so the common
-	// case costs no RPC — and the request only ever fires for a slot with an ad to justify.
-	const { data } = useQuery({
-		...sponsorSlotsQueryOptions,
-		enabled: creative !== null,
-	});
-	const status = data?.find((s) => s.id === slot)?.status ?? "unknown";
+	// The shared lookup supplies both availability and the checkout price advertised in an empty
+	// row. React Query deduplicates this across the developer and organization leaderboards.
+	const { data } = useQuery(sponsorSlotsQueryOptions);
+	const state = data?.find((s) => s.id === slot);
+	const status = state?.status ?? "unknown";
 	// Only a definitive "available" pulls the ad. On the server, during the first paint, and through
 	// any Stripe outage the status reads "unknown" — a paying sponsor keeps their row regardless.
 	return creative && status !== "available" ? (
 		<BookedRow creative={creative} ref={ref} />
 	) : (
-		<EmptyRow ref={ref} />
+		<EmptyRow price={state?.price} ref={ref} />
 	);
 }
 
@@ -116,7 +115,13 @@ function BookedRow({
 	);
 }
 
-function EmptyRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
+function EmptyRow({
+	price,
+	ref,
+}: {
+	price?: SponsorPrice;
+	ref?: React.Ref<HTMLLIElement>;
+}) {
 	return (
 		<motion.li
 			ref={ref}
@@ -145,7 +150,7 @@ function EmptyRow({ ref }: { ref?: React.Ref<HTMLLIElement> }) {
 					</span>
 				</span>
 				<span className="shrink-0 text-right text-xs text-muted-foreground">
-					Sponsoring
+					{price ? formatSponsorPrice(price) : "Sponsoring"}
 				</span>
 			</Link>
 		</motion.li>

--- a/src/lib/sponsor-price.test.ts
+++ b/src/lib/sponsor-price.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatSponsorPrice } from "#/lib/sponsor-price";
+
+describe("formatSponsorPrice", () => {
+	it("formats a monthly dollar price without redundant cents", () => {
+		expect(
+			formatSponsorPrice({
+				unitAmount: 9900,
+				currency: "usd",
+				interval: "month",
+				intervalCount: 1,
+			}),
+		).toBe("$99/month");
+	});
+
+	it("respects currencies without minor units", () => {
+		expect(
+			formatSponsorPrice({
+				unitAmount: 12000,
+				currency: "jpy",
+				interval: "month",
+				intervalCount: 1,
+			}),
+		).toBe("¥12,000/month");
+	});
+
+	it("includes non-default interval counts", () => {
+		expect(
+			formatSponsorPrice({
+				unitAmount: 25000,
+				currency: "eur",
+				interval: "month",
+				intervalCount: 3,
+			}),
+		).toBe("€250/3 months");
+	});
+});

--- a/src/lib/sponsor-price.ts
+++ b/src/lib/sponsor-price.ts
@@ -1,0 +1,30 @@
+export interface SponsorPrice {
+	/** Amount in the currency's smallest unit, matching Stripe's `unit_amount`. */
+	unitAmount: number;
+	currency: string;
+	interval: "day" | "week" | "month" | "year";
+	intervalCount: number;
+}
+
+/** Format the recurring Stripe price consistently wherever a sponsor slot is advertised. */
+export function formatSponsorPrice(price: SponsorPrice): string {
+	const currencyDigits =
+		new Intl.NumberFormat("en-US", {
+			style: "currency",
+			currency: price.currency,
+		}).resolvedOptions().maximumFractionDigits ?? 2;
+	const amount = price.unitAmount / 10 ** currencyDigits;
+	const formattedAmount = new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: price.currency,
+		currencyDisplay: "narrowSymbol",
+		minimumFractionDigits: 0,
+		maximumFractionDigits: currencyDigits,
+	}).format(amount);
+	const period =
+		price.intervalCount === 1
+			? price.interval
+			: `${price.intervalCount} ${price.interval}s`;
+
+	return `${formattedAmount}/${period}`;
+}

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import type Stripe from "stripe";
 import type { SponsorSlotId } from "#/content/sponsors";
+import type { SponsorPrice } from "#/lib/sponsor-price";
 
 /**
  * Live per-slot sponsorship status, read from Stripe. Powers the "Rent this slot" / "Booked"
@@ -26,6 +27,8 @@ export type SlotStatus = "available" | "booked" | "unknown";
 export interface SlotState {
 	id: SponsorSlotId;
 	status: SlotStatus;
+	/** Stripe's recurring price, shown anywhere this slot is advertised. */
+	price?: SponsorPrice;
 	/** Present only when status === "available": the Stripe Payment Link to send the buyer to. */
 	buyUrl?: string;
 }
@@ -93,16 +96,31 @@ async function computeSlot(
 	if (!stripe || !env.priceId || !env.linkUrl) return { id, status: "unknown" };
 
 	// status: "all" then filter locally — the list filter takes a single status, but a slot is
-	// occupied by any of several. The slot has at most a handful of subs, so the page is tiny.
-	const subs = await stripe.subscriptions.list({
-		price: env.priceId,
-		status: "all",
-		limit: 100,
-	});
+	// occupied by any of several. Fetch the Price alongside it so every advert stays in sync with
+	// checkout. Price lookup failure must not hide a slot whose availability is still known.
+	const [subs, stripePrice] = await Promise.all([
+		stripe.subscriptions.list({
+			price: env.priceId,
+			status: "all",
+			limit: 100,
+		}),
+		stripe.prices.retrieve(env.priceId).catch(() => null),
+	]);
+	const price = sponsorPrice(stripePrice);
 	const occupied = subs.data.some((s) => OCCUPIED_STATUSES.has(s.status));
 	return occupied
-		? { id, status: "booked" }
-		: { id, status: "available", buyUrl: env.linkUrl };
+		? { id, status: "booked", price }
+		: { id, status: "available", buyUrl: env.linkUrl, price };
+}
+
+function sponsorPrice(price: Stripe.Price | null): SponsorPrice | undefined {
+	if (!price?.recurring || price.unit_amount === null) return undefined;
+	return {
+		unitAmount: price.unit_amount,
+		currency: price.currency,
+		interval: price.recurring.interval,
+		intervalCount: price.recurring.interval_count,
+	};
 }
 
 // Module-level cache: one Stripe round-trip per minute, shared across the server process (the

--- a/src/routes/[-].sponsoring.tsx
+++ b/src/routes/[-].sponsoring.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import type { SponsorSlotId } from "#/content/sponsors";
 import { type SlotState, sponsorSlotsQueryOptions } from "#/lib/sponsor";
+import { formatSponsorPrice } from "#/lib/sponsor-price";
 
 const SITE = "https://commit-history.com";
 const TITLE = "Sponsoring commit-history.com";
@@ -215,6 +216,11 @@ function SlotCard({ id, state }: { id: SponsorSlotId; state?: SlotState }) {
 				)}
 			</div>
 			<p className="mt-1 flex-1 text-sm text-muted-foreground">{meta.blurb}</p>
+			{state?.price && (
+				<p className="mt-4 text-lg font-semibold tabular-nums">
+					{formatSponsorPrice(state.price)}
+				</p>
+			)}
 			<div className="mt-4">
 				{status === "available" && state?.buyUrl ? (
 					// External Stripe-hosted checkout — full page nav, not client routing.


### PR DESCRIPTION
## Summary

- fetch each sponsor slot’s recurring price from Stripe alongside availability
- show the live price in empty leaderboard sponsor rows and sponsoring-page cards
- format currencies and billing intervals consistently, with graceful fallback when pricing is unavailable

## Verification

- `pnpm test` — 77 tests passed
- `pnpm build`
- `git diff --check`

## Notes

`pnpm exec tsc --noEmit` still reports the two existing `NODE_ENV` typing errors in `src/lib/github-history.ts` and `src/lib/github-history.test.ts`; no sponsor-related type errors are reported.