### PR TITLE
Use Payment Links as the sponsor source of truth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,16 +38,12 @@ STRIPE_SECRET_KEY=
 # Signing secret for the webhook endpoint (whsec_…) — from the dashboard webhook, or `stripe listen`.
 STRIPE_WEBHOOK_SECRET=
 
-# Developer-board slot: recurring Price id, Payment Link id (webhook deactivates it on sale), and
-# Payment Link URL (the page sends buyers here — not derivable from the id).
-SPONSOR_DEV_PRICE_ID=
+# Developer-board slot: the server fetches its checkout URL and recurring Price from this Payment
+# Link. The webhook also deactivates the Link on sale to enforce single occupancy.
 SPONSOR_DEV_PAYMENT_LINK_ID=
-SPONSOR_DEV_PAYMENT_LINK_URL=
 # Force the dev slot to show "Booked" while the legacy Rebates deal holds it (not a Stripe sub).
 # Set to 1 to override; unset/empty lets Stripe subscription state decide.
 SPONSOR_DEV_SLOT_FORCE_BOOKED=
 
-# Organization-board slot: same three values.
-SPONSOR_ORG_PRICE_ID=
+# Organization-board slot: same setup.
 SPONSOR_ORG_PAYMENT_LINK_ID=
-SPONSOR_ORG_PAYMENT_LINK_URL=

--- a/src/components/SponsorRow.test.tsx
+++ b/src/components/SponsorRow.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-query", () => ({
+	useQuery: () => ({
+		data: [
+			{
+				id: "dev",
+				status: "booked",
+				price: {
+					unitAmount: 1000,
+					currency: "usd",
+					interval: "week",
+					intervalCount: 1,
+				},
+			},
+		],
+	}),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({ children, ...props }: { children: ReactNode }) => (
+		<a {...props}>{children}</a>
+	),
+}));
+
+vi.mock("motion/react", () => ({
+	motion: {
+		li: ({
+			children,
+			...props
+		}: ComponentPropsWithoutRef<"li"> & { children: ReactNode }) => (
+			<li {...props}>{children}</li>
+		),
+	},
+}));
+
+vi.mock("#/lib/sponsor", () => ({ sponsorSlotsQueryOptions: {} }));
+
+import { SponsorRow } from "#/components/SponsorRow";
+
+describe("SponsorRow", () => {
+	it("does not advertise a booked slot as empty while its creative is pending", () => {
+		render(
+			<ul>
+				<SponsorRow slot="dev" />
+			</ul>,
+		);
+
+		expect(screen.getByText("This sponsor slot is booked")).toBeTruthy();
+		expect(screen.getByText("Sponsor announcement coming soon")).toBeTruthy();
+		expect(screen.queryByText("This sponsor slot is empty")).toBeNull();
+	});
+});

--- a/src/components/SponsorRow.tsx
+++ b/src/components/SponsorRow.tsx
@@ -46,7 +46,7 @@ export function SponsorRow({
 	return creative && status !== "available" ? (
 		<BookedRow creative={creative} ref={ref} />
 	) : (
-		<EmptyRow price={state?.price} ref={ref} />
+		<EmptyRow booked={status === "booked"} price={state?.price} ref={ref} />
 	);
 }
 
@@ -116,9 +116,11 @@ function BookedRow({
 }
 
 function EmptyRow({
+	booked,
 	price,
 	ref,
 }: {
+	booked: boolean;
 	price?: SponsorPrice;
 	ref?: React.Ref<HTMLLIElement>;
 }) {
@@ -141,16 +143,22 @@ function EmptyRow({
 				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
 					Ad
 				</span>
-				{/* Dashed placeholder where the sponsor's logo would sit — reads as "empty". */}
+				{/* Dashed placeholder where the current or future sponsor's logo will sit. */}
 				<span className="h-8 w-8 shrink-0 rounded-full border border-border border-dashed" />
 				<span className="min-w-0 flex-1">
-					<span className="block truncate">This sponsor slot is empty</span>
+					<span className="block truncate">
+						{booked
+							? "This sponsor slot is booked"
+							: "This sponsor slot is empty"}
+					</span>
 					<span className="block truncate text-xs text-muted-foreground">
-						Put your product or job posting in front of thousands of developers
+						{booked
+							? "Sponsor announcement coming soon"
+							: "Put your product or job posting in front of thousands of developers"}
 					</span>
 				</span>
 				<span className="shrink-0 text-right text-xs text-muted-foreground">
-					{price ? formatSponsorPrice(price) : "Sponsoring"}
+					{booked ? "Booked" : price ? formatSponsorPrice(price) : "Sponsoring"}
 				</span>
 			</Link>
 		</motion.li>

--- a/src/components/SponsorRow.tsx
+++ b/src/components/SponsorRow.tsx
@@ -46,7 +46,11 @@ export function SponsorRow({
 	return creative && status !== "available" ? (
 		<BookedRow creative={creative} ref={ref} />
 	) : (
-		<EmptyRow booked={status === "booked"} price={state?.price} ref={ref} />
+		<SponsorPlaceholderRow
+			booked={status === "booked"}
+			price={state?.price}
+			ref={ref}
+		/>
 	);
 }
 
@@ -115,7 +119,7 @@ function BookedRow({
 	);
 }
 
-function EmptyRow({
+function SponsorPlaceholderRow({
 	booked,
 	price,
 	ref,

--- a/src/content/sponsors.ts
+++ b/src/content/sponsors.ts
@@ -4,8 +4,8 @@
  * The creative lives in code — not a DB, not a CMS. A slot changes maybe once a quarter, a logo
  * has to be hosted somewhere regardless, and keeping it here means every change is a reviewable,
  * revertable commit. *Selling* a slot is a Stripe concern (`src/lib/sponsor.ts`); *showing* the
- * creative is this file. A fresh sale flips the /-/sponsoring page to "Booked" automatically, and
- * the entry below is added by hand once the sponsor mails their logo.
+ * creative is this file. A fresh sale flips the /-/sponsoring page and leaderboard placeholder to
+ * "Booked" automatically, and the entry below is added by hand once the sponsor mails their logo.
  *
  * An entry here is permission to show an ad, not proof the slot is still paid for: `SponsorRow`
  * hides the creative whenever Stripe reports the slot available, so a lapsed subscription can't

--- a/src/lib/sponsor-stripe.test.ts
+++ b/src/lib/sponsor-stripe.test.ts
@@ -1,0 +1,71 @@
+import type Stripe from "stripe";
+import { describe, expect, it, vi } from "vitest";
+import { loadPaymentLinkSlot } from "#/lib/sponsor-stripe";
+
+const currentPrice = {
+	id: "price_current",
+	unit_amount: 1000,
+	currency: "usd",
+	recurring: { interval: "week", interval_count: 1 },
+} as Stripe.Price;
+
+function stripeWith({
+	price = currentPrice,
+	subscriptions = [],
+}: {
+	price?: Stripe.Price | null;
+	subscriptions?: Array<Pick<Stripe.Subscription, "status">>;
+} = {}) {
+	const retrieve = vi.fn(async () => ({
+		url: "https://buy.stripe.com/current-link",
+	}));
+	const listLineItems = vi.fn(async () => ({
+		data: [{ price }],
+		has_more: false,
+	}));
+	const listSubscriptions = vi.fn(async () => ({ data: subscriptions }));
+	return {
+		stripe: {
+			paymentLinks: { retrieve, listLineItems },
+			subscriptions: { list: listSubscriptions },
+		} as unknown as Pick<Stripe, "paymentLinks" | "subscriptions">,
+		retrieve,
+		listLineItems,
+		listSubscriptions,
+	};
+}
+
+describe("loadPaymentLinkSlot", () => {
+	it("uses the Payment Link as the source of its URL, price, and occupancy key", async () => {
+		const { stripe, retrieve, listLineItems, listSubscriptions } = stripeWith();
+
+		await expect(
+			loadPaymentLinkSlot("dev", "plink_dev", stripe),
+		).resolves.toEqual({
+			id: "dev",
+			status: "available",
+			buyUrl: "https://buy.stripe.com/current-link",
+			price: {
+				unitAmount: 1000,
+				currency: "usd",
+				interval: "week",
+				intervalCount: 1,
+			},
+		});
+		expect(retrieve).toHaveBeenCalledWith("plink_dev");
+		expect(listLineItems).toHaveBeenCalledWith("plink_dev", { limit: 2 });
+		expect(listSubscriptions).toHaveBeenCalledWith({
+			price: "price_current",
+			status: "all",
+			limit: 100,
+		});
+	});
+
+	it("marks the slot booked from subscriptions on the Payment Link's current price", async () => {
+		const { stripe } = stripeWith({ subscriptions: [{ status: "active" }] });
+
+		await expect(
+			loadPaymentLinkSlot("org", "plink_org", stripe),
+		).resolves.toMatchObject({ id: "org", status: "booked" });
+	});
+});

--- a/src/lib/sponsor-stripe.test.ts
+++ b/src/lib/sponsor-stripe.test.ts
@@ -12,21 +12,31 @@ const currentPrice = {
 function stripeWith({
 	active = true,
 	price = currentPrice,
+	lineItemsError,
 	subscriptions = [],
+	subscriptionsError,
 }: {
 	active?: boolean;
 	price?: Stripe.Price | null;
+	lineItemsError?: Error;
 	subscriptions?: Array<Pick<Stripe.Subscription, "status">>;
+	subscriptionsError?: Error;
 } = {}) {
 	const retrieve = vi.fn(async () => ({
 		active,
 		url: "https://buy.stripe.com/current-link",
 	}));
-	const listLineItems = vi.fn(async () => ({
-		data: [{ price }],
-		has_more: false,
-	}));
-	const listSubscriptions = vi.fn(async () => ({ data: subscriptions }));
+	const listLineItems = vi.fn(async () => {
+		if (lineItemsError) throw lineItemsError;
+		return {
+			data: [{ price }],
+			has_more: false,
+		};
+	});
+	const listSubscriptions = vi.fn(async () => {
+		if (subscriptionsError) throw subscriptionsError;
+		return { data: subscriptions };
+	});
 	return {
 		stripe: {
 			paymentLinks: { retrieve, listLineItems },
@@ -74,6 +84,28 @@ describe("loadPaymentLinkSlot", () => {
 
 	it("keeps an inactive Link booked after its Price changes", async () => {
 		const { stripe } = stripeWith({ active: false, subscriptions: [] });
+
+		await expect(
+			loadPaymentLinkSlot("dev", "plink_dev", stripe),
+		).resolves.toMatchObject({ id: "dev", status: "booked" });
+	});
+
+	it("keeps an inactive Link booked when the subscription lookup fails", async () => {
+		const { stripe } = stripeWith({
+			active: false,
+			subscriptionsError: new Error("Stripe subscriptions unavailable"),
+		});
+
+		await expect(
+			loadPaymentLinkSlot("dev", "plink_dev", stripe),
+		).resolves.toMatchObject({ id: "dev", status: "booked" });
+	});
+
+	it("keeps an inactive Link booked when the line-item lookup fails", async () => {
+		const { stripe } = stripeWith({
+			active: false,
+			lineItemsError: new Error("Stripe line items unavailable"),
+		});
 
 		await expect(
 			loadPaymentLinkSlot("dev", "plink_dev", stripe),

--- a/src/lib/sponsor-stripe.test.ts
+++ b/src/lib/sponsor-stripe.test.ts
@@ -10,13 +10,16 @@ const currentPrice = {
 } as Stripe.Price;
 
 function stripeWith({
+	active = true,
 	price = currentPrice,
 	subscriptions = [],
 }: {
+	active?: boolean;
 	price?: Stripe.Price | null;
 	subscriptions?: Array<Pick<Stripe.Subscription, "status">>;
 } = {}) {
 	const retrieve = vi.fn(async () => ({
+		active,
 		url: "https://buy.stripe.com/current-link",
 	}));
 	const listLineItems = vi.fn(async () => ({
@@ -67,5 +70,13 @@ describe("loadPaymentLinkSlot", () => {
 		await expect(
 			loadPaymentLinkSlot("org", "plink_org", stripe),
 		).resolves.toMatchObject({ id: "org", status: "booked" });
+	});
+
+	it("keeps an inactive Link booked after its Price changes", async () => {
+		const { stripe } = stripeWith({ active: false, subscriptions: [] });
+
+		await expect(
+			loadPaymentLinkSlot("dev", "plink_dev", stripe),
+		).resolves.toMatchObject({ id: "dev", status: "booked" });
 	});
 });

--- a/src/lib/sponsor-stripe.ts
+++ b/src/lib/sponsor-stripe.ts
@@ -30,10 +30,16 @@ export async function loadPaymentLinkSlot(
 	linkId: string,
 	stripe: SponsorStripe,
 ): Promise<SlotState> {
-	const [link, lineItems] = await Promise.all([
-		stripe.paymentLinks.retrieve(linkId),
-		stripe.paymentLinks.listLineItems(linkId, { limit: 2 }),
-	]);
+	const link = await stripe.paymentLinks.retrieve(linkId);
+	// The webhook deactivates the Link as soon as a slot sells. Treat that as authoritative: when
+	// the Link is later edited to use a new Price, its existing subscription remains on the old Price
+	// and can no longer be found by the current-Price filter alone. Once Stripe confirms checkout is
+	// closed, no failure from a weaker downstream signal should advertise the slot as empty.
+	if (!link.active) return { id, status: "booked" };
+
+	const lineItems = await stripe.paymentLinks.listLineItems(linkId, {
+		limit: 2,
+	});
 	// Sponsor checkout deliberately has one required recurring line item. Refuse an ambiguous Link
 	// instead of advertising one amount while Stripe charges for a different combination of items.
 	if (lineItems.has_more || lineItems.data.length !== 1) {
@@ -48,7 +54,6 @@ export async function loadPaymentLinkSlot(
 			`Sponsor Payment Link ${linkId} must use a fixed recurring Price`,
 		);
 	}
-
 	// The current line item's Price is also the slot identity used for occupancy. The subscription
 	// list filter accepts one status, so fetch all and keep the live-ish statuses locally.
 	const subs = await stripe.subscriptions.list({
@@ -56,14 +61,9 @@ export async function loadPaymentLinkSlot(
 		status: "all",
 		limit: 100,
 	});
-	// The webhook deactivates the Link as soon as a slot sells. Treat that as authoritative too:
-	// when the Link is later edited to use a new Price, its existing subscription remains on the old
-	// Price and can no longer be found by the current-Price filter alone.
-	const occupied =
-		!link.active ||
-		subs.data.some((subscription) =>
-			OCCUPIED_STATUSES.has(subscription.status),
-		);
+	const occupied = subs.data.some((subscription) =>
+		OCCUPIED_STATUSES.has(subscription.status),
+	);
 	return occupied
 		? { id, status: "booked", price }
 		: { id, status: "available", buyUrl: link.url, price };

--- a/src/lib/sponsor-stripe.ts
+++ b/src/lib/sponsor-stripe.ts
@@ -56,9 +56,14 @@ export async function loadPaymentLinkSlot(
 		status: "all",
 		limit: 100,
 	});
-	const occupied = subs.data.some((subscription) =>
-		OCCUPIED_STATUSES.has(subscription.status),
-	);
+	// The webhook deactivates the Link as soon as a slot sells. Treat that as authoritative too:
+	// when the Link is later edited to use a new Price, its existing subscription remains on the old
+	// Price and can no longer be found by the current-Price filter alone.
+	const occupied =
+		!link.active ||
+		subs.data.some((subscription) =>
+			OCCUPIED_STATUSES.has(subscription.status),
+		);
 	return occupied
 		? { id, status: "booked", price }
 		: { id, status: "available", buyUrl: link.url, price };

--- a/src/lib/sponsor-stripe.ts
+++ b/src/lib/sponsor-stripe.ts
@@ -1,0 +1,75 @@
+import type Stripe from "stripe";
+import type { SponsorSlotId } from "#/content/sponsors";
+import type { SponsorPrice } from "#/lib/sponsor-price";
+
+export type SlotStatus = "available" | "booked" | "unknown";
+
+export interface SlotState {
+	id: SponsorSlotId;
+	status: SlotStatus;
+	/** The recurring Price currently attached to the slot's Payment Link. */
+	price?: SponsorPrice;
+	/** Present only when status === "available": Stripe's current hosted Payment Link URL. */
+	buyUrl?: string;
+}
+
+type SponsorStripe = Pick<Stripe, "paymentLinks" | "subscriptions">;
+
+const OCCUPIED_STATUSES = new Set<Stripe.Subscription.Status>([
+	"active",
+	"trialing",
+	"past_due",
+]);
+
+/**
+ * Resolve all mutable slot data from its Payment Link. The Link owns both the checkout URL and its
+ * current recurring Price, so editing it in Stripe cannot leave a stale advertised price in env.
+ */
+export async function loadPaymentLinkSlot(
+	id: SponsorSlotId,
+	linkId: string,
+	stripe: SponsorStripe,
+): Promise<SlotState> {
+	const [link, lineItems] = await Promise.all([
+		stripe.paymentLinks.retrieve(linkId),
+		stripe.paymentLinks.listLineItems(linkId, { limit: 2 }),
+	]);
+	// Sponsor checkout deliberately has one required recurring line item. Refuse an ambiguous Link
+	// instead of advertising one amount while Stripe charges for a different combination of items.
+	if (lineItems.has_more || lineItems.data.length !== 1) {
+		throw new Error(
+			`Sponsor Payment Link ${linkId} must have exactly one line item`,
+		);
+	}
+	const stripePrice = lineItems.data[0]?.price;
+	const price = sponsorPrice(stripePrice);
+	if (!stripePrice || !price) {
+		throw new Error(
+			`Sponsor Payment Link ${linkId} must use a fixed recurring Price`,
+		);
+	}
+
+	// The current line item's Price is also the slot identity used for occupancy. The subscription
+	// list filter accepts one status, so fetch all and keep the live-ish statuses locally.
+	const subs = await stripe.subscriptions.list({
+		price: stripePrice.id,
+		status: "all",
+		limit: 100,
+	});
+	const occupied = subs.data.some((subscription) =>
+		OCCUPIED_STATUSES.has(subscription.status),
+	);
+	return occupied
+		? { id, status: "booked", price }
+		: { id, status: "available", buyUrl: link.url, price };
+}
+
+function sponsorPrice(price: Stripe.Price | null): SponsorPrice | undefined {
+	if (!price?.recurring || price.unit_amount === null) return undefined;
+	return {
+		unitAmount: price.unit_amount,
+		currency: price.currency,
+		interval: price.recurring.interval,
+		intervalCount: price.recurring.interval_count,
+	};
+}

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -13,11 +13,11 @@ export type { SlotState, SlotStatus } from "#/lib/sponsor-stripe";
  * whether a slot is currently for sale.
  *
  * No database: a slot's truth lives entirely in Stripe. Env maps each slot to one Payment Link;
- * the Link supplies its hosted URL and current recurring Price. "Booked" is derived from an active
- * subscription existing on that Price, NOT from the Payment Link's `active` flag — that closes the
- * checkout→webhook race, where a link is briefly still enabled after a purchase completes. Missing
- * config or any Stripe failure yields `"unknown"`, which the page renders as the mailto fallback —
- * this feature never throws a page.
+ * the Link supplies its hosted URL and current recurring Price. A live subscription on that Price
+ * closes the checkout→webhook race, where a Link is briefly still enabled after purchase; an
+ * inactive Link is also authoritative and stays booked after its Price changes. Missing config or
+ * any Stripe failure before availability is known yields `"unknown"`, which the page renders as the
+ * mailto fallback — this feature never throws a page.
  *
  * The Stripe SDK is Node-only and this module sits in a client-reachable import graph (the
  * /-/sponsoring route imports the RPC stub + types), so `stripe` is loaded via dynamic import

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -1,7 +1,9 @@
 import { createServerFn } from "@tanstack/react-start";
 import type Stripe from "stripe";
 import type { SponsorSlotId } from "#/content/sponsors";
-import type { SponsorPrice } from "#/lib/sponsor-price";
+import { loadPaymentLinkSlot, type SlotState } from "#/lib/sponsor-stripe";
+
+export type { SlotState, SlotStatus } from "#/lib/sponsor-stripe";
 
 /**
  * Live per-slot sponsorship status, read from Stripe. Powers the "Rent this slot" / "Booked"
@@ -10,11 +12,12 @@ import type { SponsorPrice } from "#/lib/sponsor-price";
  * slot shows stays a static, manual concern (`src/content/sponsors.ts`) — this module only decides
  * whether a slot is currently for sale.
  *
- * No database: a slot's truth lives entirely in Stripe (subscription state per price) plus env
- * (which price/link maps to which slot). "Booked" is derived from an active subscription existing,
- * NOT from the Payment Link's `active` flag — that closes the checkout→webhook race, where a link
- * is briefly still enabled after a purchase completes. Missing config or any Stripe failure yields
- * `"unknown"`, which the page renders as the mailto fallback — this feature never throws a page.
+ * No database: a slot's truth lives entirely in Stripe. Env maps each slot to one Payment Link;
+ * the Link supplies its hosted URL and current recurring Price. "Booked" is derived from an active
+ * subscription existing on that Price, NOT from the Payment Link's `active` flag — that closes the
+ * checkout→webhook race, where a link is briefly still enabled after a purchase completes. Missing
+ * config or any Stripe failure yields `"unknown"`, which the page renders as the mailto fallback —
+ * this feature never throws a page.
  *
  * The Stripe SDK is Node-only and this module sits in a client-reachable import graph (the
  * /-/sponsoring route imports the RPC stub + types), so `stripe` is loaded via dynamic import
@@ -22,24 +25,9 @@ import type { SponsorPrice } from "#/lib/sponsor-price";
  * incident). A static top-level import would drag the SDK into the browser bundle.
  */
 
-export type SlotStatus = "available" | "booked" | "unknown";
-
-export interface SlotState {
-	id: SponsorSlotId;
-	status: SlotStatus;
-	/** Stripe's recurring price, shown anywhere this slot is advertised. */
-	price?: SponsorPrice;
-	/** Present only when status === "available": the Stripe Payment Link to send the buyer to. */
-	buyUrl?: string;
-}
-
 interface SlotEnv {
-	/** Recurring price the slot's subscription is billed on — the "is it booked?" lookup key. */
-	priceId?: string;
-	/** Payment Link id — the webhook deactivates this on first purchase (single-occupancy). */
+	/** Source of the slot's checkout URL, recurring Price, occupancy key, and webhook identity. */
 	linkId?: string;
-	/** Payment Link URL — the page sends the buyer here. Not derivable from the id. */
-	linkUrl?: string;
 }
 
 /** Per-slot Stripe wiring, read from env at call time (never at module load — values arrive late
@@ -47,27 +35,15 @@ interface SlotEnv {
 export function sponsorSlotEnv(): Record<SponsorSlotId, SlotEnv> {
 	return {
 		dev: {
-			priceId: process.env.SPONSOR_DEV_PRICE_ID,
 			linkId: process.env.SPONSOR_DEV_PAYMENT_LINK_ID,
-			linkUrl: process.env.SPONSOR_DEV_PAYMENT_LINK_URL,
 		},
 		org: {
-			priceId: process.env.SPONSOR_ORG_PRICE_ID,
 			linkId: process.env.SPONSOR_ORG_PAYMENT_LINK_ID,
-			linkUrl: process.env.SPONSOR_ORG_PAYMENT_LINK_URL,
 		},
 	};
 }
 
 const SLOT_IDS: readonly SponsorSlotId[] = ["dev", "org"];
-
-// A slot counts as taken while a subscription on its price is live-ish. past_due is included
-// deliberately: a lapsing sponsor is still the occupant until Stripe cancels the sub outright.
-const OCCUPIED_STATUSES = new Set<Stripe.Subscription.Status>([
-	"active",
-	"trialing",
-	"past_due",
-]);
 
 /**
  * Build a Stripe client, or null when unusable (browser, or no secret key configured). Callers
@@ -93,39 +69,13 @@ async function computeSlot(
 	if (id === "dev" && process.env.SPONSOR_DEV_SLOT_FORCE_BOOKED === "1") {
 		return { id, status: "booked" };
 	}
-	if (!stripe || !env.priceId || !env.linkUrl) return { id, status: "unknown" };
-
-	// status: "all" then filter locally — the list filter takes a single status, but a slot is
-	// occupied by any of several. Fetch the Price alongside it so every advert stays in sync with
-	// checkout. Price lookup failure must not hide a slot whose availability is still known.
-	const [subs, stripePrice] = await Promise.all([
-		stripe.subscriptions.list({
-			price: env.priceId,
-			status: "all",
-			limit: 100,
-		}),
-		stripe.prices.retrieve(env.priceId).catch(() => null),
-	]);
-	const price = sponsorPrice(stripePrice);
-	const occupied = subs.data.some((s) => OCCUPIED_STATUSES.has(s.status));
-	return occupied
-		? { id, status: "booked", price }
-		: { id, status: "available", buyUrl: env.linkUrl, price };
+	if (!stripe || !env.linkId) return { id, status: "unknown" };
+	return loadPaymentLinkSlot(id, env.linkId, stripe);
 }
 
-function sponsorPrice(price: Stripe.Price | null): SponsorPrice | undefined {
-	if (!price?.recurring || price.unit_amount === null) return undefined;
-	return {
-		unitAmount: price.unit_amount,
-		currency: price.currency,
-		interval: price.recurring.interval,
-		intervalCount: price.recurring.interval_count,
-	};
-}
-
-// Module-level cache: one Stripe round-trip per minute, shared across the server process (the
-// webhook busts it on a sale so the page flips within the round-trip, not the full 60s). Purely a
-// perf shim — the truth is always Stripe, so a cold cache after a restart just refills on next read.
+// Module-level cache: one set of Stripe lookups per minute, shared across the server process (the
+// webhook busts it on a sale so the page flips immediately, not after the full 60s). Purely a perf
+// shim — the truth is always Stripe, so a cold cache after a restart just refills on next read.
 const CACHE_MS = 60_000;
 let cache: { at: number; slots: SlotState[] } | null = null;
 


### PR DESCRIPTION
## Summary

- derive each sponsor slot’s checkout URL and recurring Price from its configured Stripe Payment Link
- use that current Link Price as the subscription occupancy key
- treat an inactive Link as booked, including after the Link is changed to a new Price
- show a booked leaderboard placeholder while the sponsor creative is pending
- remove the redundant Price ID and Payment Link URL configuration
- reject ambiguous sponsor Links that do not contain exactly one fixed recurring line item

## Why

Production advertised an inactive checkout as available. It read availability from subscriptions on a separately configured stale Price ID, while the Payment Link had moved to a new Price. A current-Price-only lookup also misses the old subscription after that change.

The Payment Link ID is now the only per-slot configuration: Stripe supplies the URL and current Price, and either an inactive Link or a live subscription marks the slot booked.

## Verification

- reproduced production showing `Available` while Stripe checkout said `The link is no longer active`
- regression test failed before the inactive-Link fix and passes afterward
- `pnpm test` — 81 tests passed
- `pnpm build`
- focused live read against the locally configured Stripe test Payment Link
- `git diff --check`

## Deployment

No new variables are required. Existing `SPONSOR_DEV_PAYMENT_LINK_ID` and `SPONSOR_ORG_PAYMENT_LINK_ID` values remain authoritative. `SPONSOR_*_PRICE_ID` and `SPONSOR_*_PAYMENT_LINK_URL` become unused and may be removed after deployment.

The actual sponsor logo/title/tagline/link still need to be added to `src/content/sponsors.ts`; until then, a sold slot displays a booked placeholder rather than claiming to be empty.

## Notes

`pnpm exec tsc --noEmit` still reports the two existing `NODE_ENV` typing errors in `src/lib/github-history.ts` and `src/lib/github-history.test.ts`; no sponsor-related type errors are reported.