### PR TITLE
Fix legacy profile history rebuilds

### DIFF
--- a/src/lib/profile-ingestion-engine.ts
+++ b/src/lib/profile-ingestion-engine.ts
@@ -201,7 +201,7 @@ export function createProfileIngestion(deps: ProfileIngestionDependencies) {
 		const windows = monthlyWindows(new Date(profile.createdAt), now);
 		const completeRows = new Map(
 			rows
-				.filter((row) => isCompletedMonth(row))
+				.filter((row) => isStoredProfileMonthComplete(row, stored.builtAt))
 				.map((row) => [row.month, row]),
 		);
 		const missing = windows.filter((window) => !completeRows.has(window.label));
@@ -275,7 +275,9 @@ async function availableHistory(
 	const windows = monthlyWindows(new Date(stored.profile.createdAt), now);
 	const rows = await store.storedMonths(stored.entityId);
 	const completeRows = new Map(
-		rows.filter(isCompletedMonth).map((row) => [row.month, row]),
+		rows
+			.filter((row) => isStoredProfileMonthComplete(row, stored.builtAt))
+			.map((row) => [row.month, row]),
 	);
 	return historyFromAvailable(stored.profile, windows, completeRows);
 }
@@ -288,7 +290,9 @@ async function completedHistory(
 	const windows = monthlyWindows(new Date(stored.profile.createdAt), now);
 	const rows = await store.storedMonths(stored.entityId);
 	const completeRows = new Map(
-		rows.filter((row) => isCompletedMonth(row)).map((row) => [row.month, row]),
+		rows
+			.filter((row) => isStoredProfileMonthComplete(row, stored.builtAt))
+			.map((row) => [row.month, row]),
 	);
 	if (windows.some((window) => !completeRows.has(window.label)))
 		return undefined;
@@ -343,14 +347,27 @@ function completeResult(
 	};
 }
 
-function isCompletedMonth(row: StoredProfileMonth): boolean {
-	if (!row.fetchedAt) return false;
+/**
+ * Whether a stored month has enough provenance to be treated as immutable.
+ *
+ * New rows prove this directly with `fetchedAt`. Rows predating that column deliberately retain
+ * NULL, but a profile's original `builtAt` is also valid proof when the build completed after the
+ * month closed: initial completion was stamped only after every emitted month had been stored.
+ * Never let `builtAt` override an explicit early `fetchedAt`; those rows are the historical
+ * partial-month bug this completeness rule exists to repair.
+ */
+export function isStoredProfileMonthComplete(
+	row: Pick<StoredProfileMonth, "month" | "fetchedAt">,
+	builtAt: Date | null,
+): boolean {
+	const provenAt = row.fetchedAt ?? builtAt;
+	if (!provenAt) return false;
 	const start = new Date(`${row.month}T00:00:00.000Z`);
 	if (Number.isNaN(start.getTime())) return false;
 	const nextMonth = new Date(
 		Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 1),
 	);
-	return row.fetchedAt >= nextMonth;
+	return provenAt >= nextMonth;
 }
 
 async function rateLimitDeferral(

--- a/src/lib/profile-ingestion-store.ts
+++ b/src/lib/profile-ingestion-store.ts
@@ -3,9 +3,10 @@ import type { DB } from "#/lib/db";
 import { entities, monthlyCommits } from "#/lib/db/schema";
 import type { CommitHistory, MonthlyCount, Profile } from "#/lib/github";
 import { saveProfileIdentity } from "#/lib/profile-identity";
-import type {
-	ProfileIngestionStore,
-	StoredProfile,
+import {
+	isStoredProfileMonthComplete,
+	type ProfileIngestionStore,
+	type StoredProfile,
 } from "#/lib/profile-ingestion-engine";
 
 type EntityRow = typeof entities.$inferSelect;
@@ -70,6 +71,14 @@ export function createProfileIngestionStore(
 
 		async markComplete(entityId, history, expectedMonths, at) {
 			await database.transaction(async (tx) => {
+				const [profile] = await tx
+					.select({ builtAt: entities.builtAt })
+					.from(entities)
+					.where(eq(entities.id, entityId))
+					.limit(1);
+				if (!profile) {
+					throw new Error(`Profile entity ${entityId} disappeared.`);
+				}
 				const rows = await tx
 					.select({
 						month: monthlyCommits.month,
@@ -79,11 +88,7 @@ export function createProfileIngestionStore(
 					.where(eq(monthlyCommits.entityId, entityId));
 				const durable = new Set(
 					rows
-						.filter(
-							(row) =>
-								row.fetchedAt != null &&
-								row.fetchedAt >= nextMonthStart(row.month),
-						)
+						.filter((row) => isStoredProfileMonthComplete(row, profile.builtAt))
 						.map((row) => row.month),
 				);
 				const missing = expectedMonths.filter((month) => !durable.has(month));
@@ -188,9 +193,4 @@ function countsFromRow(row: typeof monthlyCommits.$inferSelect): MonthlyCount {
 		reviews: row.reviews,
 		repos: row.repos,
 	};
-}
-
-function nextMonthStart(month: string): Date {
-	const start = new Date(`${month}T00:00:00.000Z`);
-	return new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 1));
 }

--- a/src/lib/profile-ingestion.test.ts
+++ b/src/lib/profile-ingestion.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "#/lib/github";
 import {
 	createProfileIngestion,
+	isStoredProfileMonthComplete,
 	type ProfileIngestionGitHub,
 	type ProfileIngestionStore,
 	type StoredProfile,
@@ -95,11 +96,19 @@ class MemoryStore implements ProfileIngestionStore {
 	async markComplete(
 		entityId: string,
 		history: CommitHistory,
-		_expectedMonths: string[],
+		expectedMonths: string[],
 		at: Date,
 	) {
 		const row = this.profiles.get(entityId);
 		if (!row) throw new Error("profile missing");
+		const storedMonths = this.months.get(entityId) ?? new Map();
+		const missing = expectedMonths.filter((month) => {
+			const storedMonth = storedMonths.get(month);
+			return (
+				!storedMonth || !isStoredProfileMonthComplete(storedMonth, row.builtAt)
+			);
+		});
+		if (missing.length > 0) throw new Error("months are not durable");
 		row.builtAt ??= at;
 		row.lastFetched = at;
 		row.profile = history.user;
@@ -163,12 +172,13 @@ function seedMonth(
 	entityId: string,
 	month: string,
 	commits: number,
+	fetchedAt: Date | null = new Date("2026-05-01T00:00:00.000Z"),
 ) {
 	const rows = store.months.get(entityId) ?? new Map();
 	rows.set(month, {
 		month,
 		counts: counts(commits),
-		fetchedAt: new Date("2026-05-01T00:00:00.000Z"),
+		fetchedAt,
 	});
 	store.months.set(entityId, rows);
 }
@@ -260,6 +270,89 @@ describe("profile ingestion", () => {
 		expect(result.status).toBe("complete");
 		expect(github.fetchedChunks).toEqual([["2026-03-01", "2026-04-01"]]);
 		expect(store.completions[0]?.total).toBe(18);
+	});
+
+	it("accepts legacy months when the completed build proves they were settled", async () => {
+		const { run, store, github } = setup();
+		const stored = await store.saveProfile(PROFILE);
+		stored.builtAt = new Date("2026-05-01T00:00:00.000Z");
+		stored.lastFetched = new Date("2026-05-01T00:00:00.000Z");
+		for (const [index, month] of [
+			"2026-01-01",
+			"2026-02-01",
+			"2026-03-01",
+			"2026-04-01",
+		].entries()) {
+			seedMonth(store, stored.entityId, month, index + 1, null);
+		}
+
+		const result = await run(
+			{ login: PROFILE.login },
+			{ token: "token", now: NOW },
+		);
+
+		expect(result).toMatchObject({
+			status: "complete",
+			monthsStored: 4,
+			history: { total: 10 },
+		});
+		expect(github.profileCalls).toBe(1);
+		expect(github.fetchedChunks).toEqual([]);
+		expect(store.completions).toHaveLength(1);
+	});
+
+	it("refetches a legacy month when the build finished before that month closed", async () => {
+		const { run, store, github } = setup();
+		const stored = await store.saveProfile(PROFILE);
+		stored.builtAt = new Date("2026-01-20T00:00:00.000Z");
+		stored.lastFetched = new Date("2026-01-20T00:00:00.000Z");
+		seedMonth(store, stored.entityId, "2026-01-01", 99, null);
+		seedMonth(store, stored.entityId, "2026-02-01", 2);
+
+		await run(
+			{ login: PROFILE.login },
+			{ token: "token", now: new Date("2026-03-15T12:00:00.000Z") },
+		);
+
+		expect(github.fetchedChunks).toEqual([["2026-01-01"]]);
+		expect(store.completions[0]?.total).toBe(3);
+	});
+
+	it("does not let build provenance override an explicit early fetch", async () => {
+		const { run, store, github } = setup();
+		const stored = await store.saveProfile(PROFILE);
+		stored.builtAt = new Date("2026-05-01T00:00:00.000Z");
+		stored.lastFetched = new Date("2026-05-01T00:00:00.000Z");
+		seedMonth(
+			store,
+			stored.entityId,
+			"2026-01-01",
+			99,
+			new Date("2026-01-20T00:00:00.000Z"),
+		);
+		seedMonth(store, stored.entityId, "2026-02-01", 2, null);
+		seedMonth(store, stored.entityId, "2026-03-01", 3, null);
+		seedMonth(store, stored.entityId, "2026-04-01", 4, null);
+
+		await run({ login: PROFILE.login }, { token: "token", now: NOW });
+
+		expect(github.fetchedChunks).toEqual([["2026-01-01"]]);
+		expect(store.completions[0]?.total).toBe(10);
+	});
+
+	it("does not trust legacy provenance while the profile is incomplete", async () => {
+		const { run, store, github } = setup();
+		const stored = await store.saveProfile(PROFILE);
+		seedMonth(store, stored.entityId, "2026-01-01", 99, null);
+		seedMonth(store, stored.entityId, "2026-02-01", 2);
+
+		await run(TARGET, {
+			token: "token",
+			now: new Date("2026-03-15T12:00:00.000Z"),
+		});
+
+		expect(github.fetchedChunks).toEqual([["2026-01-01"]]);
+		expect(store.completions[0]?.total).toBe(3);
 	});
 
 	it("refetches an unproven month before marking the profile complete", async () => {


### PR DESCRIPTION
Fixes #201

## What changes

- Treat a legacy monthly row with a null fetched timestamp as durable only when the profile build timestamp proves that month had already closed.
- Keep an explicit per-month fetched timestamp authoritative, including early timestamps that require a repair fetch.
- Refuse the fallback for profiles that never completed their initial build.
- Apply the same completeness rule in both ingestion reads and the transactional completion guard.
- Cover safe legacy reuse, partial-month repair, incomplete profiles, and explicit timestamp precedence with regression tests.

This is a permanent compatibility rule for legacy data and requires no bulk production data rewrite. New rows continue to use their explicit per-month fetch timestamps.

## Verification

- pnpm exec biome check
- pnpm exec tsc --noEmit
- pnpm test (108 passed, 4 skipped)
- pnpm build
- focused ingestion suite after the final regression case (16 passed)