### PR TITLE
Refine sponsor leaderboard rows

### DIFF
--- a/src/components/SponsorRow.test.tsx
+++ b/src/components/SponsorRow.test.tsx
@@ -17,6 +17,10 @@ vi.mock("@tanstack/react-query", () => ({
 					intervalCount: 1,
 				},
 			},
+			{
+				id: "org",
+				status: "booked",
+			},
 		],
 	}),
 }));
@@ -39,7 +43,15 @@ vi.mock("motion/react", () => ({
 }));
 
 vi.mock("#/content/sponsors", () => ({
-	SPONSORS: { dev: null, org: null },
+	SPONSORS: {
+		dev: {
+			name: "Example sponsor",
+			tagline: "Example tagline",
+			href: "https://example.com",
+			logo: "https://example.com/logo.svg",
+		},
+		org: null,
+	},
 }));
 
 vi.mock("#/lib/sponsor", () => ({ sponsorSlotsQueryOptions: {} }));
@@ -50,12 +62,25 @@ describe("SponsorRow", () => {
 	it("does not advertise a booked slot as empty while its creative is pending", () => {
 		render(
 			<ul>
-				<SponsorRow slot="dev" />
+				<SponsorRow slot="org" />
 			</ul>,
 		);
 
 		expect(screen.getByText("This sponsor slot is booked")).toBeTruthy();
 		expect(screen.getByText("Sponsor announcement coming soon")).toBeTruthy();
 		expect(screen.queryByText("This sponsor slot is empty")).toBeNull();
+	});
+
+	it("shows sponsor creative without an ad prefix or avatar treatment", () => {
+		render(
+			<ul>
+				<SponsorRow slot="dev" />
+			</ul>,
+		);
+
+		expect(screen.queryByText(/^ad$/i)).toBeNull();
+		const logoClasses = screen.getByRole("img").getAttribute("class");
+		expect(logoClasses).toContain("object-contain");
+		expect(logoClasses).not.toContain("rounded-full");
 	});
 });

--- a/src/components/SponsorRow.test.tsx
+++ b/src/components/SponsorRow.test.tsx
@@ -79,6 +79,9 @@ describe("SponsorRow", () => {
 		);
 
 		expect(screen.queryByText(/^ad$/i)).toBeNull();
+		const rankGutter = screen.getByRole("link").firstElementChild;
+		expect(rankGutter?.getAttribute("aria-hidden")).toBe("true");
+		expect(rankGutter?.getAttribute("class")).toContain("w-6");
 		const logoClasses = screen.getByRole("img").getAttribute("class");
 		expect(logoClasses).toContain("object-contain");
 		expect(logoClasses).not.toContain("rounded-full");

--- a/src/components/SponsorRow.tsx
+++ b/src/components/SponsorRow.tsx
@@ -9,7 +9,6 @@ import {
 } from "#/content/sponsors";
 import { sponsorSlotsQueryOptions } from "#/lib/sponsor";
 import { formatSponsorPrice, type SponsorPrice } from "#/lib/sponsor-price";
-import { cn } from "#/lib/utils";
 
 /**
  * The sponsor slot row shown after rank 5 on a leaderboard.
@@ -90,18 +89,10 @@ function BookedRow({
 				rel="sponsored nofollow noopener"
 				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
 			>
-				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
-				    "Sponsored" on the right keeps the disclosure. */}
-				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
-					Ad
-				</span>
 				<img
 					src={creative.logo}
 					alt={creative.name}
-					className={cn(
-						"h-8 w-8 shrink-0 border border-border object-cover",
-						creative.logoShape === "square" ? "rounded-lg" : "rounded-full",
-					)}
+					className="h-8 w-8 shrink-0 object-contain"
 				/>
 				{/* Title + tagline on two lines in a lighter weight than the usernames, so the block
 				    matches the logo height and doesn't shout as loud as a real leaderboard entry. */}
@@ -142,13 +133,8 @@ function SponsorPlaceholderRow({
 				to="/-/sponsoring"
 				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
 			>
-				{/* "Ad" gutter is dropped on mobile to give the title room (it reads cramped otherwise);
-				    the right-hand label keeps the disclosure. */}
-				<span className="hidden w-6 items-center justify-center text-[10px] uppercase tracking-wide text-muted-foreground sm:flex">
-					Ad
-				</span>
 				{/* Dashed placeholder where the current or future sponsor's logo will sit. */}
-				<span className="h-8 w-8 shrink-0 rounded-full border border-border border-dashed" />
+				<span className="h-8 w-8 shrink-0 rounded-lg border border-border border-dashed" />
 				<span className="min-w-0 flex-1">
 					<span className="block truncate">
 						{booked

--- a/src/components/SponsorRow.tsx
+++ b/src/components/SponsorRow.tsx
@@ -89,6 +89,8 @@ function BookedRow({
 				rel="sponsored nofollow noopener"
 				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
 			>
+				{/* Empty rank gutter keeps the logo aligned with leaderboard avatars. */}
+				<span aria-hidden="true" className="w-6 shrink-0" />
 				<img
 					src={creative.logo}
 					alt={creative.name}
@@ -133,6 +135,8 @@ function SponsorPlaceholderRow({
 				to="/-/sponsoring"
 				className="flex w-full items-center gap-3 py-2.5 text-left hover:bg-muted"
 			>
+				{/* Empty rank gutter keeps the placeholder aligned with leaderboard avatars. */}
+				<span aria-hidden="true" className="w-6 shrink-0" />
 				{/* Dashed placeholder where the current or future sponsor's logo will sit. */}
 				<span className="h-8 w-8 shrink-0 rounded-lg border border-border border-dashed" />
 				<span className="min-w-0 flex-1">

--- a/src/content/sponsors.ts
+++ b/src/content/sponsors.ts
@@ -33,8 +33,6 @@ export interface SponsorCreative {
 	href: string;
 	/** Logo image URL (the sponsor mails it; hosted on their domain or in /public). */
 	logo: string;
-	/** Users' avatars are round, orgs' are square — match the board the slot sits on. */
-	logoShape?: "round" | "square";
 	/**
 	 * Optional A/B test on the tagline. When present the row flips to a random arm on the client;
 	 * `tagline`/`href` above stay the SSR/first-paint control so hydration matches.
@@ -48,7 +46,6 @@ export const SPONSORS: Record<SponsorSlotId, SponsorCreative | null> = {
 		tagline: "First-party maps for business websites",
 		href: "https://steadymaps.com/?utm_source=commit-history.com&utm_medium=leaderboard&utm_campaign=commit-history_sponsorship&utm_content=developer-slot-5",
 		logo: "https://steadymaps.com/assets/steadymaps-cfd27e1a18b1.svg",
-		logoShape: "round",
 	},
 	// No paid org sponsor yet → the board shows the self-advertising empty row. When the org slot
 	// sells via Stripe, drop the sponsor's creative here and deploy.


### PR DESCRIPTION
## Summary
- remove the small AD gutter from sponsor and placeholder rows
- render sponsor logos in their natural shape without avatar borders or clipping
- keep the placeholder visually distinct with a softly rounded dashed box
- cover the presentation behavior with generic sponsor test data

## Validation
- `pnpm test -- --run` (84 tests passed)
- `pnpm exec biome check src/components/SponsorRow.tsx src/components/SponsorRow.test.tsx src/content/sponsors.ts`
- `git diff --check`

## Existing issue
- `pnpm exec tsc --noEmit` still reports the pre-existing `NODE_ENV` typing errors in `src/lib/github-history.ts` and `src/lib/github-history.test.ts` from `main`.