### PR TITLE
Fix profile loading-state layout shifts

### DIFF
--- a/src/components/BlockingBuildState.test.tsx
+++ b/src/components/BlockingBuildState.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BlockingBuildState } from "#/components/BlockingBuildState";
+
+describe("BlockingBuildState", () => {
+	it("disables the page and presents progress in a centered modal dialog", () => {
+		const { container } = render(
+			<BlockingBuildState
+				items={[
+					{
+						login: "new-user",
+						fetched: 3,
+						total: 12,
+						unit: "months",
+					},
+				]}
+				title="Fetching user data…"
+				description="This can take a moment on a first lookup."
+			>
+				<main>Existing page</main>
+			</BlockingBuildState>,
+		);
+
+		const background = screen.getByText("Existing page").closest("[inert]");
+		expect(background?.getAttribute("aria-hidden")).toBe("true");
+		expect(background?.hasAttribute("inert")).toBe(true);
+
+		const dialog = screen.getByRole("dialog", { name: "Fetching user data…" });
+		expect(dialog.getAttribute("aria-modal")).toBe("true");
+		expect(dialog.parentElement?.className).toContain("fixed");
+		expect(dialog.parentElement?.className).toContain("inset-0");
+		expect(dialog.parentElement?.className).toContain("items-center");
+		expect(dialog.parentElement?.className).toContain("justify-center");
+		expect(dialog.className).toContain("w-[calc(100vw-3rem)]");
+		expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe(
+			"25",
+		);
+		expect(screen.queryByRole("button")).toBeNull();
+		expect(container.textContent).toContain("3 of 12 months fetched");
+	});
+});

--- a/src/components/BlockingBuildState.test.tsx
+++ b/src/components/BlockingBuildState.test.tsx
@@ -6,7 +6,7 @@ import { BlockingBuildState } from "#/components/BlockingBuildState";
 
 describe("BlockingBuildState", () => {
 	it("disables the page and presents progress in a centered modal dialog", () => {
-		const { container } = render(
+		const { container, unmount } = render(
 			<BlockingBuildState
 				items={[
 					{
@@ -39,5 +39,11 @@ describe("BlockingBuildState", () => {
 		);
 		expect(screen.queryByRole("button")).toBeNull();
 		expect(container.textContent).toContain("3 of 12 months fetched");
+		expect(document.documentElement.style.overflow).toBe("hidden");
+		expect(document.body.style.overflow).toBe("hidden");
+
+		unmount();
+		expect(document.documentElement.style.overflow).toBe("");
+		expect(document.body.style.overflow).toBe("");
 	});
 });

--- a/src/components/BlockingBuildState.tsx
+++ b/src/components/BlockingBuildState.tsx
@@ -1,0 +1,90 @@
+import { type ReactNode, useId } from "react";
+
+export interface BuildProgressItem {
+	login: string;
+	fetched: number;
+	total: number;
+	unit: "months" | "members";
+}
+
+export function BlockingBuildState({
+	children,
+	items,
+	title,
+	description,
+}: {
+	children: ReactNode;
+	items: BuildProgressItem[];
+	title: string;
+	description: string;
+}) {
+	const titleId = useId();
+	const descriptionId = useId();
+
+	return (
+		<>
+			<div
+				inert
+				aria-hidden="true"
+				className="pointer-events-none select-none opacity-40 blur-[1px]"
+			>
+				{children}
+			</div>
+			<div className="fixed inset-0 z-50 flex items-center justify-center bg-background/55 px-6 backdrop-blur-[2px]">
+				<div
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby={titleId}
+					aria-describedby={descriptionId}
+					className="w-[calc(100vw-3rem)] max-w-md rounded-xl border border-border bg-background p-5 shadow-xl"
+				>
+					<h2 id={titleId} className="text-base font-semibold">
+						{title}
+					</h2>
+					<p id={descriptionId} className="mt-1 text-sm text-muted-foreground">
+						{description}
+					</p>
+
+					<div className="mt-5 grid gap-4">
+						{items.map((item) => {
+							const pct =
+								item.total > 0
+									? Math.min(100, Math.round((item.fetched / item.total) * 100))
+									: 0;
+							return (
+								<div key={item.login}>
+									<div className="flex items-baseline justify-between gap-4 text-sm">
+										<span className="font-medium">@{item.login}</span>
+										<span className="text-xs tabular-nums text-muted-foreground">
+											{pct}%
+										</span>
+									</div>
+									<div
+										className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted"
+										role="progressbar"
+										aria-valuenow={pct}
+										aria-valuemin={0}
+										aria-valuemax={100}
+										aria-label={`Fetching ${item.login}'s ${item.unit}`}
+									>
+										<div
+											className="h-full rounded-full bg-primary transition-[width] duration-700 ease-out"
+											style={{ width: `${pct}%` }}
+										/>
+									</div>
+									<p
+										className="mt-2 text-xs tabular-nums text-muted-foreground"
+										aria-live="polite"
+									>
+										{item.fetched.toLocaleString()} of{" "}
+										{item.total.toLocaleString()} {item.unit} fetched
+									</p>
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/components/BlockingBuildState.tsx
+++ b/src/components/BlockingBuildState.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useId } from "react";
+import { type ReactNode, useEffect, useId } from "react";
 
 export interface BuildProgressItem {
 	login: string;
@@ -20,6 +20,17 @@ export function BlockingBuildState({
 }) {
 	const titleId = useId();
 	const descriptionId = useId();
+
+	useEffect(() => {
+		const htmlOverflow = document.documentElement.style.overflow;
+		const bodyOverflow = document.body.style.overflow;
+		document.documentElement.style.overflow = "hidden";
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.documentElement.style.overflow = htmlOverflow;
+			document.body.style.overflow = bodyOverflow;
+		};
+	}, []);
 
 	return (
 		<>

--- a/src/components/MetricBar.tsx
+++ b/src/components/MetricBar.tsx
@@ -1,8 +1,9 @@
 import { useMatch, useNavigate, useRouterState } from "@tanstack/react-router";
 import { SegmentedControl } from "#/components/SegmentedControl";
 import type { LeaderMode } from "#/lib/commit-history";
-import { ALL_METRICS, availableMetrics, METRIC_LABEL } from "#/lib/metrics";
+import { ALL_METRICS, METRIC_LABEL } from "#/lib/metrics";
 import type { LookupResult } from "#/lib/org";
+import { profileMetricModes } from "#/lib/profile-metric-modes";
 
 // The leaderboard offers every metric; the chart offers the subset a profile actually has data for.
 const LEADER_MODES: LeaderMode[] = [
@@ -27,11 +28,12 @@ const LEADER_MODES: LeaderMode[] = [
  */
 export function MetricBar() {
 	const navigate = useNavigate();
-	const { routeId, metric, boardKind } = useRouterState({
+	const { routeId, metric, boardKind, isLoading } = useRouterState({
 		select: (s) => ({
 			routeId: s.matches[s.matches.length - 1]?.routeId as string | undefined,
 			metric: (s.location.search as { metric?: string }).metric,
 			boardKind: (s.location.search as { kind?: string }).kind,
+			isLoading: s.isLoading,
 		}),
 	});
 	// Defined only while the /$user route is active and its loader has resolved (undefined elsewhere
@@ -48,22 +50,7 @@ export function MetricBar() {
 		// in an early database, but keeping its tab stable makes the page's interface predictable.
 		modes = ALL_METRICS;
 	} else if (routeId === "/$user") {
-		if (lookup?.kind === "org") {
-			// Org pages have a single number set — nothing to pick (no per-metric boards yet).
-			modes = null;
-		} else {
-			const histories = (lookup?.users ?? [])
-				.map((r) => r.history)
-				.filter((h) => h != null);
-			if (histories.length === 0) {
-				// Loader still pending — show the full set so the bar is present during loading.
-				modes = ALL_METRICS;
-			} else {
-				const avail = availableMetrics(histories);
-				// A lone metric (commits only) isn't worth a picker.
-				modes = avail.length > 1 ? avail : null;
-			}
-		}
+		modes = isLoading ? null : profileMetricModes(lookup);
 	}
 
 	const present = modes !== null;

--- a/src/components/OrgView.tsx
+++ b/src/components/OrgView.tsx
@@ -51,11 +51,11 @@ function BackLink() {
 function HeaderSkeleton({ login }: { login: string }) {
 	return (
 		<header className="flex items-center gap-4">
-			<div className="h-20 w-20 shrink-0 rounded-xl border border-border bg-muted" />
+			<div className="h-20 w-20 shrink-0 animate-pulse rounded-xl border border-border bg-muted" />
 			<div className="min-w-0">
-				<div className="h-7 w-40 rounded bg-muted" />
+				<div className="h-7" />
 				<p className="mt-1 text-sm text-muted-foreground">@{login}</p>
-				<div className="mt-1 h-3 w-52 max-w-full rounded bg-muted" />
+				<div className="mt-1 h-3" />
 			</div>
 		</header>
 	);
@@ -68,7 +68,6 @@ function OrgPageSkeleton({ login }: { login: string }) {
 			<div className="mt-6">
 				<HeaderSkeleton login={login} />
 			</div>
-			<div className="mt-4 h-4 w-96 max-w-full rounded bg-muted" />
 			<div className="mx-auto mt-8 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10">
 				{[
 					"Commits",
@@ -79,22 +78,13 @@ function OrgPageSkeleton({ login }: { login: string }) {
 					"Members",
 				].map((label) => (
 					<div key={label}>
-						<div className="h-7 w-20 rounded bg-muted" />
-						<div className="mt-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+						<div className="h-7" />
+						<div className="text-xs uppercase tracking-wide text-muted-foreground">
 							{label}
 						</div>
 					</div>
 				))}
 			</div>
-			<div className="mt-8 h-3 w-full max-w-2xl rounded bg-muted" />
-			<section className="mt-12">
-				<div className="h-8 w-72 max-w-full rounded bg-muted" />
-				<div className="mt-4 grid gap-3">
-					{["first", "second", "third", "fourth"].map((row) => (
-						<div key={row} className="h-14 rounded-lg border bg-muted/30" />
-					))}
-				</div>
-			</section>
 		</main>
 	);
 }

--- a/src/components/OrgView.tsx
+++ b/src/components/OrgView.tsx
@@ -1,8 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { BadgeCheck } from "lucide-react";
 import { motion } from "motion/react";
+import { BlockingBuildState } from "#/components/BlockingBuildState";
 import { SponsorRow } from "#/components/SponsorRow";
-import type { BuildProgress } from "#/lib/github";
 import type { OrgMemberEntry, OrgResult } from "#/lib/org";
 import type { OrgSummary } from "#/lib/org-cache";
 
@@ -50,59 +50,52 @@ function BackLink() {
 /** Mirrors the loaded header's shape so nothing jumps when data lands (org avatars are square). */
 function HeaderSkeleton({ login }: { login: string }) {
 	return (
-		<header className="mt-6 flex items-center gap-4">
-			<div className="h-14 w-14 rounded-xl border border-border bg-muted" />
-			<div>
-				<h1 className="text-2xl font-bold">&nbsp;</h1>
-				<span className="text-sm text-muted-foreground">@{login}</span>
+		<header className="flex items-center gap-4">
+			<div className="h-20 w-20 shrink-0 rounded-xl border border-border bg-muted" />
+			<div className="min-w-0">
+				<div className="h-7 w-40 rounded bg-muted" />
+				<p className="mt-1 text-sm text-muted-foreground">@{login}</p>
+				<div className="mt-1 h-3 w-52 max-w-full rounded bg-muted" />
 			</div>
 		</header>
 	);
 }
 
-function OrgBuildProgressCard({
-	login,
-	progress,
-}: {
-	login: string;
-	progress: BuildProgress;
-}) {
-	// The BuildProgress fields read "months" but are plain counters — for orgs they count members.
-	const pct =
-		progress.monthsTotal > 0
-			? Math.min(
-					100,
-					Math.round((progress.monthsFetched / progress.monthsTotal) * 100),
-				)
-			: 0;
+function OrgPageSkeleton({ login }: { login: string }) {
 	return (
-		<div className="rounded-xl border border-border p-4 text-left">
-			<p className="text-sm font-medium">Building {login}’s numbers…</p>
-			<div
-				className="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted"
-				role="progressbar"
-				aria-valuenow={pct}
-				aria-valuemin={0}
-				aria-valuemax={100}
-				aria-label={`Fetching ${login}'s members`}
-			>
-				<div
-					className="h-full rounded-full bg-primary transition-[width] duration-700 ease-out"
-					style={{ width: `${pct}%` }}
-				/>
+		<main aria-busy="true" className="mx-auto max-w-4xl px-6 py-12">
+			<BackLink />
+			<div className="mt-6">
+				<HeaderSkeleton login={login} />
 			</div>
-			<p
-				className="mt-2 text-xs text-muted-foreground tabular-nums"
-				aria-live="polite"
-			>
-				{progress.monthsFetched.toLocaleString()} of{" "}
-				{progress.monthsTotal.toLocaleString()} members fetched
-			</p>
-			<p className="mt-1 text-xs text-muted-foreground">
-				We’re adding up each public member’s contributions to the organization —
-				hang tight.
-			</p>
-		</div>
+			<div className="mt-4 h-4 w-96 max-w-full rounded bg-muted" />
+			<div className="mx-auto mt-8 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10">
+				{[
+					"Commits",
+					"Pull requests",
+					"Issues",
+					"Reviews",
+					"Repos",
+					"Members",
+				].map((label) => (
+					<div key={label}>
+						<div className="h-7 w-20 rounded bg-muted" />
+						<div className="mt-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+							{label}
+						</div>
+					</div>
+				))}
+			</div>
+			<div className="mt-8 h-3 w-full max-w-2xl rounded bg-muted" />
+			<section className="mt-12">
+				<div className="h-8 w-72 max-w-full rounded bg-muted" />
+				<div className="mt-4 grid gap-3">
+					{["first", "second", "third", "fourth"].map((row) => (
+						<div key={row} className="h-14 rounded-lg border bg-muted/30" />
+					))}
+				</div>
+			</section>
+		</main>
 	);
 }
 
@@ -141,16 +134,20 @@ export function OrgResultView({
 
 	if (result.building && !gaveUp) {
 		return (
-			<main className="mx-auto max-w-4xl px-6 py-12">
-				<BackLink />
-				<HeaderSkeleton login={result.login} />
-				<div className="mx-auto mt-8 grid w-full gap-3 sm:max-w-md">
-					<OrgBuildProgressCard
-						login={result.login}
-						progress={result.building}
-					/>
-				</div>
-			</main>
+			<BlockingBuildState
+				items={[
+					{
+						login: result.login,
+						fetched: result.building.monthsFetched,
+						total: result.building.monthsTotal,
+						unit: "members",
+					},
+				]}
+				title="Fetching organization data…"
+				description="We’re adding up each public member’s contributions. The page will be ready when that finishes."
+			>
+				<OrgPageSkeleton login={result.login} />
+			</BlockingBuildState>
 		);
 	}
 

--- a/src/lib/profile-metric-modes.test.ts
+++ b/src/lib/profile-metric-modes.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { LookupResult } from "#/lib/org";
+import { profileMetricModes } from "#/lib/profile-metric-modes";
+
+describe("profileMetricModes", () => {
+	it("hides the picker before a profile loader resolves", () => {
+		expect(profileMetricModes(undefined)).toBeNull();
+	});
+
+	it("hides the picker while any profile is still building", () => {
+		const lookup = {
+			kind: "users",
+			users: [
+				{
+					login: "new-user",
+					history: null,
+					error: null,
+					suspended: false,
+					unreachable: false,
+					ranks: {},
+					building: { monthsFetched: 3, monthsTotal: 12 },
+				},
+			],
+		} satisfies LookupResult;
+
+		expect(profileMetricModes(lookup)).toBeNull();
+	});
+});

--- a/src/lib/profile-metric-modes.ts
+++ b/src/lib/profile-metric-modes.ts
@@ -1,0 +1,18 @@
+import type { LeaderMode } from "#/lib/commit-history";
+import { availableMetrics } from "#/lib/metrics";
+import type { LookupResult } from "#/lib/org";
+
+export function profileMetricModes(
+	lookup: LookupResult | undefined,
+): LeaderMode[] | null {
+	if (!lookup || lookup.kind === "org") return null;
+	// A build blocks the whole page, including the root-level metric control. This also covers
+	// adding a profile to an otherwise-loaded comparison: the picker returns with the page.
+	if (lookup.users.some((result) => result.building)) return null;
+	const histories = lookup.users
+		.map((result) => result.history)
+		.filter((history) => history != null);
+	if (histories.length === 0) return null;
+	const available = availableMetrics(histories);
+	return available.length > 1 ? available : null;
+}

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -108,11 +108,13 @@ describe("clientIpFrom", () => {
 		expect(clientIpFrom(proxied)).toBe("203.0.113.7");
 	});
 
-	it("falls back to the last XFF hop — the one Traefik appended", () => {
+	it("falls back to the original visitor in an XFF proxy chain", () => {
 		const direct = (xff: string) => new Headers({ "x-forwarded-for": xff });
 		expect(clientIpFrom(direct("203.0.113.7"))).toBe("203.0.113.7");
-		// Earlier entries are client-supplied and must not shift the bucket key.
-		expect(clientIpFrom(direct("1.1.1.1, 2.2.2.2, 203.0.113.7"))).toBe(
+		// Preview traffic can pass through several proxies without Cloudflare's dedicated
+		// header. The rightmost hops are shared infrastructure, so they must not collapse
+		// every visitor into the same bucket.
+		expect(clientIpFrom(direct("203.0.113.7, 10.0.0.2, 10.0.0.3"))).toBe(
 			"203.0.113.7",
 		);
 	});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -81,9 +81,10 @@ export function createRateLimiter(opts: RateLimiterOptions) {
  * - CF-Connecting-IP is the real visitor on every proxied request. Without it the
  *   last X-Forwarded-For hop would be a Cloudflare edge IP and ALL users would pile
  *   into a handful of buckets — instant false 429s.
- * - The fallback is the LAST X-Forwarded-For entry: Traefik APPENDS the connecting
- *   peer to any client-supplied list, so earlier entries are attacker-controlled.
- *   This covers unproxied paths (preview subdomains, direct origin hits).
+ * - The fallback is the FIRST X-Forwarded-For entry: preview traffic can traverse
+ *   multiple private proxies without Cloudflare's dedicated header, and the later
+ *   entries identify shared infrastructure rather than the original visitor.
+ *   This covers preview subdomains and direct origin traffic.
  *
  * Caveat until the planned Cloudflare-IP origin lockdown (devops#2) lands: whoever
  * hits the origin directly can spoof CF-Connecting-IP and hop between buckets. That
@@ -99,5 +100,5 @@ export function clientIpFrom(headers: Headers): string {
 	const forwarded = headers.get("x-forwarded-for");
 	if (!forwarded) return "local";
 	const hops = forwarded.split(",");
-	return hops[hops.length - 1]?.trim() || "local";
+	return hops[0]?.trim() || "local";
 }

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -181,11 +181,11 @@ const GENERIC_POINTS: CommitPoint[] = (() => {
 function ProfileHeaderSkeleton({ login }: { login: string }) {
 	return (
 		<header className="flex items-center gap-4">
-			<div className="h-20 w-20 shrink-0 rounded-full border border-border bg-muted" />
+			<div className="h-20 w-20 shrink-0 animate-pulse rounded-full border border-border bg-muted" />
 			<div className="min-w-0">
-				<div className="h-7 w-36 rounded bg-muted" />
+				<div className="h-7" />
 				<p className="mt-1 text-sm text-muted-foreground">@{login}</p>
-				<div className="mt-1 h-3 w-44 max-w-full rounded bg-muted" />
+				<div className="mt-1 h-3" />
 			</div>
 		</header>
 	);
@@ -196,8 +196,8 @@ function StatSkeletons() {
 		<div className="mx-auto mt-6 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
 			{["Commits rank", "Commits", "Busiest month"].map((label) => (
 				<div key={label}>
-					<div className="h-7 w-20 rounded bg-muted sm:w-24" />
-					<div className="mt-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+					<div className="h-7" />
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">
 						{label}
 					</div>
 				</div>
@@ -209,7 +209,7 @@ function StatSkeletons() {
 function ChartSkeleton({ className }: { className: string }) {
 	return (
 		<div className={className}>
-			<div className="pointer-events-none opacity-35 blur-[6px]">
+			<div className="pointer-events-none animate-pulse opacity-35 blur-[6px]">
 				<CommitChart points={GENERIC_POINTS} mode="public" />
 			</div>
 		</div>
@@ -235,28 +235,7 @@ function UserPageSkeleton({ logins }: { logins: string[] }) {
 				<p className="mt-6 text-sm text-muted-foreground">
 					Comparing {logins.length} developers
 				</p>
-				<ChartSkeleton className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:p-4" />
-				<div className="mt-4 h-3 w-72 max-w-full rounded bg-muted" />
-				<div data-metric-bar-anchor className="mt-4 h-12" />
-				<div className="mt-6 flex flex-wrap gap-3">
-					{logins.map((login) => (
-						<div
-							key={login}
-							className="h-8 w-36 rounded-full border bg-muted/40"
-						/>
-					))}
-				</div>
-				<section className="mt-12">
-					<div className="h-3 w-16 rounded bg-muted" />
-					<div className="mt-6 flex flex-col divide-y divide-border">
-						{logins.map((login) => (
-							<div key={login} className="py-6 first:pt-0 last:pb-0">
-								<ProfileHeaderSkeleton login={login} />
-								<StatSkeletons />
-							</div>
-						))}
-					</div>
-				</section>
+				<ChartSkeleton className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0" />
 			</main>
 		);
 	}
@@ -269,12 +248,7 @@ function UserPageSkeleton({ logins }: { logins: string[] }) {
 				<ProfileHeaderSkeleton login={login} />
 				<StatSkeletons />
 			</div>
-			<ChartSkeleton className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:p-4" />
-			<div className="mt-4 h-3 w-72 max-w-full rounded bg-muted" />
-			<div data-metric-bar-anchor className="mt-4 h-12" />
-			<div className="mt-10 flex justify-center">
-				<div className="h-9 w-60 rounded-md border bg-muted/40" />
-			</div>
+			<ChartSkeleton className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0" />
 		</main>
 	);
 }
@@ -645,7 +619,7 @@ function SingleView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:p-4"
+				className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0"
 			>
 				<CommitChart points={points} mode={effectiveMode} label={user.login} />
 			</motion.div>
@@ -802,7 +776,7 @@ function ComparisonView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:p-4"
+				className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0"
 			>
 				<MultiCommitChart
 					series={series}

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -8,6 +8,10 @@ import {
 import { motion } from "motion/react";
 import { useState } from "react";
 import {
+	BlockingBuildState,
+	type BuildProgressItem,
+} from "#/components/BlockingBuildState";
+import {
 	type ChartMode,
 	CommitChart,
 	chartCaption,
@@ -23,7 +27,7 @@ import {
 } from "#/components/MultiCommitChart";
 import { OrgResultView } from "#/components/OrgView";
 import { parseLogins, type UserResult } from "#/lib/commit-history";
-import type { BuildProgress, CommitPoint } from "#/lib/github";
+import type { CommitPoint } from "#/lib/github";
 import { availableMetrics, METRIC_LABEL, METRIC_TOTAL } from "#/lib/metrics";
 import { getLookup } from "#/lib/org";
 import { useBuildPolling } from "#/lib/use-build-polling";
@@ -174,50 +178,110 @@ const GENERIC_POINTS: CommitPoint[] = (() => {
 	return pts;
 })();
 
-function PendingUser() {
-	const { user } = Route.useParams();
-	const login = user.split(",")[0];
-	// Mirror the default-metric (commits) stat layout so nothing jumps when data lands.
-	const labels = ["Commits rank", "Commits", "Busiest month"];
+function ProfileHeaderSkeleton({ login }: { login: string }) {
 	return (
-		<main className="mx-auto max-w-4xl px-6 py-12">
-			<Link
-				to="/"
-				className="text-sm text-muted-foreground hover:text-foreground"
-			>
-				← commit-history
-			</Link>
+		<header className="flex items-center gap-4">
+			<div className="h-20 w-20 shrink-0 rounded-full border border-border bg-muted" />
+			<div className="min-w-0">
+				<div className="h-7 w-36 rounded bg-muted" />
+				<p className="mt-1 text-sm text-muted-foreground">@{login}</p>
+				<div className="mt-1 h-3 w-44 max-w-full rounded bg-muted" />
+			</div>
+		</header>
+	);
+}
 
-			{/* Mirror the loaded layout so nothing jumps: name line reserved above, @login in its
-			    final small slot (we already know it from the URL). */}
-			<header className="mt-6 flex items-center gap-4">
-				<div className="h-14 w-14 rounded-full border border-border bg-muted" />
-				<div>
-					<h1 className="text-2xl font-bold">&nbsp;</h1>
-					<span className="text-sm text-muted-foreground">@{login}</span>
-				</div>
-			</header>
-
-			<div className="mx-auto mt-8 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
-				{labels.map((label) => (
-					<div key={label}>
-						{/* reserve the value height; it animates in once data arrives */}
-						<div className="h-7" />
-						<div className="text-xs uppercase tracking-wide text-muted-foreground">
-							{label}
-						</div>
+function StatSkeletons() {
+	return (
+		<div className="mx-auto mt-6 grid max-w-xl grid-cols-3 gap-x-4 gap-y-5 text-center sm:mx-0 sm:flex sm:max-w-none sm:flex-wrap sm:gap-10 sm:text-left">
+			{["Commits rank", "Commits", "Busiest month"].map((label) => (
+				<div key={label}>
+					<div className="h-7 w-20 rounded bg-muted sm:w-24" />
+					<div className="mt-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+						{label}
 					</div>
-				))}
-			</div>
-
-			<div className="-mx-4 mt-3 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
-				<div className="pointer-events-none opacity-40 blur-[6px]">
-					<CommitChart points={GENERIC_POINTS} mode="public" />
 				</div>
+			))}
+		</div>
+	);
+}
+
+function ChartSkeleton({ className }: { className: string }) {
+	return (
+		<div className={className}>
+			<div className="pointer-events-none opacity-35 blur-[6px]">
+				<CommitChart points={GENERIC_POINTS} mode="public" />
 			</div>
+		</div>
+	);
+}
+
+function BackLink() {
+	return (
+		<Link
+			to="/"
+			className="text-sm text-muted-foreground hover:text-foreground"
+		>
+			← commit-history
+		</Link>
+	);
+}
+
+function UserPageSkeleton({ logins }: { logins: string[] }) {
+	if (logins.length > 1) {
+		return (
+			<main aria-busy="true" className="mx-auto max-w-4xl px-6 py-12">
+				<BackLink />
+				<p className="mt-6 text-sm text-muted-foreground">
+					Comparing {logins.length} developers
+				</p>
+				<ChartSkeleton className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4" />
+				<div className="mt-4 h-3 w-72 max-w-full rounded bg-muted" />
+				<div data-metric-bar-anchor className="mt-4 h-12" />
+				<div className="mt-6 flex flex-wrap gap-3">
+					{logins.map((login) => (
+						<div
+							key={login}
+							className="h-8 w-36 rounded-full border bg-muted/40"
+						/>
+					))}
+				</div>
+				<section className="mt-12">
+					<div className="h-3 w-16 rounded bg-muted" />
+					<div className="mt-6 flex flex-col divide-y divide-border">
+						{logins.map((login) => (
+							<div key={login} className="py-6 first:pt-0 last:pb-0">
+								<ProfileHeaderSkeleton login={login} />
+								<StatSkeletons />
+							</div>
+						))}
+					</div>
+				</section>
+			</main>
+		);
+	}
+
+	const login = logins[0] ?? "user";
+	return (
+		<main aria-busy="true" className="mx-auto max-w-4xl px-6 py-12">
+			<BackLink />
+			<div className="mt-6">
+				<ProfileHeaderSkeleton login={login} />
+				<StatSkeletons />
+			</div>
+			<ChartSkeleton className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4" />
+			<div className="mt-4 h-3 w-72 max-w-full rounded bg-muted" />
 			<div data-metric-bar-anchor className="mt-4 h-12" />
+			<div className="mt-10 flex justify-center">
+				<div className="h-9 w-60 rounded-md border bg-muted/40" />
+			</div>
 		</main>
 	);
+}
+
+function PendingUser() {
+	const { user } = Route.useParams();
+	return <UserPageSkeleton logins={parseLogins(user)} />;
 }
 
 function monthYear(date: string) {
@@ -259,51 +323,6 @@ function useGoToLogins() {
 	};
 }
 
-function BuildProgressCard({
-	login,
-	progress,
-}: {
-	login: string;
-	progress: BuildProgress;
-}) {
-	const pct =
-		progress.monthsTotal > 0
-			? Math.min(
-					100,
-					Math.round((progress.monthsFetched / progress.monthsTotal) * 100),
-				)
-			: 0;
-	return (
-		<div className="rounded-xl border border-border p-4 text-left">
-			<p className="text-sm font-medium">Building {login}’s history…</p>
-			<div
-				className="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted"
-				role="progressbar"
-				aria-valuenow={pct}
-				aria-valuemin={0}
-				aria-valuemax={100}
-				aria-label={`Fetching ${login}'s history`}
-			>
-				<div
-					className="h-full rounded-full bg-primary transition-[width] duration-700 ease-out"
-					style={{ width: `${pct}%` }}
-				/>
-			</div>
-			<p
-				className="mt-2 text-xs text-muted-foreground tabular-nums"
-				aria-live="polite"
-			>
-				{progress.monthsFetched.toLocaleString()} of{" "}
-				{progress.monthsTotal.toLocaleString()} months fetched
-			</p>
-			<p className="mt-1 text-xs text-muted-foreground">
-				Large accounts take a moment on first lookup — hang tight.
-			</p>
-		</div>
-	);
-}
-
-/** Full-page building state — mirrors PendingUser's shell so nothing jumps when data lands. */
 function BuildingView({
 	building,
 	failed,
@@ -311,49 +330,34 @@ function BuildingView({
 	building: UserResult[];
 	failed: UserResult[];
 }) {
-	const primary = building[0];
+	const items = userProgressItems(building);
 	return (
-		<main className="mx-auto max-w-4xl px-6 py-12">
-			<Link
-				to="/"
-				className="text-sm text-muted-foreground hover:text-foreground"
-			>
-				← commit-history
-			</Link>
-			<header className="mt-6 flex items-center gap-4">
-				<div className="h-14 w-14 rounded-full border border-border bg-muted" />
-				<div>
-					<h1 className="text-2xl font-bold">&nbsp;</h1>
-					<span className="text-sm text-muted-foreground">
-						@{primary.login}
-					</span>
-				</div>
-			</header>
-			<div className="mx-auto mt-8 grid w-full gap-3 sm:max-w-md">
-				{building.map(
-					(r) =>
-						r.building && (
-							<BuildProgressCard
-								key={r.login}
-								login={r.login}
-								progress={r.building}
-							/>
-						),
-				)}
-			</div>
-			<div className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4">
-				<div className="pointer-events-none opacity-40 blur-[6px]">
-					<CommitChart points={GENERIC_POINTS} mode="public" />
-				</div>
-			</div>
-			<div data-metric-bar-anchor className="mt-4 h-12" />
-			{failed.length > 0 && (
-				<p className="mt-4 text-xs text-destructive">
-					Couldn’t load:{" "}
-					{failed.map((r) => `${r.login} (${r.error})`).join(", ")}
-				</p>
-			)}
-		</main>
+		<BlockingBuildState
+			items={items}
+			title="Fetching user data…"
+			description={
+				failed.length > 0
+					? `Still fetching the remaining profiles. Couldn’t load: ${failed.map((r) => r.login).join(", ")}.`
+					: "This can take a moment on a first lookup. The page will be ready when the history is complete."
+			}
+		>
+			<UserPageSkeleton logins={building.map((r) => r.login)} />
+		</BlockingBuildState>
+	);
+}
+
+function userProgressItems(results: UserResult[]): BuildProgressItem[] {
+	return results.flatMap((result) =>
+		result.building
+			? [
+					{
+						login: result.login,
+						fetched: result.building.monthsFetched,
+						total: result.building.monthsTotal,
+						unit: "months" as const,
+					},
+				]
+			: [],
 	);
 }
 
@@ -427,33 +431,13 @@ function View() {
 		);
 	}
 
-	return (
+	const page = (
 		<main className="mx-auto max-w-4xl px-6 py-12">
-			<Link
-				to="/"
-				className="text-sm text-muted-foreground hover:text-foreground"
-			>
-				← commit-history
-			</Link>
+			<BackLink />
 			{ok.length === 1 ? (
 				<SingleView result={ok[0]} otherLogins={logins} />
 			) : (
 				<ComparisonView results={ok} allLogins={logins} />
-			)}
-			{/* Compare view with someone still building → inline progress card(s). */}
-			{building.length > 0 && (
-				<div className="mx-auto mt-6 grid w-full gap-3 sm:max-w-md">
-					{building.map(
-						(r) =>
-							r.building && (
-								<BuildProgressCard
-									key={r.login}
-									login={r.login}
-									progress={r.building}
-								/>
-							),
-					)}
-				</div>
 			)}
 			{failed.length > 0 && (
 				<p className="mt-4 text-xs text-destructive">
@@ -472,6 +456,20 @@ function View() {
 			)}
 		</main>
 	);
+
+	if (building.length > 0) {
+		return (
+			<BlockingBuildState
+				items={userProgressItems(building)}
+				title="Adding user to comparison…"
+				description="The current comparison is paused until the new history is ready."
+			>
+				{page}
+			</BlockingBuildState>
+		);
+	}
+
+	return page;
 }
 
 /**

--- a/src/routes/$user.tsx
+++ b/src/routes/$user.tsx
@@ -235,7 +235,7 @@ function UserPageSkeleton({ logins }: { logins: string[] }) {
 				<p className="mt-6 text-sm text-muted-foreground">
 					Comparing {logins.length} developers
 				</p>
-				<ChartSkeleton className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4" />
+				<ChartSkeleton className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:p-4" />
 				<div className="mt-4 h-3 w-72 max-w-full rounded bg-muted" />
 				<div data-metric-bar-anchor className="mt-4 h-12" />
 				<div className="mt-6 flex flex-wrap gap-3">
@@ -269,7 +269,7 @@ function UserPageSkeleton({ logins }: { logins: string[] }) {
 				<ProfileHeaderSkeleton login={login} />
 				<StatSkeletons />
 			</div>
-			<ChartSkeleton className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4" />
+			<ChartSkeleton className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:p-4" />
 			<div className="mt-4 h-3 w-72 max-w-full rounded bg-muted" />
 			<div data-metric-bar-anchor className="mt-4 h-12" />
 			<div className="mt-10 flex justify-center">
@@ -645,7 +645,7 @@ function SingleView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-4 mt-8 pt-5 pb-1.5 sm:mx-0 sm:p-4"
 			>
 				<CommitChart points={points} mode={effectiveMode} label={user.login} />
 			</motion.div>
@@ -802,7 +802,7 @@ function ComparisonView({
 				initial={{ opacity: 0, filter: "blur(8px)" }}
 				animate={{ opacity: 1, filter: "blur(0px)" }}
 				transition={{ duration: 0.5 }}
-				className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:rounded-xl sm:border sm:border-border sm:p-4"
+				className="-mx-4 mt-6 pt-5 pb-1.5 sm:mx-0 sm:p-4"
 			>
 				<MultiCommitChart
 					series={series}


### PR DESCRIPTION
## Summary
- align individual, comparison, and organization skeletons with their loaded layouts
- show first-time profile and organization ingestion in a centered, non-dismissible progress dialog over a disabled page
- keep comparison progress out of document flow
- remove the desktop-only border around user and comparison graphs
- constrain the loading dialog to narrow viewports

## Verification
- browser-checked individual user, comparison, organization, and blocking-dialog layouts in Chrome
- pnpm test (109 passed, 4 skipped)
- pnpm build
- scoped Biome checks