### PR TITLE
Preserve GitHub profile identity across login changes

### DIFF
--- a/drizzle/0009_profile_identity.sql
+++ b/drizzle/0009_profile_identity.sql
@@ -1,0 +1,22 @@
+-- Do not guess which history owns a duplicated immutable identity. A failed deploy leaves the
+-- existing schema and data untouched, with the conflicting node ids in the exception for an
+-- operator to inspect and reconcile deliberately.
+DO $$
+DECLARE duplicate_node_ids text;
+BEGIN
+	SELECT string_agg("github_node_id", ', ' ORDER BY "github_node_id")
+	INTO duplicate_node_ids
+	FROM (
+		SELECT "github_node_id"
+		FROM "entities"
+		WHERE "kind" = 'user' AND "github_node_id" IS NOT NULL
+		GROUP BY "github_node_id"
+		HAVING count(*) > 1
+	) AS duplicates;
+
+	IF duplicate_node_ids IS NOT NULL THEN
+		RAISE EXCEPTION 'Duplicate GitHub user node ids must be reconciled before migration: %', duplicate_node_ids;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "entities_user_github_node_id_idx" ON "entities" USING btree ("github_node_id") WHERE "kind" = 'user' AND "github_node_id" IS NOT NULL;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,525 @@
+{
+  "id": "688d47c6-d048-45fe-acd1-479d8fbc8c7a",
+  "prevId": "4ba87ded-db35-4633-9880-81fa58fcacc8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_commits": {
+          "name": "total_commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_restricted": {
+          "name": "total_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_issues": {
+          "name": "total_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pull_requests": {
+          "name": "total_pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_reviews": {
+          "name": "total_reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_repos": {
+          "name": "total_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followers": {
+          "name": "followers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following": {
+          "name": "following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_repos": {
+          "name": "public_repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_username": {
+          "name": "twitter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_node_id": {
+          "name": "github_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "built_at": {
+          "name": "built_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "members_enumerated_at": {
+          "name": "members_enumerated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unreachable_at": {
+          "name": "unreachable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "entities_user_github_node_id_idx": {
+          "name": "entities_user_github_node_id_idx",
+          "columns": [
+            {
+              "expression": "github_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"entities\".\"kind\" = 'user' AND \"entities\".\"github_node_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lookups": {
+      "name": "lookups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searched_at": {
+          "name": "searched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lookups_entity_id_idx": {
+          "name": "lookups_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lookups_searched_at_idx": {
+          "name": "lookups_searched_at_idx",
+          "columns": [
+            {
+              "expression": "searched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lookups_entity_id_entities_id_fk": {
+          "name": "lookups_entity_id_entities_id_fk",
+          "tableFrom": "lookups",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monthly_commits": {
+      "name": "monthly_commits",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted": {
+          "name": "restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issues": {
+          "name": "issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_requests": {
+          "name": "pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "repos": {
+          "name": "repos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monthly_commits_entity_id_entities_id_fk": {
+          "name": "monthly_commits_entity_id_entities_id_fk",
+          "tableFrom": "monthly_commits",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monthly_commits_entity_id_month_pk": {
+          "name": "monthly_commits_entity_id_month_pk",
+          "columns": [
+            "entity_id",
+            "month"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public_member'"
+        },
+        "commits": {
+          "name": "commits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pull_requests": {
+          "name": "pull_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviews": {
+          "name": "reviews",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issues": {
+          "name": "issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched": {
+          "name": "last_fetched",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "org_members_member_idx": {
+          "name": "org_members_member_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_entities_id_fk": {
+          "name": "org_members_org_id_entities_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_members_member_id_entities_id_fk": {
+          "name": "org_members_member_id_entities_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_members_org_id_member_id_pk": {
+          "name": "org_members_org_id_member_id_pk",
+          "columns": [
+            "org_id",
+            "member_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1787584331934,
       "tag": "0008_faulty_sabretooth",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1788164420463,
+      "tag": "0009_profile_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/cache-identity.test.ts
+++ b/src/lib/cache-identity.test.ts
@@ -1,0 +1,192 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Profile } from "#/lib/github";
+
+const mocks = vi.hoisted(() => {
+	const profile: Profile = {
+		nodeId: "U_new_owner",
+		login: "shared-login",
+		name: "Current owner",
+		avatarUrl: "https://avatars.example/current",
+		createdAt: "2026-07-01T00:00:00.000Z",
+		bio: null,
+		company: null,
+		location: null,
+		websiteUrl: null,
+		twitterUsername: null,
+		followers: 1,
+		following: 2,
+		publicRepos: 3,
+	};
+	const now = new Date("2026-08-31T08:00:00.000Z");
+	const entityRow = (
+		id: string,
+		nodeId: string,
+		lastFetched: Date,
+		name: string,
+	) => ({
+		id,
+		kind: "user",
+		login: profile.login,
+		name,
+		avatarUrl: "",
+		htmlUrl: `https://github.com/${profile.login}`,
+		createdAt: new Date(profile.createdAt),
+		totalCommits: 7,
+		totalRestricted: 0,
+		totalIssues: 0,
+		totalPullRequests: 0,
+		totalReviews: 0,
+		totalRepos: 0,
+		followers: 0,
+		following: 0,
+		publicRepos: 0,
+		bio: null,
+		company: null,
+		location: null,
+		websiteUrl: null,
+		twitterUsername: null,
+		isVerified: null,
+		githubNodeId: nodeId,
+		memberCount: null,
+		lastFetched,
+		builtAt: now,
+		membersEnumeratedAt: null,
+		suspendedAt: null,
+		suspendedReason: null,
+		unreachableAt: null,
+	});
+	return {
+		profile,
+		now,
+		entityRow,
+		candidateRows: [] as ReturnType<typeof entityRow>[],
+		monthRows: [] as Array<Record<string, unknown>>,
+		candidateClauses: [] as unknown[],
+		monthClauses: [] as unknown[],
+		fetchProfile: vi.fn(async () => profile),
+		fetchMonthlyCommits: vi.fn(async () => []),
+		saveProfileIdentity: vi.fn(),
+	};
+});
+
+vi.mock("#/lib/db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: (clause: unknown) => {
+					let limited = false;
+					return Object.assign(
+						Promise.resolve().then(() => {
+							if (!limited) mocks.monthClauses.push(clause);
+							return mocks.monthRows;
+						}),
+						{
+							limit: async () => {
+								limited = true;
+								mocks.candidateClauses.push(clause);
+								return mocks.candidateRows;
+							},
+						},
+					);
+				},
+			}),
+		}),
+	},
+}));
+
+vi.mock("#/lib/github", async (importOriginal) => ({
+	...(await importOriginal<typeof import("#/lib/github")>()),
+	fetchProfile: mocks.fetchProfile,
+	fetchMonthlyCommits: mocks.fetchMonthlyCommits,
+}));
+
+vi.mock("#/lib/profile-identity", async (importOriginal) => ({
+	...(await importOriginal<typeof import("#/lib/profile-identity")>()),
+	saveProfileIdentity: mocks.saveProfileIdentity,
+}));
+
+import { getCommitHistory } from "#/lib/cache";
+
+const dialect = new PgDialect();
+const monthsFor = (entityId: string) => [
+	{
+		entityId,
+		month: "2026-07-01",
+		commits: 7,
+		restricted: 0,
+		issues: 0,
+		pullRequests: 0,
+		reviews: 0,
+		repos: 0,
+		fetchedAt: mocks.now,
+	},
+];
+
+describe("live profile cache identity", () => {
+	beforeEach(() => {
+		mocks.candidateRows = [];
+		mocks.monthRows = [];
+		mocks.candidateClauses.length = 0;
+		mocks.monthClauses.length = 0;
+		vi.clearAllMocks();
+	});
+
+	it("serves one fresh login match without a GitHub call", async () => {
+		const cachedId = "user:shared-login";
+		mocks.candidateRows = [
+			mocks.entityRow(cachedId, "U_cached", mocks.now, "Cached owner"),
+		];
+		mocks.monthRows = monthsFor(cachedId);
+
+		const history = await getCommitHistory(mocks.profile.login, "token", {
+			now: mocks.now,
+			record: false,
+		});
+
+		expect(history.user.nodeId).toBe("U_cached");
+		expect(history.total).toBe(7);
+		expect(mocks.fetchProfile).not.toHaveBeenCalled();
+		expect(mocks.saveProfileIdentity).not.toHaveBeenCalled();
+	});
+
+	it("resolves a stale login before reading history from its current owner", async () => {
+		const oldId = "user:shared-login";
+		const resolvedId = "github-user:U_new_owner";
+		mocks.candidateRows = [
+			mocks.entityRow(
+				oldId,
+				"U_old_owner",
+				new Date("2026-08-31T07:00:00.000Z"),
+				"Previous owner",
+			),
+		];
+		mocks.monthRows = monthsFor(resolvedId);
+		mocks.saveProfileIdentity.mockResolvedValue({
+			entityId: resolvedId,
+			created: false,
+			row: mocks.entityRow(
+				resolvedId,
+				mocks.profile.nodeId,
+				mocks.now,
+				"Current owner",
+			),
+		});
+
+		const history = await getCommitHistory(mocks.profile.login, "token", {
+			now: mocks.now,
+			record: false,
+		});
+
+		expect(mocks.saveProfileIdentity).toHaveBeenCalledWith(
+			expect.anything(),
+			mocks.profile,
+		);
+		expect(history.user).toBe(mocks.profile);
+		expect(history.total).toBe(7);
+
+		const monthQuery = dialect.sqlToQuery(mocks.monthClauses[0] as never);
+		expect(monthQuery.params).toEqual([resolvedId]);
+		expect(monthQuery.params).not.toContain(oldId);
+	});
+});

--- a/src/lib/cache-memory-identity.test.ts
+++ b/src/lib/cache-memory-identity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CommitHistory, Profile } from "#/lib/github";
+
+const mocks = vi.hoisted(() => {
+	const makeProfile = (nodeId: string): Profile => ({
+		nodeId,
+		login: "recycled-memory-login",
+		name: nodeId,
+		avatarUrl: "",
+		createdAt: "2026-07-01T00:00:00.000Z",
+		bio: null,
+		company: null,
+		location: null,
+		websiteUrl: null,
+		twitterUsername: null,
+		followers: 0,
+		following: 0,
+		publicRepos: 0,
+	});
+	const history = (user: Profile): CommitHistory => ({
+		user,
+		points: [],
+		total: 0,
+		totalRestricted: 0,
+		totalIssues: 0,
+		totalPullRequests: 0,
+		totalReviews: 0,
+		totalRepos: 0,
+	});
+	const oldProfile = makeProfile("U_old_owner");
+	const newProfile = makeProfile("U_new_owner");
+	return {
+		oldProfile,
+		newProfile,
+		fetchProfile: vi.fn(async () => newProfile),
+		fetchCommitHistory: vi
+			.fn()
+			.mockResolvedValueOnce(history(oldProfile))
+			.mockResolvedValueOnce(history(newProfile)),
+	};
+});
+
+vi.mock("#/lib/db", () => ({ db: null }));
+vi.mock("#/lib/github", async (importOriginal) => ({
+	...(await importOriginal<typeof import("#/lib/github")>()),
+	fetchProfile: mocks.fetchProfile,
+	fetchCommitHistory: mocks.fetchCommitHistory,
+}));
+
+import { getCommitHistory } from "#/lib/cache";
+
+describe("in-memory profile cache identity", () => {
+	it("trusts a warm entry, then replaces it when stale ownership changes", async () => {
+		const first = await getCommitHistory("recycled-memory-login", "token", {
+			now: new Date("2026-08-31T08:00:00.000Z"),
+		});
+		const warm = await getCommitHistory("recycled-memory-login", "token", {
+			now: new Date("2026-08-31T08:00:01.000Z"),
+		});
+		const stale = await getCommitHistory("recycled-memory-login", "token", {
+			now: new Date("2026-08-31T08:01:01.000Z"),
+		});
+
+		expect(first.user.nodeId).toBe("U_old_owner");
+		expect(warm.user.nodeId).toBe("U_old_owner");
+		expect(stale.user.nodeId).toBe("U_new_owner");
+		expect(mocks.fetchProfile).toHaveBeenCalledTimes(1);
+		expect(mocks.fetchCommitHistory).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { type DB, db } from "#/lib/db";
 import { entities, lookups, monthlyCommits } from "#/lib/db/schema";
 import {
@@ -15,6 +15,10 @@ import {
 	type Profile,
 	sumContributionTypes,
 } from "#/lib/github";
+import {
+	ProfileIdentityConflictError,
+	saveProfileIdentity,
+} from "#/lib/profile-identity";
 
 /**
  * Incremental commit-history cache.
@@ -36,7 +40,7 @@ import {
  * Storage is Postgres when DATABASE_URL is set (durable + shared across instances),
  * else a per-process in-memory Map (so local dev / the app still work with no database).
  */
-const TAIL_TTL = 60_000; // serve cached untouched for 1 min — no GitHub call at all
+const TAIL_TTL = 60_000; // serve one unambiguous cached login untouched for 1 min
 
 // Months fetched + persisted per resumable step: 3 batches × 6 months (see BATCH/CONCURRENCY
 // in github.ts) = one full concurrency wave, ~5s of wall clock.
@@ -113,12 +117,6 @@ function appendTail(
 
 // ── Postgres-backed store ────────────────────────────────────────────────────
 
-function entityId(login: string) {
-	return `user:${login.trim().toLowerCase()}`;
-}
-
-type EntityRow = typeof entities.$inferSelect;
-
 const EMPTY_MONTH: MonthlyCount = {
 	commits: 0,
 	restricted: 0,
@@ -128,8 +126,11 @@ const EMPTY_MONTH: MonthlyCount = {
 	repos: 0,
 };
 
+type EntityRow = typeof entities.$inferSelect;
+
 function profileFromRow(row: EntityRow, now: Date): Profile {
 	return {
+		nodeId: row.githubNodeId ?? "",
 		login: row.login,
 		name: row.name,
 		avatarUrl: row.avatarUrl ?? "",
@@ -152,56 +153,73 @@ async function getFromDb(
 	now: Date,
 	record: boolean,
 ): Promise<CommitHistory> {
-	const id = entityId(login);
 	const nowMs = now.getTime();
 
-	let row: EntityRow | undefined;
+	let candidates: EntityRow[];
 	try {
-		[row] = await database
+		candidates = await database
 			.select()
 			.from(entities)
-			.where(eq(entities.id, id))
-			.limit(1);
+			.where(
+				and(
+					eq(entities.kind, "user"),
+					sql`lower(${entities.login}) = lower(${login.trim()})`,
+				),
+			)
+			.limit(2);
 	} catch {
-		// DB read failed — degrade to a direct fetch so the page still renders.
+		// DB lookup failed — direct fetch is safe because it cannot mix durable histories.
 		return fetchCommitHistory(login, token);
 	}
 
 	let profile: Profile;
-	if (row) {
-		profile = profileFromRow(row, now);
+	let id: string;
+	let row: EntityRow;
+	const cached = candidates.length === 1 ? candidates[0] : null;
+	if (
+		cached?.builtAt &&
+		cached.lastFetched &&
+		nowMs - cached.lastFetched.getTime() < TAIL_TTL
+	) {
+		// A unique, fresh login match keeps the established zero-GitHub-call path. Login reuse can
+		// therefore show the previous owner for at most this TTL, but never writes mixed identity data.
+		profile = profileFromRow(cached, now);
+		id = cached.id;
+		row = cached;
 	} else {
-		// First sighting: the profile fetch validates the login and yields createdAt, which
-		// defines the window range. Insert the row up front — it's the FK target for the month
-		// rows and the resume anchor if this build doesn't finish within the request.
+		// Stale, incomplete, missing, and ambiguous login matches must resolve GitHub's current
+		// immutable identity before any month is read or written.
 		profile = await fetchProfile(login, token);
+		let identity: Awaited<ReturnType<typeof saveProfileIdentity>>;
 		try {
-			await upsertProfile(database, id, profile);
-		} catch {
-			// Can't store anything without the entity row (FK) — degrade to a direct fetch.
+			identity = await saveProfileIdentity(database, profile);
+		} catch (error) {
+			if (error instanceof ProfileIdentityConflictError) {
+				throw new GitHubError(error.message, 409);
+			}
+			// DB identity storage failed — direct fetch cannot mix durable histories.
 			return fetchCommitHistory(login, token);
 		}
+		id = identity.entityId;
+		row = identity.row;
 	}
 
 	// Stored months = the immutable head of the series.
-	let monthRows: { month: string; counts: MonthlyCount }[] = [];
-	if (row) {
-		const rows = await database
-			.select()
-			.from(monthlyCommits)
-			.where(eq(monthlyCommits.entityId, id));
-		monthRows = rows.map((r) => ({
-			month: r.month,
-			counts: {
-				commits: r.commits,
-				restricted: r.restricted,
-				issues: r.issues,
-				pullRequests: r.pullRequests,
-				reviews: r.reviews,
-				repos: r.repos,
-			},
-		}));
-	}
+	const rows = await database
+		.select()
+		.from(monthlyCommits)
+		.where(eq(monthlyCommits.entityId, id));
+	const monthRows = rows.map((r) => ({
+		month: r.month,
+		counts: {
+			commits: r.commits,
+			restricted: r.restricted,
+			issues: r.issues,
+			pullRequests: r.pullRequests,
+			reviews: r.reviews,
+			repos: r.repos,
+		},
+	}));
 	const byMonth = new Map(monthRows.map((r) => [r.month, r.counts]));
 	// Labels are YYYY-MM-DD, so string order = time order.
 	const lastStored = monthRows.reduce<string | null>(
@@ -209,7 +227,7 @@ async function getFromDb(
 		null,
 	);
 
-	const createdAt = row?.createdAt ?? new Date(profile.createdAt);
+	const createdAt = row.createdAt ?? new Date(profile.createdAt);
 	const windows = monthlyWindows(createdAt, now);
 	const headWindows = lastStored
 		? windows.filter((w) => w.label <= lastStored)
@@ -226,26 +244,16 @@ async function getFromDb(
 
 	// A row only carries builtAt once its initial build completed; until then every request
 	// resumes the build regardless of TTLs.
-	const complete = row?.builtAt != null;
+	const complete = row.builtAt != null;
 
-	// Fully built + fresh → serve straight from the DB, no GitHub calls at all.
+	// Fully built + fresh → serve the contribution series straight from the DB.
 	if (
 		complete &&
-		row?.lastFetched &&
+		row.lastFetched &&
 		nowMs - row.lastFetched.getTime() < TAIL_TTL
 	) {
 		if (record) await recordLookup(database, id, now);
 		return toHistory(profile, head);
-	}
-
-	// Refresh the mutable profile metadata (followers, bio, …) — one cheap request. Skipped
-	// on first sighting, where the profile was fetched moments ago.
-	if (row) {
-		try {
-			profile = await fetchProfile(login, token);
-		} catch {
-			/* keep the stored profile */
-		}
 	}
 
 	// Fetch the outstanding months in resumable chunks, persisting each as soon as it lands.
@@ -259,7 +267,7 @@ async function getFromDb(
 				break;
 			}
 			const chunk = todo.slice(i, i + CHUNK_MONTHS);
-			const counts = await fetchMonthlyCommits(login, token, chunk);
+			const counts = await fetchMonthlyCommits(profile.login, token, chunk);
 			// `now`, not the loop's clock: monthlyWindows only ever yields completed months, so any
 			// row written here is final, and the stamp is what proves it to the monthly refresh.
 			await persistMonths(database, id, chunk, counts, now);
@@ -290,37 +298,6 @@ async function getFromDb(
 	}
 	if (record) await recordLookup(database, id, now);
 	return history;
-}
-
-/** Insert/refresh the profile columns only — never touches totals or builtAt. */
-async function upsertProfile(database: DB, id: string, user: Profile) {
-	const profileCols = {
-		name: user.name,
-		avatarUrl: user.avatarUrl,
-		followers: user.followers,
-		following: user.following,
-		publicRepos: user.publicRepos,
-		bio: user.bio,
-		company: user.company,
-		location: user.location,
-		websiteUrl: user.websiteUrl,
-		twitterUsername: user.twitterUsername,
-		// GitHub just resolved this login, so whatever made the refresh worker mark it unreachable
-		// is over (un-deleted, renamed back). This is the only path that clears the flag — the
-		// worker itself skips unreachable entities, so it can never un-mark one.
-		unreachableAt: null,
-	};
-	await database
-		.insert(entities)
-		.values({
-			id,
-			kind: "user",
-			login: user.login,
-			htmlUrl: `https://github.com/${user.login}`,
-			createdAt: new Date(user.createdAt),
-			...profileCols,
-		})
-		.onConflictDoUpdate({ target: entities.id, set: profileCols });
 }
 
 /**
@@ -395,6 +372,7 @@ async function persistEntity(
 				id,
 				kind: "user",
 				login: user.login,
+				githubNodeId: user.nodeId,
 				name: user.name,
 				avatarUrl: user.avatarUrl,
 				htmlUrl: `https://github.com/${user.login}`,
@@ -419,8 +397,12 @@ async function persistEntity(
 			.onConflictDoUpdate({
 				target: entities.id,
 				set: {
+					login: user.login,
+					githubNodeId: user.nodeId,
 					name: user.name,
 					avatarUrl: user.avatarUrl,
+					htmlUrl: `https://github.com/${user.login}`,
+					createdAt: new Date(user.createdAt),
 					totalCommits: total,
 					totalRestricted,
 					followers: user.followers,
@@ -514,8 +496,16 @@ async function getFromMemory(
 		mem.set(key, { history, fetchedAt: nowMs });
 		return history;
 	}
+
 	if (nowMs - cached.fetchedAt < TAIL_TTL) return cached.history;
 
+	// Once stale, memory mode must validate the current owner before using a login-keyed entry.
+	const profile = await fetchProfile(login, token);
+	if (profile.nodeId !== cached.history.user.nodeId) {
+		const history = await fetchCommitHistory(profile.login, token);
+		mem.set(key, { history, fetchedAt: nowMs });
+		return history;
+	}
 	const lastLabel = cached.history.points.at(-1)?.date;
 	const tailStart = lastLabel
 		? new Date(`${lastLabel}T00:00:00Z`)
@@ -523,13 +513,11 @@ async function getFromMemory(
 	const tailWindows = monthlyWindows(tailStart, now);
 
 	try {
-		const tailCounts = await fetchMonthlyCommits(login, token, tailWindows);
-		let profile = cached.history.user;
-		try {
-			profile = await fetchProfile(login, token);
-		} catch {
-			/* keep */
-		}
+		const tailCounts = await fetchMonthlyCommits(
+			profile.login,
+			token,
+			tailWindows,
+		);
 		const history = toHistory(
 			profile,
 			appendTail(cached.history.points, tailWindows, tailCounts),

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
 	boolean,
 	date,
@@ -15,60 +16,70 @@ import {
  * A tracked entity — currently a GitHub user; `kind` leaves room for orgs/repos later.
  * `id` is namespaced so the same login can't collide across kinds: e.g. "user:torvalds".
  */
-export const entities = pgTable("entities", {
-	id: text("id").primaryKey(),
-	kind: text("kind").notNull(), // 'user' | 'org' | 'repo'
-	login: text("login").notNull(),
-	name: text("name"),
-	avatarUrl: text("avatar_url"),
-	htmlUrl: text("html_url"),
-	createdAt: timestamp("created_at", { withTimezone: true }), // defines the window start
-	totalCommits: integer("total_commits").notNull().default(0), // public commits
-	totalRestricted: integer("total_restricted").notNull().default(0), // private contributions
-	// Additional public contribution-type lifetime totals. Nullable so null = "not yet backfilled
-	// with the new types" (drives the backfill script's default mode), distinct from a real 0 —
-	// same rationale as the profile-metadata columns below.
-	totalIssues: integer("total_issues"), // public issues opened
-	totalPullRequests: integer("total_pull_requests"), // public PRs opened
-	totalReviews: integer("total_reviews"), // public PR reviews
-	totalRepos: integer("total_repos"), // public repositories created
-	// Profile metadata — mutable, refreshed on the trailing-refresh path (see cache.ts). All
-	// nullable so an unknown value (older row, fetch failure) stays distinguishable from a real 0.
-	followers: integer("followers"),
-	following: integer("following"),
-	publicRepos: integer("public_repos"),
-	bio: text("bio"),
-	company: text("company"),
-	location: text("location"),
-	websiteUrl: text("website_url"),
-	twitterUsername: text("twitter_username"),
-	// Org-only metadata (null on user rows — same "unknown vs not applicable" convention).
-	isVerified: boolean("is_verified"), // org domain-verified badge
-	githubNodeId: text("github_node_id"), // GraphQL node id — keys contributionsCollection(organizationID:) without a profile round-trip
-	memberCount: integer("member_count"), // membersWithRole.totalCount (includes private members) — display only
-	lastFetched: timestamp("last_fetched", { withTimezone: true }), // staleness / trailing refresh; also "profile last updated"
-	builtAt: timestamp("built_at", { withTimezone: true }), // initial build completed; null = months still being fetched incrementally
-	// Org-only: when this org's membership was last re-read from `membersWithRole`. The org refresh
-	// worker re-enumerates monthly off this, which is how a member who joined (or made their
-	// membership public) after the initial build ever gets discovered — see #150.
-	//
-	// Deliberately NOT `lastFetched`: that column is bumped by any profile-only refresh
-	// (scripts/refresh.ts, the org-cache staleness path), which would mark the membership current
-	// when it was never re-read. Same trap #151 hit reusing it as a month-freshness gate.
-	membersEnumeratedAt: timestamp("members_enumerated_at", {
-		withTimezone: true,
-	}),
-	// Moderation: null = active. When set, the entity is hidden from the leaderboard and
-	// "recently looked up" (still directly viewable, with an under-review notice) until cleared.
-	suspendedAt: timestamp("suspended_at", { withTimezone: true }),
-	suspendedReason: text("suspended_reason"), // internal note — never shown publicly
-	// GitHub no longer resolves this login (GraphQL NOT_FOUND / REST 404) — deleted, renamed, or
-	// blocked. Deliberately NOT moderation: the contributions we already stored were real, so the
-	// entity stays ranked and viewable (with a notice). It only drops out of the monthly refresh
-	// cohort, so a dead login can't burn a request and fail the scheduled task every pass.
-	// Cleared automatically the next time the login resolves.
-	unreachableAt: timestamp("unreachable_at", { withTimezone: true }),
-});
+export const entities = pgTable(
+	"entities",
+	{
+		id: text("id").primaryKey(),
+		kind: text("kind").notNull(), // 'user' | 'org' | 'repo'
+		login: text("login").notNull(),
+		name: text("name"),
+		avatarUrl: text("avatar_url"),
+		htmlUrl: text("html_url"),
+		createdAt: timestamp("created_at", { withTimezone: true }), // defines the window start
+		totalCommits: integer("total_commits").notNull().default(0), // public commits
+		totalRestricted: integer("total_restricted").notNull().default(0), // private contributions
+		// Additional public contribution-type lifetime totals. Nullable so null = "not yet backfilled
+		// with the new types" (drives the backfill script's default mode), distinct from a real 0 —
+		// same rationale as the profile-metadata columns below.
+		totalIssues: integer("total_issues"), // public issues opened
+		totalPullRequests: integer("total_pull_requests"), // public PRs opened
+		totalReviews: integer("total_reviews"), // public PR reviews
+		totalRepos: integer("total_repos"), // public repositories created
+		// Profile metadata — mutable, refreshed on the trailing-refresh path (see cache.ts). All
+		// nullable so an unknown value (older row, fetch failure) stays distinguishable from a real 0.
+		followers: integer("followers"),
+		following: integer("following"),
+		publicRepos: integer("public_repos"),
+		bio: text("bio"),
+		company: text("company"),
+		location: text("location"),
+		websiteUrl: text("website_url"),
+		twitterUsername: text("twitter_username"),
+		// Org-only metadata (null on user rows — same "unknown vs not applicable" convention).
+		isVerified: boolean("is_verified"), // org domain-verified badge
+		githubNodeId: text("github_node_id"), // immutable GraphQL identity for users and organizations
+		memberCount: integer("member_count"), // membersWithRole.totalCount (includes private members) — display only
+		lastFetched: timestamp("last_fetched", { withTimezone: true }), // staleness / trailing refresh; also "profile last updated"
+		builtAt: timestamp("built_at", { withTimezone: true }), // initial build completed; null = months still being fetched incrementally
+		// Org-only: when this org's membership was last re-read from `membersWithRole`. The org refresh
+		// worker re-enumerates monthly off this, which is how a member who joined (or made their
+		// membership public) after the initial build ever gets discovered — see #150.
+		//
+		// Deliberately NOT `lastFetched`: that column is bumped by any profile-only refresh
+		// (scripts/refresh.ts, the org-cache staleness path), which would mark the membership current
+		// when it was never re-read. Same trap #151 hit reusing it as a month-freshness gate.
+		membersEnumeratedAt: timestamp("members_enumerated_at", {
+			withTimezone: true,
+		}),
+		// Moderation: null = active. When set, the entity is hidden from the leaderboard and
+		// "recently looked up" (still directly viewable, with an under-review notice) until cleared.
+		suspendedAt: timestamp("suspended_at", { withTimezone: true }),
+		suspendedReason: text("suspended_reason"), // internal note — never shown publicly
+		// GitHub no longer resolves this login (GraphQL NOT_FOUND / REST 404) — deleted, renamed, or
+		// blocked. Deliberately NOT moderation: the contributions we already stored were real, so the
+		// entity stays ranked and viewable (with a notice). It only drops out of the monthly refresh
+		// cohort, so a dead login can't burn a request and fail the scheduled task every pass.
+		// Cleared automatically the next time the login resolves.
+		unreachableAt: timestamp("unreachable_at", { withTimezone: true }),
+	},
+	(t) => [
+		// User-only by design: organization identity migration is a separate concern, and org rows
+		// keyed by an old login must not make this user-safety migration undeployable.
+		uniqueIndex("entities_user_github_node_id_idx")
+			.on(t.githubNodeId)
+			.where(sql`${t.kind} = 'user' AND ${t.githubNodeId} IS NOT NULL`),
+	],
+);
 
 /**
  * Per-month commit counts. GitHub's numbers for a past month are settled, but a *stored* row for

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -100,6 +100,8 @@ async function mapWithConcurrency<T, R>(
 }
 
 export interface Profile {
+	/** Immutable GraphQL identity; unlike login, this survives renames and login reuse. */
+	nodeId: string;
 	login: string;
 	name: string | null;
 	avatarUrl: string;
@@ -405,6 +407,7 @@ function assertLogin(rawLogin: string): string {
 
 /** Raw shape from GraphQL, before flattening the `{ totalCount }` connections. */
 interface RawProfile {
+	id: string;
 	login: string;
 	name: string | null;
 	avatarUrl: string;
@@ -432,7 +435,7 @@ export async function fetchProfile(
 	const data = await graphql<{ user: RawProfile | null }>(
 		token,
 		`query { user(login: "${login}") {
-			login name avatarUrl createdAt bio company location websiteUrl twitterUsername
+			id login name avatarUrl createdAt bio company location websiteUrl twitterUsername
 			followers { totalCount }
 			following { totalCount }
 			repositories(ownerAffiliations: OWNER, privacy: PUBLIC) { totalCount }
@@ -441,6 +444,7 @@ export async function fetchProfile(
 	if (!data.user) throw new GitHubError(`User "${login}" not found.`, 404);
 	const u = data.user;
 	return {
+		nodeId: u.id,
 		login: u.login,
 		name: u.name,
 		avatarUrl: u.avatarUrl,

--- a/src/lib/profile-identity-migration.test.ts
+++ b/src/lib/profile-identity-migration.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("profile identity migration", () => {
+	const migration = readFileSync(
+		new URL("../../drizzle/0009_profile_identity.sql", import.meta.url),
+		"utf8",
+	);
+
+	it("preflights duplicate user node ids before adding the invariant", () => {
+		const duplicateCheck = migration.indexOf("HAVING count(*) > 1");
+		const uniqueIndex = migration.indexOf("CREATE UNIQUE INDEX");
+
+		expect(duplicateCheck).toBeGreaterThanOrEqual(0);
+		expect(uniqueIndex).toBeGreaterThan(duplicateCheck);
+		expect(migration).toContain("Duplicate GitHub user node ids");
+	});
+
+	it("scopes node-id uniqueness to user rows so organization renames are unaffected", () => {
+		expect(migration).toContain("WHERE \"kind\" = 'user'");
+	});
+});

--- a/src/lib/profile-identity.test.ts
+++ b/src/lib/profile-identity.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { Profile } from "#/lib/github";
+import {
+	type ProfileIdentityCandidate,
+	ProfileIdentityConflictError,
+	resolveProfileIdentity,
+} from "#/lib/profile-identity";
+
+const profile = (nodeId: string, login: string): Profile => ({
+	nodeId,
+	login,
+	name: login,
+	avatarUrl: `https://avatars.example/${login}`,
+	createdAt: "2020-01-01T00:00:00.000Z",
+	bio: null,
+	company: null,
+	location: null,
+	websiteUrl: null,
+	twitterUsername: null,
+	followers: 1,
+	following: 2,
+	publicRepos: 3,
+});
+
+const candidate = (
+	id: string,
+	login: string,
+	githubNodeId: string | null,
+): ProfileIdentityCandidate => ({ id, login, githubNodeId });
+
+describe("profile identity resolution", () => {
+	it("keeps a renamed profile on the row identified by its immutable node id", () => {
+		const result = resolveProfileIdentity(profile("U_immutable", "new-login"), {
+			byNodeId: candidate("user:old-login", "old-login", "U_immutable"),
+			byCurrentLogin: [],
+		});
+
+		expect(result).toEqual({
+			entityId: "user:old-login",
+			operation: "update",
+		});
+	});
+
+	it("gives a recycled login a new row instead of the previous owner's row", () => {
+		const result = resolveProfileIdentity(
+			profile("U_new_owner", "shared-login"),
+			{
+				byNodeId: null,
+				byCurrentLogin: [
+					candidate("user:shared-login", "shared-login", "U_old_owner"),
+				],
+			},
+		);
+
+		expect(result).toEqual({
+			entityId: "github-user:U_new_owner",
+			operation: "insert",
+		});
+	});
+
+	it("claims one legacy login row when it has no immutable identity yet", () => {
+		const result = resolveProfileIdentity(profile("U_claimed", "legacy"), {
+			byNodeId: null,
+			byCurrentLogin: [candidate("user:legacy", "Legacy", null)],
+		});
+
+		expect(result).toEqual({
+			entityId: "user:legacy",
+			operation: "update",
+		});
+	});
+
+	it("fails closed when multiple legacy rows could own the current login", () => {
+		expect(() =>
+			resolveProfileIdentity(profile("U_unknown", "ambiguous"), {
+				byNodeId: null,
+				byCurrentLogin: [
+					candidate("user:ambiguous", "ambiguous", null),
+					candidate("user:legacy-alias", "Ambiguous", null),
+				],
+			}),
+		).toThrow(ProfileIdentityConflictError);
+	});
+
+	it("fails closed when the immutable node id is already duplicated", () => {
+		expect(() =>
+			resolveProfileIdentity(profile("U_duplicate", "current"), {
+				byNodeId: [
+					candidate("user:first", "first", "U_duplicate"),
+					candidate("user:second", "second", "U_duplicate"),
+				],
+				byCurrentLogin: [],
+			}),
+		).toThrow(ProfileIdentityConflictError);
+	});
+});

--- a/src/lib/profile-identity.ts
+++ b/src/lib/profile-identity.ts
@@ -1,0 +1,205 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { DB } from "#/lib/db";
+import { entities } from "#/lib/db/schema";
+import type { Profile } from "#/lib/github";
+
+type EntityRow = typeof entities.$inferSelect;
+type DBTransaction = Parameters<Parameters<DB["transaction"]>[0]>[0];
+
+export interface ProfileIdentityCandidate {
+	id: string;
+	login: string;
+	githubNodeId: string | null;
+}
+
+export class ProfileIdentityConflictError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ProfileIdentityConflictError";
+	}
+}
+
+type CandidateSet =
+	| ProfileIdentityCandidate
+	| ProfileIdentityCandidate[]
+	| null;
+
+export function resolveProfileIdentity(
+	profile: Profile,
+	candidates: {
+		byNodeId: CandidateSet;
+		byCurrentLogin: ProfileIdentityCandidate[];
+	},
+): { entityId: string; operation: "insert" | "update" } {
+	const byNodeId = candidates.byNodeId
+		? Array.isArray(candidates.byNodeId)
+			? candidates.byNodeId
+			: [candidates.byNodeId]
+		: [];
+	if (byNodeId.length > 1) {
+		throw new ProfileIdentityConflictError(
+			`GitHub user identity ${profile.nodeId} is duplicated in storage; refusing to choose a profile history.`,
+		);
+	}
+	if (byNodeId[0]) {
+		return { entityId: byNodeId[0].id, operation: "update" };
+	}
+
+	const legacyCandidates = candidates.byCurrentLogin.filter(
+		(candidate) => candidate.githubNodeId == null,
+	);
+	if (legacyCandidates.length === 1 && candidates.byCurrentLogin.length === 1) {
+		return { entityId: legacyCandidates[0].id, operation: "update" };
+	}
+	if (legacyCandidates.length > 1) {
+		throw new ProfileIdentityConflictError(
+			`GitHub login "${profile.login}" matches multiple legacy profiles; refusing to combine their histories.`,
+		);
+	}
+
+	return {
+		entityId:
+			candidates.byCurrentLogin.length === 0
+				? `user:${profile.login.trim().toLowerCase()}`
+				: `github-user:${profile.nodeId}`,
+		operation: "insert",
+	};
+}
+
+export interface StoredProfileIdentity {
+	entityId: string;
+	row: EntityRow;
+	created: boolean;
+}
+
+/**
+ * Resolve and refresh a GitHub user by immutable node id.
+ *
+ * The requested login is only a mutable locator. A row with that login but a different node id
+ * is a previous owner and is never selected. Advisory locks serialize first discovery even before
+ * the partial unique index is deployed.
+ */
+export async function saveProfileIdentity(
+	database: DB,
+	profile: Profile,
+): Promise<StoredProfileIdentity> {
+	return database.transaction(async (tx) => {
+		await tx.execute(
+			sql`select pg_advisory_xact_lock(hashtext('commit-history-profile-identity'), hashtext(${profile.nodeId}))`,
+		);
+		await tx.execute(
+			sql`select pg_advisory_xact_lock(hashtext('commit-history-profile-login'), hashtext(lower(${profile.login})))`,
+		);
+
+		const byNodeId = await tx
+			.select()
+			.from(entities)
+			.where(
+				and(
+					eq(entities.kind, "user"),
+					eq(entities.githubNodeId, profile.nodeId),
+				),
+			)
+			.limit(2);
+		const byCurrentLogin = await tx
+			.select()
+			.from(entities)
+			.where(
+				and(
+					eq(entities.kind, "user"),
+					sql`lower(${entities.login}) = lower(${profile.login})`,
+				),
+			);
+
+		const resolution = resolveProfileIdentity(profile, {
+			byNodeId,
+			byCurrentLogin,
+		});
+		if (resolution.operation === "update") {
+			return updateProfile(tx, resolution.entityId, profile, false);
+		}
+
+		const inserted = await insertProfile(tx, resolution.entityId, profile);
+		if (inserted) return inserted;
+
+		// A renamed legacy row can retain the preferred login-derived primary key. It is a
+		// different immutable identity, so retry with a node-derived opaque id instead.
+		const fallbackId = `github-user:${profile.nodeId}`;
+		if (fallbackId !== resolution.entityId) {
+			const fallback = await insertProfile(tx, fallbackId, profile);
+			if (fallback) return fallback;
+		}
+
+		const winner = await tx
+			.select()
+			.from(entities)
+			.where(
+				and(
+					eq(entities.kind, "user"),
+					eq(entities.githubNodeId, profile.nodeId),
+				),
+			)
+			.limit(2);
+		if (winner.length !== 1) {
+			throw new ProfileIdentityConflictError(
+				`Could not assign GitHub user identity ${profile.nodeId} to exactly one stored profile.`,
+			);
+		}
+		return updateProfile(tx, winner[0].id, profile, false);
+	});
+}
+
+async function insertProfile(
+	database: DBTransaction,
+	id: string,
+	profile: Profile,
+): Promise<StoredProfileIdentity | null> {
+	const [row] = await database
+		.insert(entities)
+		.values({
+			id,
+			kind: "user",
+			...profileColumns(profile),
+		})
+		.onConflictDoNothing()
+		.returning();
+	return row ? { entityId: row.id, row, created: true } : null;
+}
+
+async function updateProfile(
+	database: DBTransaction,
+	id: string,
+	profile: Profile,
+	created: boolean,
+): Promise<StoredProfileIdentity> {
+	const [row] = await database
+		.update(entities)
+		.set({ ...profileColumns(profile), unreachableAt: null })
+		.where(and(eq(entities.id, id), eq(entities.kind, "user")))
+		.returning();
+	if (!row) {
+		throw new ProfileIdentityConflictError(
+			`Stored profile ${id} changed while resolving GitHub identity ${profile.nodeId}.`,
+		);
+	}
+	return { entityId: row.id, row, created };
+}
+
+function profileColumns(profile: Profile) {
+	return {
+		login: profile.login,
+		githubNodeId: profile.nodeId,
+		name: profile.name,
+		avatarUrl: profile.avatarUrl,
+		htmlUrl: `https://github.com/${profile.login}`,
+		createdAt: new Date(profile.createdAt),
+		followers: profile.followers,
+		following: profile.following,
+		publicRepos: profile.publicRepos,
+		bio: profile.bio,
+		company: profile.company,
+		location: profile.location,
+		websiteUrl: profile.websiteUrl,
+		twitterUsername: profile.twitterUsername,
+	};
+}


### PR DESCRIPTION
## Stack position

1 of 5 in the profile-ingestion stack. Merge this first. Next: #198.

## What changes

- stores GitHub's immutable user node ID separately from the mutable login
- preserves one entity and its history across login renames
- refuses ambiguous legacy/duplicate identity matches instead of combining histories
- gives a recycled login a new node-derived entity ID
- adds a user-only partial unique index with a duplicate preflight
- preserves the existing one-minute zero-GitHub-call warm-cache path; stale or ambiguous matches resolve identity before reading months

## What does not change

- no pg-boss dependency, queue, worker, or Coolify process
- live profile ingestion remains synchronous
- organization ingestion and its uniqueness rules are unchanged
- no Compose, research, ADR, plan, or context files

## Verification

- `pnpm test` — 94 passed
- focused Biome checks passed
- `pnpm build` passed
- `pnpm exec tsc --noEmit` reports the two existing `NODE_ENV` typing errors from `main`; stack PR 2 fixes that narrow type without changing behavior

This PR intentionally does not close #185; it is the identity prerequisite for the queue architecture.
