### PR TITLE
fix: add dedicated profile worker image target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,20 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
 
-FROM node:24-alpine
+FROM node:24-alpine AS runtime
 ENV NODE_ENV=production
 WORKDIR /app
-# `.output` carries nitro's server bundle (CMD below) and self-contained worker entrypoints. The
-# same image can therefore run the web app, scheduled refreshes, or the continuous profile worker
-# without runtime node_modules, sources, or tsx.
+# `.output` carries Nitro's server bundle and the self-contained worker entrypoints. They are
+# bundled, so the runtime image needs no node_modules, sources, or tsx.
 COPY --from=build /app/.output ./.output
-EXPOSE 3000
 USER node
+
+# Coolify's profile-ingestion application builds this target. Dockerfile applications ignore
+# Coolify's start-command override, so the worker needs its own image target and CMD.
+FROM runtime AS worker
+CMD ["node", ".output/worker/profile-ingestion-worker.mjs"]
+
+# Keep the web image as the final/default target so the existing Coolify application is unchanged.
+FROM runtime AS web
+EXPOSE 3000
 CMD ["node", ".output/server/index.mjs"]


### PR DESCRIPTION
Adds an explicit `worker` Docker build target for the continuous profile-ingestion process while keeping `web` as the final/default target.

Coolify Dockerfile applications do not apply their configured start-command override, so a separate target is required to avoid launching the web server in the worker service.

- shares the existing minimal runtime layer
- worker CMD: `node .output/worker/profile-ingestion-worker.mjs`
- existing web CMD and default image behavior remain unchanged