### PR TITLE
Add SteadyMaps developer leaderboard sponsor

### DIFF
--- a/src/components/SponsorRow.test.tsx
+++ b/src/components/SponsorRow.test.tsx
@@ -38,6 +38,10 @@ vi.mock("motion/react", () => ({
 	},
 }));
 
+vi.mock("#/content/sponsors", () => ({
+	SPONSORS: { dev: null, org: null },
+}));
+
 vi.mock("#/lib/sponsor", () => ({ sponsorSlotsQueryOptions: {} }));
 
 import { SponsorRow } from "#/components/SponsorRow";

--- a/src/content/sponsors.ts
+++ b/src/content/sponsors.ts
@@ -43,10 +43,13 @@ export interface SponsorCreative {
 }
 
 export const SPONSORS: Record<SponsorSlotId, SponsorCreative | null> = {
-	// The Rebates.ai deal ended when its subscription lapsed — the board shows the self-advertising
-	// empty row again. Its creative (logo, the slot-5 tagline A/B test, utm_content arms) is in git
-	// history if the deal comes back.
-	dev: null,
+	dev: {
+		name: "SteadyMaps",
+		tagline: "First-party maps for business websites",
+		href: "https://steadymaps.com/?utm_source=commit-history.com&utm_medium=leaderboard&utm_campaign=commit-history_sponsorship&utm_content=developer-slot-5",
+		logo: "https://steadymaps.com/assets/steadymaps-cfd27e1a18b1.svg",
+		logoShape: "round",
+	},
 	// No paid org sponsor yet → the board shows the self-advertising empty row. When the org slot
 	// sells via Stripe, drop the sponsor's creative here and deploy.
 	org: null,


### PR DESCRIPTION
## Summary

- add SteadyMaps to the developer leaderboard sponsor slot
- use the sponsor-provided SVG logo and first-party product description
- add UTM parameters identifying commit-history.com, the leaderboard placement, sponsorship campaign, and developer slot

## Validation

- `git diff --check`
- verified the remote logo URL returns HTTP 200 with `image/svg+xml`

Full local checks were not run because dependencies are not installed in this worktree.